### PR TITLE
battery: Re-evaluate gpu state on udev change event

### DIFF
--- a/cosmic-applet-battery/src/dgpu.rs
+++ b/cosmic-applet-battery/src/dgpu.rs
@@ -466,6 +466,13 @@ async fn start_listening(
                                         });
                                     }
                                 },
+                                EventType::Change => {
+                                    if let Some(path) = event.devnode() {
+                                        if let Some(gpu) = monitor.gpus.iter_mut().find(|gpu| gpu.path == path) {
+                                            gpu.interval.reset_immediately();
+                                        }
+                                    }
+                                }
                                 EventType::Remove => {
                                     if let Some(path) = event.devnode() {
                                         monitor.gpus.retain(|gpu| gpu.path != path);


### PR DESCRIPTION
Handles hotplug events more reliably/quicker and seems to prevent the applet state freezing.