### PR TITLE
hack: a temprorary fix for power applet sizing

### DIFF
--- a/applets/cosmic-applet-power/src/main.rs
+++ b/applets/cosmic-applet-power/src/main.rs
@@ -49,6 +49,7 @@ struct Audio {
 
 #[derive(Debug, Clone)]
 enum Message {
+    BadCode(()),
     Lock,
     LogOut,
     Suspend,
@@ -72,7 +73,7 @@ impl Application for Audio {
                 icon_name: "system-shutdown-symbolic".to_string(),
                 ..Default::default()
             },
-            Command::none(),
+            Command::perform(bad_code(), Message::BadCode),
         )
     }
 
@@ -135,6 +136,7 @@ impl Application for Audio {
                 Command::none()
             }
             Message::Ignore => Command::none(),
+            Message::BadCode(_) => Command::none(),
         }
     }
 
@@ -292,4 +294,10 @@ async fn log_out() -> zbus::Result<()> {
         None => {}
     }
     Ok(())
+}
+
+// TODO: This is just a temporary bug fix, please don't let this reach production.
+async fn bad_code() -> () {
+  use std::{thread, time};
+  thread::sleep(time::Duration::from_millis(5));
 }


### PR DESCRIPTION
The power applet currently doen't load properly in the panel. The icon doesn't load and the allocated space is far too big.

This seems to be caused by the power applet only rendering once, all of the other applets render more than once to fully load, all this does is add a dummy command at app start to casuse a redraw.

My guess is that this bug is caused somewhere in iced_sctk, but that is just a guess. As iced_sctk is currelty being moved as I write this message, this is a temporary fix until I can look into the issue further (it might not be iced_sctk at all).

> This seems to only fix the issue after a power cycle. The bug still appears after log out and back in