### PR TITLE
refactor: set dispatch to None for tiling and workspaces

### DIFF
--- a/cosmic-applet-tiling/src/wayland.rs
+++ b/cosmic-applet-tiling/src/wayland.rs
@@ -114,9 +114,7 @@ pub fn spawn_workspaces(tx: mpsc::Sender<TilingState>) -> SyncSender<TilingState
                 })
                 .unwrap();
             while state.running {
-                event_loop
-                    .dispatch(Duration::from_millis(16), &mut state)
-                    .unwrap();
+                event_loop.dispatch(None, &mut state).unwrap();
             }
         });
     } else {

--- a/cosmic-applet-workspaces/src/wayland.rs
+++ b/cosmic-applet-workspaces/src/wayland.rs
@@ -168,9 +168,7 @@ pub fn spawn_workspaces(tx: mpsc::Sender<WorkspaceList>) -> SyncSender<Workspace
                 })
                 .unwrap();
             while state.running {
-                event_loop
-                    .dispatch(Duration::from_millis(16), &mut state)
-                    .unwrap();
+                event_loop.dispatch(None, &mut state).unwrap();
             }
         });
     } else {


### PR DESCRIPTION
This should help lower cpu usage of the workspaces applet and tiling applet