### PR TITLE
DRAFT: cosmic-applet-network: WPA2 Enterprise / 802.1x support

### DIFF
--- a/cosmic-applet-network/i18n/en/cosmic_applet_network.ftl
+++ b/cosmic-applet-network/i18n/en/cosmic_applet_network.ftl
@@ -13,6 +13,7 @@ connect = Connect
 cancel = Cancel
 settings = Network Settings...
 visible-wireless-networks = Visible Wireless Networks
+enter-identity = Enter your identity for the network
 enter-password = Enter the password or encryption key
 router-wps-button = You can also connect by pressing the "WPS" button on the router
 unable-to-connect = Unable to connect to network

--- a/cosmic-applet-network/src/network_manager/mod.rs
+++ b/cosmic-applet-network/src/network_manager/mod.rs
@@ -166,7 +166,7 @@ async fn start_listening(
                     };
                     _ = output.send(response).await;
                 }
-                Some(NetworkManagerRequest::Password(ssid, password)) => {
+                Some(NetworkManagerRequest::Password(ssid, identity, password)) => {
                     let s = match NetworkManagerSettings::new(&conn).await {
                         Ok(s) => s,
                         Err(_) => return State::Finished,
@@ -268,6 +268,7 @@ async fn start_listening(
                                 status = Some(NetworkManagerEvent::RequestResponse {
                                     req: NetworkManagerRequest::Password(
                                         ssid.clone(),
+                                        identity.clone(),
                                         password.clone(),
                                     ),
                                     success,
@@ -357,6 +358,7 @@ async fn start_listening(
                                     .send(NetworkManagerEvent::RequestResponse {
                                         req: NetworkManagerRequest::Password(
                                             ssid.clone(),
+                                            identity.clone(),
                                             password.clone(),
                                         ),
                                         success,
@@ -376,7 +378,7 @@ async fn start_listening(
                     } else {
                         _ = output
                             .send(NetworkManagerEvent::RequestResponse {
-                                req: NetworkManagerRequest::Password(ssid, password),
+                                req: NetworkManagerRequest::Password(ssid, identity, password),
                                 success: false,
                                 state: NetworkManagerState::new(&conn).await.unwrap_or_default(),
                             })
@@ -491,7 +493,7 @@ pub enum NetworkManagerRequest {
     SetWiFi(bool),
     SelectAccessPoint(String),
     Disconnect(String),
-    Password(String, String),
+    Password(String, String, String),
     Reload,
 }
 


### PR DESCRIPTION
This PR will add support for networks that require both an identity and password to connect to the network.
Fixes: https://github.com/pop-os/cosmic-applets/issues/225

Some questions I am thinking about while working on this:

* Should the `NetworkManagerRequest::Password` be modified to include an `identity` argument that will only optionally be used? Or should I make a separate `NetworkManagerRequest::IdentityPassword` request that has the 3 arguments (SSID, identity, password).

* I'm still working out how to use NetworkManager to detect when a network is using a scheme that requires an identity. I'll be doing more research into the NetworkManager interface.

Side note: This is my first time using Rust! :crab: 