### PR TITLE
Use `cosmic::SingleThreadExecutor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#b4e60dc30bb798d59cc57957291609e794d38821"
+source = "git+https://github.com/pop-os/cosmic-panel#310139295f0d3748f49d8bb13edfe659d3f80c4b"
 dependencies = [
  "anyhow",
  "ron",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "directories"
 version = "4.0.1"
-source = "git+https://github.com/edfloreshz/directories-rs#b93c018bc319f066fbeadcd8e3b865f1fccaaa8c"
+source = "git+https://github.com/edfloreshz/directories-rs#6a6d83d853a35ee3273034215c4defaf61286fe5"
 dependencies = [
  "anyhow",
  "dirs-sys",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.6.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.6.2"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "bitflags",
  "palette",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "futures",
  "log",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "iced_glow"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.5.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "iced_lazy"
 version = "0.3.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "iced_native",
  "ouroboros 0.13.0",
@@ -2094,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "enum-repr",
  "futures",
@@ -2127,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "iced_softbuffer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "cosmic-text",
  "iced_graphics",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2342,7 +2342,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#3bb193c3d2f41f87359d80e3eebba365425c4018"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
 dependencies = [
  "apply",
  "cosmic-panel-config",
@@ -2353,11 +2353,13 @@ dependencies = [
  "iced_core",
  "iced_lazy",
  "iced_native",
+ "iced_sctk",
  "iced_style",
  "lazy_static",
  "palette",
  "slotmap",
  "smithay-client-toolkit",
+ "tokio",
 ]
 
 [[package]]
@@ -3974,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -19,7 +19,7 @@ use cosmic::iced::wayland::popup::get_popup;
 use cosmic::iced::wayland::SurfaceIdWrapper;
 use cosmic::iced::widget::mouse_listener;
 use cosmic::iced::widget::{column, row};
-use cosmic::iced::{executor, window, Application, Command, Subscription};
+use cosmic::iced::{window, Application, Command, Subscription};
 use cosmic::iced_native::alignment::Horizontal;
 use cosmic::iced_native::subscription::events_with;
 use cosmic::iced_native::widget::vertical_space;
@@ -162,7 +162,7 @@ fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {
 impl Application for CosmicAppList {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Self, Command<Message>) {

--- a/cosmic-applet-audio/src/main.rs
+++ b/cosmic-applet-audio/src/main.rs
@@ -9,7 +9,7 @@ use cosmic::widget::{button, icon};
 use cosmic::Renderer;
 
 use cosmic::iced::{
-    self, executor,
+    self,
     widget::{column, horizontal_rule, row, slider, text, toggler},
     window, Alignment, Application, Command, Length, Subscription,
 };
@@ -69,7 +69,7 @@ enum Message {
 impl Application for Audio {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Audio, Command<Message>) {

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -15,7 +15,6 @@ use cosmic::iced::alignment::Horizontal;
 use cosmic::iced::wayland::popup::{destroy_popup, get_popup};
 use cosmic::iced::wayland::SurfaceIdWrapper;
 use cosmic::iced::{
-    executor,
     widget::{column, container, row, slider, text},
     window, Alignment, Application, Command, Length, Subscription,
 };
@@ -94,7 +93,7 @@ enum Message {
 impl Application for CosmicBatteryApplet {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Self, Command<Message>) {

--- a/cosmic-applet-graphics/src/window.rs
+++ b/cosmic-applet-graphics/src/window.rs
@@ -60,7 +60,7 @@ pub enum Message {
 }
 
 impl Application for Window {
-    type Executor = iced::executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
     type Message = Message;
     type Theme = Theme;

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -2,7 +2,6 @@ use cosmic::iced_style;
 use cosmic::{
     applet::CosmicAppletHelper,
     iced::{
-        executor,
         wayland::{
             popup::{destroy_popup, get_popup},
             SurfaceIdWrapper,
@@ -117,7 +116,7 @@ enum Message {
 impl Application for CosmicNetworkApplet {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Self, Command<Message>) {

--- a/cosmic-applet-notifications/src/main.rs
+++ b/cosmic-applet-notifications/src/main.rs
@@ -4,7 +4,6 @@ use cosmic::iced::wayland::{
     SurfaceIdWrapper,
 };
 use cosmic::iced::{
-    executor,
     widget::{button, column, horizontal_rule, row, text, Row, Space},
     window, Alignment, Application, Color, Command, Length, Subscription,
 };
@@ -46,7 +45,7 @@ enum Message {
 impl Application for Notifications {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Notifications, Command<Message>) {

--- a/cosmic-applet-power/src/main.rs
+++ b/cosmic-applet-power/src/main.rs
@@ -9,7 +9,6 @@ use cosmic::widget::{button, horizontal_rule, icon};
 use cosmic::Renderer;
 
 use cosmic::iced::{
-    executor,
     widget::{self, column, container, row, Row},
     window, Alignment, Application, Command, Length, Subscription,
 };
@@ -60,7 +59,7 @@ enum Message {
 impl Application for Power {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Power, Command<Message>) {

--- a/cosmic-applet-time/src/main.rs
+++ b/cosmic-applet-time/src/main.rs
@@ -4,7 +4,7 @@ use cosmic::iced::wayland::{
     SurfaceIdWrapper,
 };
 use cosmic::iced::{
-    executor, time,
+    time,
     widget::{button, column, text},
     window, Alignment, Application, Color, Command, Length, Subscription,
 };
@@ -60,7 +60,7 @@ enum Message {
 impl Application for Time {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Time, Command<Message>) {

--- a/cosmic-applet-workspaces/src/components/app.rs
+++ b/cosmic-applet-workspaces/src/components/app.rs
@@ -7,8 +7,8 @@ use cosmic::iced::wayland::actions::window::SctkWindowSettings;
 use cosmic::iced::wayland::{window::resize_window, InitialSurface, SurfaceIdWrapper};
 use cosmic::iced::widget::{column, container, row, text};
 use cosmic::iced::{
-    executor, subscription, widget::button, window, Application, Command, Event::Mouse, Length,
-    Settings, Subscription,
+    subscription, widget::button, window, Application, Command, Event::Mouse, Length, Settings,
+    Subscription,
 };
 use cosmic::iced_style::application::{self, Appearance};
 use cosmic::iced_style::Color;
@@ -60,7 +60,7 @@ enum Message {
 impl Application for IcedWorkspacesApplet {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::SingleThreadExecutor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Self, Command<Message>) {


### PR DESCRIPTION
This cuts down the number of threads per applet process. This is probably no benefit to having multiple tokio worker threads for a typical applet.