### PR TITLE
chore: add applet key and do some cleanup

### DIFF
--- a/cosmic-app-list/data/com.system76.CosmicAppList.desktop
+++ b/cosmic-app-list/data/com.system76.CosmicAppList.desktop
@@ -1,13 +1,14 @@
 [Desktop Entry]
 Name=Cosmic Dock App List
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-app-list
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppList
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true
 X-HostWaylandDisplay=true

--- a/cosmic-app-list/data/com.system76.CosmicAppList.metainfo.xml
+++ b/cosmic-app-list/data/com.system76.CosmicAppList.metainfo.xml
@@ -5,7 +5,7 @@
   <metadata_license>CC0</metadata_license>
   <project_license>MPL</project_license>
   <name>Cosmic Dock App List</name>
-  <summary>Write a GTK + Rust application</summary>
+  <summary>Applet for Cosmic Panel</summary>
   <description>
     <p>A boilerplate template for GTK + Rust. It uses Meson as a build system and has flatpak support by default.</p>
   </description>

--- a/cosmic-applet-audio/data/com.system76.CosmicAppletAudio.desktop
+++ b/cosmic-applet-audio/data/com.system76.CosmicAppletAudio.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Applet Audio
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-applet-audio
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppletAudio
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-battery/data/com.system76.CosmicAppletBattery.desktop
+++ b/cosmic-applet-battery/data/com.system76.CosmicAppletBattery.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Applet Battery
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-applet-battery
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppletBattery
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-bluetooth/data/com.system76.CosmicAppletBluetooth.desktop
+++ b/cosmic-applet-bluetooth/data/com.system76.CosmicAppletBluetooth.desktop
@@ -10,3 +10,4 @@ Keywords=COSMIC;Iced;
 Icon=com.system76.CosmicAppletBluetooth
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-graphics/data/com.system76.CosmicAppletGraphics.desktop
+++ b/cosmic-applet-graphics/data/com.system76.CosmicAppletGraphics.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Applet Graphics
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-applet-graphics
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppletGraphics
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-network/data/com.system76.CosmicAppletNetwork.desktop
+++ b/cosmic-applet-network/data/com.system76.CosmicAppletNetwork.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Applet Network
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-applet-network
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppletNetwork
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-notifications/data/com.system76.CosmicAppletNotifications.desktop
+++ b/cosmic-applet-notifications/data/com.system76.CosmicAppletNotifications.desktop
@@ -3,8 +3,9 @@ Name=Cosmic Applet Notifications
 Type=Application
 Exec=cosmic-applet-notifications
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppletNotifications
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-power/data/com.system76.CosmicAppletPower.desktop
+++ b/cosmic-applet-power/data/com.system76.CosmicAppletPower.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Applet Power
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-applet-power
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppletPower
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-time/data/com.system76.CosmicAppletTime.desktop
+++ b/cosmic-applet-time/data/com.system76.CosmicAppletTime.desktop
@@ -3,8 +3,9 @@ Name=Cosmic Applet Time
 Type=Application
 Exec=cosmic-applet-time
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicAppletTime
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-applet-workspaces/data/com.system76.CosmicAppletWorkspaces.desktop
+++ b/cosmic-applet-workspaces/data/com.system76.CosmicAppletWorkspaces.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Applet Workspaces
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-applet-workspaces
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 Icon=com.system76.CosmicAppletWorkspaces
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true
 X-HostWaylandDisplay=true

--- a/cosmic-panel-app-button/data/com.system76.CosmicPanelAppButton.desktop
+++ b/cosmic-panel-app-button/data/com.system76.CosmicPanelAppButton.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Panel App Library Button
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-panel-button com.system76.CosmicAppLibrary
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicPanelAppButton
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true

--- a/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
+++ b/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Cosmic Panel Workspaces Button
-Comment=Write a GTK + Rust application
+Comment=Applet for Cosmic Panel
 Type=Application
 Exec=cosmic-panel-button com.system76.CosmicWorkspaces
 Terminal=false
-Categories=GNOME;GTK;
-Keywords=Gnome;GTK;
+Categories=Cosmic;Iced;
+Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=com.system76.CosmicPanelWorkspacesButton
 StartupNotify=true
 NoDisplay=true
+X-CosmicApplet=true


### PR DESCRIPTION
the applet key marks an application as possible to be used as an applet