### PR TITLE
workspaces: Cleaner design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#021faaf459cbb47e7f5b94316cfd93ccaed7ecf6"
+source = "git+https://github.com/pop-os/cosmic-panel#a5825ebc39672a26434bcb3066f10f66ac2a1176"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2436,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "bitflags 1.3.2",
  "iced_accessibility",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "futures",
  "iced_core",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.1.1"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.11.1"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.1.3"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -2862,7 +2862,7 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6b517ddb0e7fe2ed8b04d6f71d1c45a374c92e14"
+source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
 dependencies = [
  "apply",
  "ashpd",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.3.11"
-source = "git+https://github.com/DioxusLabs/taffy#d4374b93f0ec2c0ace42d3feafec22d3af1940d8"
+source = "git+https://github.com/DioxusLabs/taffy#278f5e39b6edcd6f5a3ee9e10da81c0bfb0b3124"
 dependencies = [
  "arrayvec",
  "grid",

--- a/cosmic-applet-workspaces/src/components/app.rs
+++ b/cosmic-applet-workspaces/src/components/app.rs
@@ -1,8 +1,11 @@
 use cctk::sctk::reexports::{calloop::channel::SyncSender, client::backend::ObjectId};
 use cosmic::iced::alignment::{Horizontal, Vertical};
 use cosmic::iced::mouse::{self, ScrollDelta};
-use cosmic::iced::widget::{column, container, row, text};
-use cosmic::iced::{subscription, widget::button, Event::Mouse, Length, Subscription};
+use cosmic::iced::widget::{button, column, container, row, text};
+use cosmic::iced::{subscription, Event::Mouse, Length, Subscription};
+use cosmic::iced_core::{font, Background};
+use cosmic::iced_runtime::font::Family;
+use cosmic::iced_runtime::Font;
 use cosmic::iced_style::application;
 use cosmic::{applet::cosmic_panel_config::PanelAnchor, Command};
 use cosmic::{Element, Theme};
@@ -127,29 +130,80 @@ impl cosmic::Application for IcedWorkspacesApplet {
             .filter_map(|w| {
                 let btn = button(
                     text(w.0.clone())
-                        .size(14)
+                        .font(Font {
+                            family: Family::Name("Fira Sans"),
+                            weight: if w.1 == Some(zcosmic_workspace_handle_v1::State::Active) {
+                                font::Weight::Bold
+                            } else {
+                                font::Weight::Normal
+                            },
+                            stretch: font::Stretch::Normal,
+                            monospaced: false,
+                        })
+                        .size(16)
                         .horizontal_alignment(Horizontal::Center)
                         .vertical_alignment(Vertical::Center)
                         .width(Length::Fill)
                         .height(Length::Fill),
                 )
                 .width(Length::Fixed(
-                    self.core.applet.suggested_size().0 as f32 + 16.0,
+                    self.core.applet.suggested_size().0 as f32
+                        + match self.layout {
+                            Layout::Row => 20.0,
+                            Layout::Column => 16.0,
+                        },
                 ))
                 .height(Length::Fixed(
-                    self.core.applet.suggested_size().0 as f32 + 16.0,
+                    self.core.applet.suggested_size().0 as f32
+                        + match self.layout {
+                            Layout::Row => 16.0,
+                            Layout::Column => 20.0,
+                        },
                 ))
                 .on_press(Message::WorkspacePressed(w.2.clone()))
                 .padding(0);
+
                 Some(
                     btn.style(match w.1 {
                         Some(zcosmic_workspace_handle_v1::State::Active) => {
                             cosmic::theme::iced::Button::Primary
                         }
                         Some(zcosmic_workspace_handle_v1::State::Urgent) => {
-                            cosmic::theme::iced::Button::Destructive
+                            let appearence = |theme: &Theme| button::Appearance {
+                                background: Some(Background::Color(
+                                    theme.cosmic().palette.neutral_3.into(),
+                                )),
+                                border_radius: theme.cosmic().radius_xl().into(),
+                                text_color: theme.cosmic().destructive_button.base.into(),
+                                ..button::Appearance::default()
+                            };
+                            cosmic::theme::iced::Button::Custom {
+                                active: Box::new(move |theme| appearence(theme)),
+                                hover: Box::new(move |theme| button::Appearance {
+                                    background: Some(Background::Color(
+                                        theme.current_container().component.hover.into(),
+                                    )),
+                                    ..appearence(theme)
+                                }),
+                            }
                         }
-                        None => cosmic::theme::iced::Button::Secondary,
+                        None => {
+                            let appearence = |theme: &Theme| button::Appearance {
+                                background: None,
+                                border_radius: theme.cosmic().radius_xl().into(),
+                                text_color: theme.current_container().component.on.into(),
+                                ..button::Appearance::default()
+                            };
+                            cosmic::theme::iced::Button::Custom {
+                                active: Box::new(move |theme| appearence(theme)),
+                                hover: Box::new(move |theme| button::Appearance {
+                                    background: Some(Background::Color(
+                                        theme.current_container().component.hover.into(),
+                                    )),
+                                    ..appearence(theme)
+                                }),
+                            }
+                        }
                         _ => return None,
                     })
                     .into(),
@@ -160,12 +214,14 @@ impl cosmic::Application for IcedWorkspacesApplet {
             Layout::Row => row(buttons)
                 .width(Length::Shrink)
                 .height(Length::Shrink)
-                .padding(0)
+                .padding([0, 4])
+                .spacing(4)
                 .into(),
             Layout::Column => column(buttons)
                 .width(Length::Shrink)
                 .height(Length::Shrink)
-                .padding(0)
+                .padding([4, 0])
+                .spacing(4)
                 .into(),
         };
 

--- a/cosmic-applet-workspaces/src/components/app.rs
+++ b/cosmic-applet-workspaces/src/components/app.rs
@@ -3,11 +3,9 @@ use cosmic::iced::alignment::{Horizontal, Vertical};
 use cosmic::iced::mouse::{self, ScrollDelta};
 use cosmic::iced::widget::{button, column, container, row, text};
 use cosmic::iced::{subscription, Event::Mouse, Length, Subscription};
-use cosmic::iced_core::{font, Background};
-use cosmic::iced_runtime::font::Family;
-use cosmic::iced_runtime::Font;
+use cosmic::iced_core::Background;
 use cosmic::iced_style::application;
-use cosmic::{applet::cosmic_panel_config::PanelAnchor, Command};
+use cosmic::{applet::cosmic_panel_config::PanelAnchor, font::FONT_BOLD, Command};
 use cosmic::{Element, Theme};
 
 use cosmic_protocols::workspace::v1::client::zcosmic_workspace_handle_v1;
@@ -130,16 +128,7 @@ impl cosmic::Application for IcedWorkspacesApplet {
             .filter_map(|w| {
                 let btn = button(
                     text(w.0.clone())
-                        .font(Font {
-                            family: Family::Name("Fira Sans"),
-                            weight: if w.1 == Some(zcosmic_workspace_handle_v1::State::Active) {
-                                font::Weight::Bold
-                            } else {
-                                font::Weight::Normal
-                            },
-                            stretch: font::Stretch::Normal,
-                            monospaced: false,
-                        })
+                        .font(FONT_BOLD)
                         .size(16)
                         .horizontal_alignment(Horizontal::Center)
                         .vertical_alignment(Vertical::Center)


### PR DESCRIPTION
Redesign of the workspaces applet based on issac's last iteration and @maria-komarova's feedback and changes.

https://www.figma.com/file/fJ9QmTUhtV9ytSFCF3mvi8/Workspace-Switcher-Panel-Applet?type=design&node-id=414-542&mode=design&t=nxurraRJJPG1q3Og-0

Code has been cleaned up, this is the only case so far, where we needed a Bold font variant. Should this be added to libcosmic or does that not warrant pre-loading for every single app?

Any other suggestions to make the style code more concise? Essentially the Urgent and Normal modes are Text-Buttons with custom Text colors, but I didn't find a better way to express this.