### PR TITLE
fix: increase popup size limits to fix text for each button

### DIFF
--- a/cosmic-applet-power/src/main.rs
+++ b/cosmic-applet-power/src/main.rs
@@ -4,6 +4,7 @@ use cosmic::applet::CosmicAppletHelper;
 use cosmic::iced::wayland::popup::{destroy_popup, get_popup};
 use cosmic::iced::wayland::SurfaceIdWrapper;
 use cosmic::iced::widget::{self, Row};
+use cosmic::iced_native::layout::Limits;
 use cosmic::iced_native::widget::Space;
 use cosmic::widget::{horizontal_rule, icon};
 use cosmic::Renderer;
@@ -106,13 +107,18 @@ impl Application for Power {
                     let new_id = window::Id::new(self.id_ctr);
                     self.popup.replace(new_id);
 
-                    let popup_settings = self.applet_helper.get_popup_settings(
+                    let mut popup_settings = self.applet_helper.get_popup_settings(
                         window::Id::new(0),
                         new_id,
                         None,
                         None,
                         None,
                     );
+                    popup_settings.positioner.size_limits = Limits::NONE
+                        .min_width(100)
+                        .min_height(100)
+                        .max_height(400)
+                        .max_width(500);
                     get_popup(popup_settings)
                 }
             }


### PR DESCRIPTION
The horizontal rule widget is problematic for auto-sized popups. Ideally there would be a divider which fills out to the same width as the other widgets in its parent, but not any further. Maybe, for example, a container which contains optional rule widgets on the top or bottom and sets them to the width of it's contents would be a good solution.

In any case, for now, I've increased the size limit of the popup here to fit the English text, but I'll also work on a solution via libcosmic.