### PR TITLE
Fix suspend icon in cosmic-applet-power

### DIFF
--- a/cosmic-applet-power/src/main.rs
+++ b/cosmic-applet-power/src/main.rs
@@ -265,7 +265,7 @@ impl cosmic::Application for Power {
             ];
 
             let power = row![
-                power_buttons("system-lock-screen-symbolic", fl!("suspend"))
+                power_buttons("system-suspend-symbolic", fl!("suspend"))
                     .on_press(Message::Action(PowerAction::Suspend)),
                 power_buttons("system-restart-symbolic", fl!("restart"))
                     .on_press(Message::Action(PowerAction::Restart)),


### PR DESCRIPTION
Not sure if this is all that needs to be done, but I haven't been able to find anything else that relates to the suspend icon. If this is intended temporarily (since the icon was a crescent moon at some point, and now is the same as the lock screen icon), feel free to close the pull request. :)