### PR TITLE
feat: set integer X-MinimizeApplet priorities

### DIFF
--- a/cosmic-app-list/data/com.system76.CosmicAppList.desktop
+++ b/cosmic-app-list/data/com.system76.CosmicAppList.desktop
@@ -11,4 +11,5 @@ Icon=com.system76.CosmicAppList
 StartupNotify=true
 NoDisplay=true
 X-CosmicApplet=true
+X-MinimizeApplet=5
 X-HostWaylandDisplay=true

--- a/cosmic-applet-minimize/data/com.system76.CosmicAppletMinimize.desktop
+++ b/cosmic-applet-minimize/data/com.system76.CosmicAppletMinimize.desktop
@@ -11,5 +11,5 @@ Icon=com.system76.CosmicAppletMinimize
 StartupNotify=true
 NoDisplay=true
 X-CosmicApplet=true
-X-MinimizeApplet=true
+X-MinimizeApplet=10
 X-HostWaylandDisplay=true


### PR DESCRIPTION
Now that https://github.com/pop-os/cosmic-panel/commit/6590999f80459726bf026a4529711be7af8eb316 is merged, we should set integer priorities for the X-MinimizeApplet entry in the cosmic-applet-minimize .desktop file. Additionally, we can now make cosmic-app-list a 'fallback' minimize applet when cosmic-applet-minimize isn't present.

Future work:
In addition to this, I can make a 2nd PR which will let cosmic-applet-minimize gracefully exit with no errors if it is not chosen as the minimize applet (this would only happen if someone were to make a 3rd party minimize applet with higher priority than the 1st party one)