### PR TITLE
app-list: Match by startup WM Class for Xwayland compatibility

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -270,7 +270,7 @@ fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {
                 DesktopEntry::decode(&path, &input).ok().and_then(|de| {
                     if let Some(i) = app_ids
                         .iter()
-                        .position(|s| s == de.appid || s.eq(&de.name(None).unwrap_or_default()))
+                        .position(|s| s == de.appid || s.eq(&de.startup_wm_class().unwrap_or_default()))
                     {
                         let icon = freedesktop_icons::lookup(de.icon().unwrap_or(de.appid))
                             .with_size(128)

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -255,11 +255,19 @@ struct DesktopInfo {
 }
 
 fn default_app_icon() -> PathBuf {
-  freedesktop_icons::lookup("application-default")
-      .with_size(128)
-      .with_cache()
-      .find()
-      .unwrap_or_default()
+    freedesktop_icons::lookup("application-default")
+        .with_theme("Pop")
+        .with_size(128)
+        .with_cache()
+        .find()
+        .or_else(|| {
+            freedesktop_icons::lookup("application-x-executable")
+                .with_theme("default")
+                .with_size(128)
+                .with_cache()
+                .find()
+        })
+        .unwrap_or_default()
 }
 
 fn desktop_info_for_app_ids(mut app_ids: Vec<String>) -> Vec<DesktopInfo> {


### PR DESCRIPTION
Also fixes the default icon. `application-default` is a name given by the Pop-icon-theme. `application-x-executable`  is used as an additional fallback. That is a freedesktop standard icon name, but not included in the usual `hicolor`-theme, which `freedesktop-icons` searches by default. So lets explicitly link the `default` theme, which should link to user-preference.