### PR TITLE
chore: update libcosmic (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
  "futures-util",
  "i18n-embed 0.13.9",
  "i18n-embed-fl 0.6.7",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "libcosmic",
  "log",
  "nix 0.26.4",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1250,7 +1250,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2093,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45157175a725e81f3f594382430b6b78af5f8f72db9bd51b94f0785f80fc6d29"
+checksum = "287f89b1a3d88dd04d2b65dfec39f3c381efbcded7b736456039c4ee49d54b17"
 dependencies = [
  "dirs 3.0.2",
  "gettext-rs",
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2806,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "bitflags 1.3.2",
  "iced_accessibility",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "futures",
  "iced_core",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "iced_accessibility",
  "iced_core",
@@ -2886,7 +2886,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2911,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2957,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -3242,7 +3242,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#6754aeb0dcfa8d5e132d3c515343be98af101594"
+source = "git+https://github.com/pop-os/libcosmic#b4ad96066bee18eb3e95aeab41b50e89be2e5b1b"
 dependencies = [
  "apply",
  "ashpd 0.7.0",


### PR DESCRIPTION
This PR bumps the libcosmic dependency to this commit https://github.com/pop-os/libcosmic/commit/b4ad96066bee18eb3e95aeab41b50e89be2e5b1b

I used `cargo update libcosmic`, which I assume is correct but I haven't updated dependencies in a rust project before so let me know.