### PR TITLE
fix: crash when no icon found

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -133,13 +133,12 @@ fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {
                         .iter()
                         .position(|s| s == de.appid || s.eq(&de.name(None).unwrap_or_default()))
                     {
-                        let id = app_ids.remove(i);
                         freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
                             .with_size(128)
                             .with_cache()
                             .find()
                             .map(|buf| DesktopInfo {
-                                id,
+                                id: app_ids.remove(i),
                                 icon: buf,
                                 exec: de.exec().unwrap_or_default().to_string(),
                                 name: de.name(None).unwrap_or_default().to_string(),


### PR DESCRIPTION
Specific case when using vscode, the open file/folder dialog doesn't succeed in looking up the icon on my system. This would cause lookup to return None, thus the ret vector is empty. Since we removed the id before the lookup, the append below would append an empty vec. This would cause an error in AddTopLevel message handler when trying to remove the first item of the returned vec.

Move the id remove directly within the map, so it only gets removed if we succeed in looking up the icon.