### PR TITLE
app-list: Use cosmic theme instead of pop

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -257,8 +257,8 @@ struct DesktopInfo {
 
 fn default_app_icon() -> PathBuf {
     freedesktop_icons::lookup("application-default")
-        .with_theme("Pop")
-        .with_size(128)
+        .with_theme("Cosmic")
+        .force_svg()
         .with_cache()
         .find()
         .or_else(|| {


### PR DESCRIPTION
Quick follow up PR to https://github.com/pop-os/cosmic-applets/pull/123.

`application-default` is also in the `Cosmic`, which is probably what we want here, given it is also the default for libcosmic and falls back to `Pop` anyway.

Additionally, given we control this theme and know it's contents, force the svg variant instead of a specific size for a cleaner look.