### PR TITLE
feat(network): improve state handling & add disconnect option

### DIFF
--- a/cosmic-applet-network/src/network_manager/available_wifi.rs
+++ b/cosmic-applet-network/src/network_manager/available_wifi.rs
@@ -39,6 +39,7 @@ pub async fn handle_wireless_device(device: WirelessDevice<'_>) -> zbus::Result<
                 ssid,
                 strength,
                 state: state,
+                working: false,
             },
         );
     }
@@ -55,4 +56,5 @@ pub struct AccessPoint {
     pub ssid: String,
     pub strength: u8,
     pub state: DeviceState,
+    pub working: bool,
 }

--- a/cosmic-applet-network/src/network_manager/current_networks.rs
+++ b/cosmic-applet-network/src/network_manager/current_networks.rs
@@ -3,7 +3,7 @@
 use cosmic_dbus_networkmanager::{
     active_connection::ActiveConnection,
     device::SpecificDevice,
-    interface::enums::{ApFlags, ApSecurityFlags},
+    interface::enums::{ActiveConnectionState, ApFlags, ApSecurityFlags},
 };
 use std::net::Ipv4Addr;
 
@@ -19,6 +19,10 @@ pub async fn active_connections(
             .await
             .unwrap_or_default();
         let addresses: Vec<_> = ipv4.iter().map(|d| d.address).collect();
+        let state = connection
+            .state()
+            .await
+            .unwrap_or_else(|_| ActiveConnectionState::Unknown);
 
         if connection.vpn().await.unwrap_or_default() {
             info.push(ActiveConnectionInfo::Vpn {
@@ -51,6 +55,7 @@ pub async fn active_connections(
                             flags: access_point.flags().await?,
                             rsn_flags: access_point.rsn_flags().await?,
                             wpa_flags: access_point.wpa_flags().await?,
+                            state,
                         });
                     }
                 }
@@ -92,6 +97,7 @@ pub enum ActiveConnectionInfo {
         flags: ApFlags,
         rsn_flags: ApSecurityFlags,
         wpa_flags: ApSecurityFlags,
+        state: ActiveConnectionState,
     },
     Vpn {
         name: String,


### PR DESCRIPTION
This improves some of the state handling. Specifically, when an action was finished, the loading icon didn't always go away before, or for some items, it didn't appear at all. Also, the option to disconnect networks has been added as indicated the mockup.

The applet could probably be cleaned up more in the future, but I might improve the dbus bindings before doing that.