### PR TITLE
fix: disable wgpu feature for tiling applet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,7 +3218,6 @@ dependencies = [
  "iced_sctk",
  "iced_style",
  "iced_tiny_skia",
- "iced_wgpu",
  "iced_widget",
  "lazy_static",
  "nix 0.27.1",

--- a/cosmic-applet-tiling/Cargo.toml
+++ b/cosmic-applet-tiling/Cargo.toml
@@ -15,7 +15,6 @@ libcosmic.features = [
     "desktop",
     "tokio",
     "wayland",
-    "wgpu"
 ]
 cosmic-time.workspace = true
 cctk.workspace = true


### PR DESCRIPTION
this seems to resolve recent performance issues for the panel. #239 