### PR TITLE
app-list: Fix missing icons

### DIFF
--- a/cosmic-app-list/Cargo.toml
+++ b/cosmic-app-list/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 tokio = { version = "1.17.0", features = ["sync", "rt", "rt-multi-thread", "macros", "process"] }
 itertools = "*"
 freedesktop-desktop-entry = "0.5.0"
-freedesktop-icons = "0.2.2"
+freedesktop-icons = "0.2.4"
 i18n-embed = { version = "0.13", features = ["fluent-system", "desktop-requester"] }
 i18n-embed-fl = "0.6"
 rust-embed = "6.3"

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -264,17 +264,18 @@ fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {
                         .iter()
                         .position(|s| s == de.appid || s.eq(&de.name(None).unwrap_or_default()))
                     {
-                        freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
+                        let icon = freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
                             .with_size(128)
                             .with_cache()
-                            .find()
-                            .map(|buf| DesktopInfo {
-                                id: app_ids.remove(i),
-                                icon: buf,
-                                exec: de.exec().unwrap_or_default().to_string(),
-                                name: de.name(None).unwrap_or_default().to_string(),
-                                path: path.clone(),
-                            })
+                            .find();
+
+                        Some(DesktopInfo {
+                            id: app_ids.remove(i),
+                            icon: icon.unwrap_or_default(),
+                            exec: de.exec().unwrap_or_default().to_string(),
+                            name: de.name(None).unwrap_or_default().to_string(),
+                            path: path.clone(),
+                        })
                     } else {
                         None
                     }

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -254,6 +254,14 @@ struct DesktopInfo {
     path: PathBuf,
 }
 
+fn default_app_icon() -> PathBuf {
+  freedesktop_icons::lookup("application-default")
+      .with_size(128)
+      .with_cache()
+      .find()
+      .unwrap_or_default()
+}
+
 fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {
     let app_ids_clone = app_ids.clone();
     let mut ret = freedesktop_desktop_entry::Iter::new(freedesktop_desktop_entry::default_paths())
@@ -267,11 +275,12 @@ fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {
                         let icon = freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
                             .with_size(128)
                             .with_cache()
-                            .find();
+                            .find()
+                            .unwrap_or_else(default_app_icon);
 
                         Some(DesktopInfo {
                             id: app_ids.remove(i),
-                            icon: icon.unwrap_or_default(),
+                            icon,
                             exec: de.exec().unwrap_or_default().to_string(),
                             name: de.name(None).unwrap_or_default().to_string(),
                             path: path.clone(),
@@ -288,6 +297,7 @@ fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {
             .into_iter()
             .map(|id| DesktopInfo {
                 id,
+                icon: default_app_icon(),
                 ..Default::default()
             })
             .collect_vec(),
@@ -604,17 +614,18 @@ impl cosmic::Application for CosmicAppList {
                         DesktopEntry::decode(&file_path, &input)
                             .ok()
                             .and_then(|de| {
-                                freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
+                                let icon = freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
                                     .with_size(128)
                                     .with_cache()
                                     .find()
-                                    .map(|buf| DesktopInfo {
-                                        id: de.id().to_string(),
-                                        icon: buf,
-                                        exec: de.exec().unwrap_or_default().to_string(),
-                                        name: de.name(None).unwrap_or_default().to_string(),
-                                        path: file_path.clone(),
-                                    })
+                                    .unwrap_or_else(default_app_icon);
+                                Some(DesktopInfo {
+                                    id: de.id().to_string(),
+                                    icon,
+                                    exec: de.exec().unwrap_or_default().to_string(),
+                                    name: de.name(None).unwrap_or_default().to_string(),
+                                    path: file_path.clone(),
+                                }))
                             })
                     }) {
                         self.item_ctr += 1;


### PR DESCRIPTION
This fixes a bunch of cases, where missing icons cause trouble in the app-list.

1. Updates freedesktop-icons to the latest version, which contains a couple of fixes for icon lookups.
2. Still create a `DesktopInfo` struct from a `DesktopEntry` if the icon is missing, otherwise `exec` is unpopulated and the app can't be launched, even if the entry is found.
3. Try to use the generic application icon, if it can't be found.

Todo: Maybe we should use a different icon, if the desktop entry can't be found in the first place? So that the user is aware of the broken favorite entry? E.g. `system-error` or `image-missing`?