### PR TITLE
Fix airplane mode text in cosmic-applet-network

### DIFF
--- a/cosmic-applet-network/i18n/en/cosmic_applet_network.ftl
+++ b/cosmic-applet-network/i18n/en/cosmic_applet_network.ftl
@@ -1,7 +1,7 @@
 network = Network
 airplane-mode = Airplane mode
 airplane-mode-on = Airplane Mode is on
-turn-off-airplane-mode = Turn on to enable Wi-Fi, Bluetooth and mobile broadband.
+turn-off-airplane-mode = Turn off to enable Wi-Fi, Bluetooth and mobile broadband.
 wifi = Wi-Fi
 ipv4 = IPv4 Address
 ipv6 = IPv6 Address


### PR DESCRIPTION
Currently when airplane mode is **on** the message states "Turn on to enable Wi-Fi..." instead of "Turn off...", which seems to be the intended meaning.