### PR TITLE
app-list (RFC): make app list icons more visible at smaller panel sizes (and some various fixes)

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -139,53 +139,100 @@ impl DockItem {
         let cosmic_icon = desktop_info
             .icon
             .as_cosmic_icon()
-            .size(applet.suggested_size().0);
+            .size(applet.suggested_size().0 + 6);
 
         let dot_radius = 2;
-        let dots = (0..min(toplevels.len(), 3))
+        let dot_spacer = (0..1)
             .map(|_| {
                 container(vertical_space(Length::Fixed(0.0)))
                     .padding(dot_radius)
-                    .style(<Theme as container::StyleSheet>::Style::Custom(Box::new(
-                        |theme| container::Appearance {
-                            text_color: Some(Color::TRANSPARENT),
-                            background: Some(Background::Color(
-                                theme.cosmic().on_bg_color().into(),
-                            )),
-                            border: Border {
-                                radius: 4.0.into(),
-                                width: 0.0,
-                                color: Color::TRANSPARENT,
-                            },
-                            shadow: Shadow::default(),
-                            icon_color: Some(Color::TRANSPARENT),
-                        },
-                    )))
                     .into()
             })
             .collect_vec();
-        let icon_wrapper: Element<_> = match applet.anchor {
-            PanelAnchor::Left => row(vec![column(dots).spacing(4).into(), cosmic_icon.into()])
-                .align_items(iced::Alignment::Center)
-                .spacing(4)
-                .into(),
-            PanelAnchor::Right => row(vec![cosmic_icon.into(), column(dots).spacing(4).into()])
-                .align_items(iced::Alignment::Center)
-                .spacing(4)
-                .into(),
-            PanelAnchor::Top => column(vec![row(dots).spacing(4).into(), cosmic_icon.into()])
-                .align_items(iced::Alignment::Center)
-                .spacing(4)
-                .into(),
-            PanelAnchor::Bottom => column(vec![cosmic_icon.into(), row(dots).spacing(4).into()])
-                .align_items(iced::Alignment::Center)
-                .spacing(4)
-                .into(),
+
+        let dots = if toplevels.is_empty() {
+            (0..1)
+                .map(|_| {
+                    container(vertical_space(Length::Fixed(0.0)))
+                        .padding(dot_radius)
+                        .into()
+                })
+                .collect_vec()
+        } else {
+            (0..min(toplevels.len(), 3))
+                .map(|_| {
+                    container(vertical_space(Length::Fixed(0.0)))
+                        .padding(dot_radius)
+                        .style(<Theme as container::StyleSheet>::Style::Custom(Box::new(
+                            |theme| container::Appearance {
+                                text_color: Some(Color::TRANSPARENT),
+                                background: Some(Background::Color(
+                                    theme.cosmic().on_bg_color().into(),
+                                )),
+                                border: Border {
+                                    radius: 4.0.into(),
+                                    width: 0.0,
+                                    color: Color::TRANSPARENT,
+                                },
+                                shadow: Shadow::default(),
+                                icon_color: Some(Color::TRANSPARENT),
+                            },
+                        )))
+                        .into()
+                })
+                .collect_vec()
         };
 
-        let icon_button = cosmic::widget::button(icon_wrapper)
-            .style(Button::Text)
-            .padding(8);
+        let icon_wrapper: Element<_> = match applet.anchor {
+            PanelAnchor::Left => row(vec![
+                column(dots).spacing(4).into(),
+                cosmic_icon.into(),
+                column(dot_spacer).spacing(4).into(),
+            ])
+            .align_items(iced::Alignment::Center)
+            .spacing(1)
+            .into(),
+            PanelAnchor::Right => row(vec![
+                column(dot_spacer).spacing(4).into(),
+                cosmic_icon.into(),
+                column(dots).spacing(4).into(),
+            ])
+            .align_items(iced::Alignment::Center)
+            .spacing(1)
+            .into(),
+            PanelAnchor::Top => column(vec![
+                row(dots).spacing(4).into(),
+                cosmic_icon.into(),
+                row(dot_spacer).spacing(4).into(),
+            ])
+            .align_items(iced::Alignment::Center)
+            .spacing(1)
+            .into(),
+            PanelAnchor::Bottom => column(vec![
+                row(dot_spacer).spacing(4).into(),
+                cosmic_icon.into(),
+                row(dots).spacing(4).into(),
+            ])
+            .align_items(iced::Alignment::Center)
+            .spacing(1)
+            .into(),
+        };
+
+        let icon_button = match applet.anchor {
+            PanelAnchor::Left => cosmic::widget::button(icon_wrapper)
+                .style(Button::Text)
+                .padding([5, 0]),
+            PanelAnchor::Right => cosmic::widget::button(icon_wrapper)
+                .style(Button::Text)
+                .padding([5, 0]),
+            PanelAnchor::Top => cosmic::widget::button(icon_wrapper)
+                .style(Button::Text)
+                .padding([0, 5]),
+            PanelAnchor::Bottom => cosmic::widget::button(icon_wrapper)
+                .style(Button::Text)
+                .padding([0, 5]),
+        };
+
         let icon_button = if interaction_enabled {
             dnd_source(
                 mouse_area(


### PR DESCRIPTION
Potential solution for:
https://github.com/pop-os/cosmic-applets/issues/222

Fixes:
https://github.com/pop-os/cosmic-panel/issues/101

## Current changes/fixes in the PR:

### Design Changes
* Reduced width padding to 1, length padding remains at 8
* Reduced the spacing between the dot and icon in an app icon button to 1
* Increased the size of the app's icon by 8

### Fixes
* App icons for closed apps will now align with app icons for opened apps
* The panel at smaller sizes will no longer need to resize itself to be larger when the app list applet is loaded in 
  * Basically if no apps were open, the sizing would be fine, but if an app was open, the panel would have to resize itself to make room for the dot and all the padding.

### Screenshots (Note updated pictures are sent further down in the conversation)
| With the PR | Without the PR |
| --- | --- |
| ![screenshot-2024-03-03-06-28-19](https://github.com/pop-os/cosmic-applets/assets/56272643/0999debf-99ba-458d-a2b4-6eae73c2c3ad) |  ![screenshot-2024-03-03-06-42-26](https://github.com/pop-os/cosmic-applets/assets/56272643/136c825b-e66e-4f3b-a15f-fdb8a246b6c4) |
| ![screenshot-2024-03-03-06-29-09](https://github.com/pop-os/cosmic-applets/assets/56272643/218d54cc-5216-43f9-a249-da10a78c394c) | ![screenshot-2024-03-03-06-48-40](https://github.com/pop-os/cosmic-applets/assets/56272643/ea194705-7b20-4604-80b1-3fb50beabc47) |
| ![screenshot-2024-03-03-06-30-25](https://github.com/pop-os/cosmic-applets/assets/56272643/d2f6c5c0-400f-423e-b514-b1dd550fd115) | ![screenshot-2024-03-03-06-49-12](https://github.com/pop-os/cosmic-applets/assets/56272643/438fc3ef-29a4-4c12-bf59-1a34fa74f12a) |

cc: @pop-os/ux 