### PR TITLE
Use linker time optimization for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ members = [
 
 [patch.crates-io]
 zbus = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main"}
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
This reduces total package size by ~25%. There are no runtime consequences, though this does nearly double build times. But with the cargo workspace, this repo builds pretty quick. As well the same `lto` settings are already used in cosmic-comp.