### PR TITLE
feat(cosmic-panel-button): add capability to execute commands

### DIFF
--- a/cosmic-panel-button/src/main.rs
+++ b/cosmic-panel-button/src/main.rs
@@ -60,18 +60,60 @@ impl cosmic::Application for Button {
 }
 
 pub fn main() -> iced::Result {
-    let id = env::args()
-        .nth(1)
-        .expect("Requires desktop file id as argument.");
-
-    let filename = format!("{id}.desktop");
     let mut desktop = None;
-    for mut path in freedesktop_desktop_entry::default_paths() {
-        path.push(&filename);
-        if let Ok(bytes) = fs::read_to_string(&path) {
-            if let Ok(entry) = DesktopEntry::decode(&path, &bytes) {
-                desktop =
-                    Some(Desktop {
+    if env::args().len() > 2
+        || env::args()
+            .nth(1)
+            .expect("Requires a desktop id or --help for an argument.")
+            == "--help"
+    {
+        let args: Vec<String> = env::args().collect();
+        let mut exec = None;
+        let mut name = None;
+        let mut icon = None;
+
+        for i in 1..args.len() {
+            match args[i].as_str() {
+                "-e" | "--exec" => {
+                    exec = args.get(i + 1).map(|s| s.to_owned());
+                }
+                "-n" | "--name" => {
+                    name = args.get(i + 1).map(|s| s.to_owned());
+                }
+                "-i" | "--icon" => {
+                    icon = args.get(i + 1).map(|s| s.to_owned());
+                }
+                "-h" | "--help" => {
+                    println!("cosmic-panel-button is a cosmic applet which creates a button to either run .desktop files or execute a command. \n");
+                    println!("--exec and --name are required arguments. \n");
+                    println!("-e, --exec <COMMAND>  Command to execute");
+                    println!("-n, --name <NAME>     Name of the applet");
+                    println!("-i, --icon <ICON>     Name of the icon for the applet \n");
+                    println!("Example line .desktop file:");
+                    println!("Exec=sh -c \"cosmic-panel-button --exec 'notify-send cosmic-panel-button_pressed' --name 'send-notification' --icon bell\"");
+                    std::process::exit(1)
+                }
+                _ => {}
+            }
+        }
+
+        desktop = Some(Desktop {
+            name: name.unwrap_or_else(|| panic!("Name is a required argument")),
+            icon: icon,
+            exec: exec.unwrap_or_else(|| panic!("Exec is a required argument")),
+        });
+    } else {
+        let arg = env::args()
+            .nth(1)
+            .expect("Requires a desktop id or --help for an argument.");
+
+        let filename = format!("{arg}.desktop");
+
+        for mut path in freedesktop_desktop_entry::default_paths() {
+            path.push(&filename);
+            if let Ok(bytes) = fs::read_to_string(&path) {
+                if let Ok(entry) = DesktopEntry::decode(&path, &bytes) {
+                    desktop = Some(Desktop {
                         name: entry.name(None).map(|x| x.to_string()).unwrap_or_else(|| {
                             panic!("Desktop file '{filename}' doesn't have `Name`")
                         }),
@@ -80,12 +122,13 @@ pub fn main() -> iced::Result {
                             panic!("Desktop file '{filename}' doesn't have `Exec`")
                         }),
                     });
-                break;
+                    break;
+                }
             }
         }
+        desktop = Some(desktop.unwrap_or_else(|| {
+            panic!("Failed to find valid desktop file '{filename}' in search paths")
+        }));
     }
-    let desktop = desktop.unwrap_or_else(|| {
-        panic!("Failed to find valid desktop file '{filename}' in search paths")
-    });
-    cosmic::applet::run::<Button>(true, desktop)
+    cosmic::applet::run::<Button>(true, desktop.unwrap())
 }


### PR DESCRIPTION
Adds the ability to run commands directly from the app instead of needing to create a separate .desktop file an example invocation of this would be below

A couple things I want to fix up, 
- [ ] The if statement is stupid and rustfmt did it no favors, however I ran out of time.
- [ ] I don't actually know what the icon does since setting it has never actually done anything for me
- [ ] word the help better or maybe just remove it and put it into it's own little document file

as it stands however i'm out of time until next week or so.

```.desktop
[Desktop Entry]
Name=Cosmic Panel wvkbd trigger
Comment=Applet to trigger wvkbd
Type=Application
Exec=sh -c "cosmic-panel-button --exec 'notify-send cosmic-panel-button_pressed' --name 'send-notification' --icon bell"
Terminal=false
Categories=Cosmic;Iced;
Keywords=Cosmic;Iced;
Icon=bell
StartupNotify=true
NoDisplay=true
X-CosmicApplet=true
```