### PR TITLE
feat: update libcosmic to use dyrend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,9 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fluent"
@@ -1960,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.6.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "iced_core",
  "iced_dyrend",
@@ -1978,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.6.2"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "bitflags",
  "palette",
@@ -1988,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "iced_dyrend"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "iced_glow",
  "iced_graphics",
@@ -2002,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "futures",
  "log",
@@ -2014,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "iced_glow"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -2029,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.5.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2049,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "iced_lazy"
 version = "0.3.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "iced_native",
  "ouroboros 0.13.0",
@@ -2058,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2072,9 +2075,10 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "enum-repr",
+ "float-cmp",
  "futures",
  "iced_futures",
  "iced_graphics",
@@ -2089,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "iced_softbuffer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "cosmic-text",
  "iced_graphics",
@@ -2104,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2114,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2304,7 +2308,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#771ddff482de79264ce50191517715d09988924f"
 dependencies = [
  "apply",
  "cosmic-panel-config",
@@ -3718,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "softbuffer"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/softbuffer?rev=68240f56b#68240f56b6e837b9c4f43438bce866a0e1b1ab61"
+source = "git+https://github.com/pop-os/softbuffer?rev=8dcb6438b#8dcb6438b6c1688a0015b477dfa76c6c0bee3318"
 dependencies = [
  "bytemuck",
  "cfg_aliases",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -359,15 +359,6 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cgl"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cgmath"
@@ -1412,6 +1403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fraction"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c37ba08fe22fba12a3ada3e479d09a8f7fac6081aa6f5c27f22b78639025031"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "freedesktop-desktop-entry"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,58 +1703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glutin"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524d807cd49a0c56a53ef9a6738cd15e7c8c4e9d37a3b7fdb3c250c1cd5bf7a3"
-dependencies = [
- "bitflags",
- "cfg_aliases",
- "cgl",
- "cocoa",
- "core-foundation",
- "glutin_egl_sys",
- "glutin_glx_sys",
- "glutin_wgl_sys",
- "libloading",
- "objc",
- "once_cell",
- "raw-window-handle",
- "wayland-sys",
- "windows-sys 0.36.1",
- "x11-dl",
-]
-
-[[package]]
-name = "glutin_egl_sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adbb8fec0e18e340f990c78f79f5f0e142d0d83f46b10909aaa7d251c00afdf"
-dependencies = [
- "gl_generator",
- "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "glutin_glx_sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947c4850c58211c9627969c2b4e2674764b81ae5b47bab2c9a477d7942f96e0f"
-dependencies = [
- "gl_generator",
- "x11-dl",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c33975a6c9d49d72c8f032a60079bf8df536954fbf9e4cee90396ace815c57"
-dependencies = [
- "gl_generator",
-]
-
-[[package]]
 name = "glyph_brush"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,9 +1960,10 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.6.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "iced_core",
+ "iced_dyrend",
  "iced_futures",
  "iced_glow",
  "iced_graphics",
@@ -2028,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.6.2"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "bitflags",
  "palette",
@@ -2036,9 +1986,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_dyrend"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
+dependencies = [
+ "iced_glow",
+ "iced_graphics",
+ "iced_native",
+ "iced_softbuffer",
+ "iced_wgpu",
+ "log",
+ "raw-window-handle",
+]
+
+[[package]]
 name = "iced_futures"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "futures",
  "log",
@@ -2050,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "iced_glow"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -2065,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.5.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2085,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "iced_lazy"
 version = "0.3.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "iced_native",
  "ouroboros 0.13.0",
@@ -2094,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2108,12 +2072,10 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "enum-repr",
  "futures",
- "glow",
- "glutin",
  "iced_futures",
  "iced_graphics",
  "iced_native",
@@ -2127,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "iced_softbuffer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "cosmic-text",
  "iced_graphics",
@@ -2142,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.5.1"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2152,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2250,7 +2212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2342,12 +2304,13 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?branch=master#cd19bbf37aa23954bb3dbd8599543bf705aa41a1"
+source = "git+https://github.com/pop-os/libcosmic/?branch=master#4733069988e784ef390c72eaad46cde74c2559f5"
 dependencies = [
  "apply",
  "cosmic-panel-config",
  "cosmic-theme",
  "derive_setters",
+ "fraction",
  "freedesktop-icons",
  "iced",
  "iced_core",
@@ -2597,7 +2560,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2686,6 +2649,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,12 +2704,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2942,7 +2951,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3054,7 +3063,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3418,7 +3427,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3709,8 +3718,7 @@ dependencies = [
 [[package]]
 name = "softbuffer"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3177eca2c15033e254b9b70c4915150200b1cf6fa777de18be9977ae5850077f"
+source = "git+https://github.com/pop-os/softbuffer?rev=68240f56b#68240f56b6e837b9c4f43438bce866a0e1b1ab61"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -3729,7 +3737,7 @@ dependencies = [
  "wayland-client",
  "wayland-sys",
  "web-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
  "x11-dl",
  "x11rb",
 ]
@@ -3992,7 +4000,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4645,30 +4653,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4679,21 +4674,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4703,21 +4686,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4730,12 +4701,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/cosmic-applet-graphics/src/main.rs
+++ b/cosmic-applet-graphics/src/main.rs
@@ -26,6 +26,7 @@ pub fn main() -> cosmic::iced::Result {
                         .min_width(1)
                         .max_width(1000);
                 }
+                InitialSurface::None => unimplemented!(),
             };
         }
         _ => {}

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -1,3 +1,4 @@
+use cosmic::iced_sctk::Rectangle;
 use cosmic::iced_style;
 use cosmic::{
     applet::CosmicAppletHelper,
@@ -13,14 +14,14 @@ use cosmic::{
         alignment::{Horizontal, Vertical},
         layout::Limits,
         renderer::BorderRadius,
-        subscription, window,
+        window,
     },
     iced_style::{application, button::StyleSheet, svg},
     theme::{Button, Svg},
-    widget::{button, horizontal_rule, icon, list_column, toggler},
+    widget::{button, horizontal_rule, icon, toggler},
     Element, Theme,
 };
-use cosmic_dbus_networkmanager::{access_point, interface::enums::DeviceState};
+use cosmic_dbus_networkmanager::interface::enums::DeviceState;
 use futures::channel::mpsc::UnboundedSender;
 
 use crate::network_manager::NetworkManagerState;
@@ -151,11 +152,12 @@ impl Application for CosmicNetworkApplet {
                         None,
                         None,
                     );
+
                     popup_settings.positioner.size_limits = Limits::NONE
                         .min_height(1)
                         .min_width(1)
-                        .max_height(600)
-                        .max_width(600);
+                        .max_height(800)
+                        .max_width(400);
                     return get_popup(popup_settings);
                 }
             }

--- a/cosmic-applet-workspaces/src/components/app.rs
+++ b/cosmic-applet-workspaces/src/components/app.rs
@@ -47,6 +47,7 @@ struct IcedWorkspacesApplet {
     workspaces: WorkspaceList,
     workspace_tx: Option<SyncSender<WorkspaceEvent>>,
     layout: Layout,
+    helper: CosmicAppletHelper,
 }
 
 #[derive(Debug, Clone)]
@@ -74,6 +75,7 @@ impl Application for IcedWorkspacesApplet {
                 theme: Default::default(),
                 workspaces: Vec::new(),
                 workspace_tx: Default::default(),
+                helper: Default::default(),
             },
             Command::none(),
         )
@@ -96,7 +98,7 @@ impl Application for IcedWorkspacesApplet {
                         Ordering::Greater => Ordering::Greater,
                     });
                     self.workspaces = list;
-                    let unit = 32;
+                    let unit = self.helper.suggested_size().0 as u32 + 16;
                     let (w, h) = match self.layout {
                         Layout::Row => (unit * self.workspaces.len().max(1) as u32, unit),
                         Layout::Column => (unit, unit * self.workspaces.len().max(1) as u32),


### PR DESCRIPTION
This updates libcosmic so that the applets use dyrend.

Currently it works quite well except when the app-list shrinks in size, there is visual corruption. Perhaps it is an issue with iced-sctk.