### PR TITLE
justfile: respect target variable

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ _install_desktop path:
     install -Dm0644 {{path}} {{sharedir}}/applications/{{file_name(path)}}
 
 _install_bin name:
-    install -Dm0755 target/release/{{name}} {{bindir}}/{{name}}
+    install -Dm0755 target/{{target}}/{{name}} {{bindir}}/{{name}}
 
 _install id name: (_install_icons name) (_install_desktop name + '/data/' + id + '.desktop') (_install_bin name)
 


### PR DESCRIPTION
This variable was defined, but never used, and "release" was hardcoded instead.