### PR TITLE
Time: Update Cargo.lock

### DIFF
--- a/applets/cosmic-applet-time/Cargo.lock
+++ b/applets/cosmic-applet-time/Cargo.lock
@@ -359,13 +359,15 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#671492242ce64dbec8644d4b51f732a814c994bd"
+source = "git+https://github.com/pop-os/cosmic-panel?rev=6714922#671492242ce64dbec8644d4b51f732a814c994bd"
 dependencies = [
  "anyhow",
  "ron",
  "serde",
  "slog",
+ "wayland-protocols-wlr",
  "xdg",
+ "xdg-shell-wrapper-config",
 ]
 
 [[package]]
@@ -1179,6 +1181,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.6.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1195,6 +1198,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.6.2"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "bitflags",
  "palette",
@@ -1204,6 +1208,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.5.1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "futures",
  "log",
@@ -1215,6 +1220,7 @@ dependencies = [
 [[package]]
 name = "iced_glow"
 version = "0.5.1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -1229,6 +1235,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.5.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1248,6 +1255,7 @@ dependencies = [
 [[package]]
 name = "iced_lazy"
 version = "0.3.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "iced_native",
  "ouroboros 0.13.0",
@@ -1256,6 +1264,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.7.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1269,6 +1278,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "enum-repr",
  "futures",
@@ -1287,6 +1297,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.5.1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1296,6 +1307,7 @@ dependencies = [
 [[package]]
 name = "iced_swbuf"
 version = "0.1.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "cosmic-text",
  "iced_graphics",
@@ -1310,6 +1322,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.7.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1464,13 +1477,14 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#9880bf2f5675f0256ad13292999f126942d32acd"
 dependencies = [
  "apply",
  "cosmic-panel-config",
@@ -3007,6 +3021,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
+ "wayland-server",
 ]
 
 [[package]]
@@ -3020,6 +3035,7 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-scanner",
+ "wayland-server",
 ]
 
 [[package]]
@@ -3032,6 +3048,20 @@ dependencies = [
  "quick-xml",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "wayland-server"
+version = "0.30.0-beta.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246d94f203cd9b2993f130255e608639a335e57ec59a2e1ff40164ae4ed6ae40"
+dependencies = [
+ "bitflags",
+ "downcast-rs",
+ "nix 0.25.1",
+ "thiserror",
+ "wayland-backend",
+ "wayland-scanner",
 ]
 
 [[package]]
@@ -3326,6 +3356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
 dependencies = [
  "dirs",
+]
+
+[[package]]
+name = "xdg-shell-wrapper-config"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/xdg-shell-wrapper?rev=1bf60b8eff599ef2ee68d5ce8d46f05b7807ffc6#1bf60b8eff599ef2ee68d5ce8d46f05b7807ffc6"
+dependencies = [
+ "serde",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]


### PR DESCRIPTION
After https://github.com/pop-os/cosmic-applets/pull/40 the clock has been getting stuck at times. This seems to be a swbuf issue that was fixed, updating the cargo.lock seems to have fixed the issue for me.