### PR TITLE
fix(time): layout should ignore the current bounds of the window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#a5825ebc39672a26434bcb3066f10f66ac2a1176"
+source = "git+https://github.com/pop-os/cosmic-panel#39add9bead80e54300b6e18f6823a6590b42caad"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2436,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "bitflags 1.3.2",
  "iced_accessibility",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "futures",
  "iced_core",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.1.1"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.11.1"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.1.3"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -2862,7 +2862,7 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a946e7e85b6fa98232ec757ea3ee7deba3aa0a96"
+source = "git+https://github.com/pop-os/libcosmic#470b966e8db539d17128e889b7f9b83eae9ddfc0"
 dependencies = [
  "apply",
  "ashpd",

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -165,7 +165,7 @@ impl cosmic::Application for Window {
                 }
                 Command::none()
             }
-            Message::SelectDay(day) => {
+            Message::SelectDay(_day) => {
                 // TODO
                 Command::none()
             }
@@ -190,9 +190,9 @@ impl cosmic::Application for Window {
                 self.core.applet.anchor,
                 PanelAnchor::Top | PanelAnchor::Bottom
             ) {
-                column![
-                    cosmic::widget::text(self.now.format("%b %-d %-I:%M %p").to_string()).size(14)
-                ]
+                Element::from(
+                    cosmic::widget::text(self.now.format("%b %-d %-I:%M %p").to_string()).size(14),
+                )
             } else {
                 let mut date_time_col = column![
                     icon::from_name("emoji-recent-symbolic")
@@ -212,14 +212,14 @@ impl cosmic::Application for Window {
                 for d in self.now.format("%x").to_string().split("/") {
                     date_time_col = date_time_col.push(text(d.to_string()).size(14));
                 }
-                date_time_col
+                date_time_col.into()
             },
         )
         .on_press(Message::TogglePopup)
         .style(cosmic::theme::Button::AppletIcon);
 
         if let Some(tracker) = self.rectangle_tracker.as_ref() {
-            tracker.container(0, button).into()
+            tracker.container(0, button).ignore_bounds(true).into()
         } else {
             button.into()
         }


### PR DESCRIPTION
This adds a custom container which ignores the layout bounds it is provided. Maybe this could be made an optional part of the `RectangleTracker` instead?