### PR TITLE
improv(app-list): only send screencopy requests as needed

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -658,6 +658,12 @@ impl cosmic::Application for CosmicAppList {
                     .chain(self.favorite_list.iter())
                     .find(|t| t.desktop_info.id == id)
                 {
+                    for (ref handle, _, _) in &toplevel_group.toplevels {
+                        if let Some(tx) = self.wayland_sender.as_ref() {
+                            let _ = tx.send(WaylandRequest::Screencopy(handle.clone()));
+                        }
+                    }
+
                     let rectangle = match self.rectangles.get(&toplevel_group.id) {
                         Some(r) => r,
                         None => return Command::none(),

--- a/cosmic-app-list/src/wayland_handler.rs
+++ b/cosmic-app-list/src/wayland_handler.rs
@@ -220,15 +220,13 @@ impl ToplevelInfoHandler for AppData {
         toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
     ) {
         if let Some(info) = self.toplevel_info_state.info(toplevel) {
-            // spawn thread for sending the image
-            self.send_image(toplevel.clone());
-
             let _ = self
                 .tx
                 .unbounded_send(WaylandUpdate::Toplevel(ToplevelUpdate::Add(
                     toplevel.clone(),
                     info.clone(),
                 )));
+            self.send_image(toplevel.clone());
         }
     }
 
@@ -239,8 +237,6 @@ impl ToplevelInfoHandler for AppData {
         toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
     ) {
         if let Some(info) = self.toplevel_info_state.info(toplevel) {
-            // spawn thread for sending the image
-            self.send_image(toplevel.clone());
             let _ = self
                 .tx
                 .unbounded_send(WaylandUpdate::Toplevel(ToplevelUpdate::Update(
@@ -615,6 +611,9 @@ pub(crate) fn wayland_handler(
     if handle
         .insert_source(rx, |event, _, state| match event {
             calloop::channel::Event::Msg(req) => match req {
+                WaylandRequest::Screencopy(handle) => {
+                    state.send_image(handle.clone());
+                }
                 WaylandRequest::Toplevel(req) => match req {
                     ToplevelRequest::Activate(handle) => {
                         if let Some(seat) = state.seat_state.seats().next() {

--- a/cosmic-app-list/src/wayland_subscription.rs
+++ b/cosmic-app-list/src/wayland_subscription.rs
@@ -128,6 +128,7 @@ pub enum WaylandRequest {
         exec: String,
         gpu_idx: Option<usize>,
     },
+    Screencopy(ZcosmicToplevelHandleV1),
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR lessens the use of screencopy in my recent app-list PR, by only requesting window captures once the popup is triggered and when the toplevel first exists.

The previous method (whenever a TopLevelUpdate occurs) sacrifices performance for no reason, since the images aren't needed every update, and also means we don't always get a toplevel update between checking the popup (for example, scroll on an app without changing anything else about the window, the image won't update)

The caveat with this method is that there will be a small period of time where the previous screencopy is used on the popup, then the new image will take its place once its ready. That time will depend on the speed of the computer, but for my debug build it was a noticeable amount of time, less than half a second but still noticeable.

If we can come up with a better metric to trigger screencopies without compromising too much performance, let me know. This method is likely the most performant method that still remains really effective.