### PR TITLE
app-list/applet-minimize: stability fixes

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -8,13 +8,11 @@ use crate::wayland_subscription::ToplevelUpdate;
 use crate::wayland_subscription::WaylandImage;
 use crate::wayland_subscription::WaylandRequest;
 use crate::wayland_subscription::WaylandUpdate;
-use crate::wayland_subscription::WorkspaceUpdate;
 use cctk::sctk::reexports::calloop::channel::Sender;
 use cctk::toplevel_info::ToplevelInfo;
 use cctk::wayland_client::protocol::wl_data_device_manager::DndAction;
 use cctk::wayland_client::protocol::wl_seat::WlSeat;
 use cosmic::cosmic_config::{Config, CosmicConfigEntry};
-use cosmic::desktop::IconSource;
 use cosmic::desktop::{
     app_id_or_fallback_matches, load_applications_for_app_ids, DesktopEntryData,
 };
@@ -1064,12 +1062,9 @@ impl cosmic::Application for CosmicAppList {
                             }
                         }
                     },
-                    WaylandUpdate::Workspace(event) => match event {
-                        WorkspaceUpdate::Enter(handle) => {
-                            self.active_workspace = Some(handle);
-                        }
-                        _ => {}
-                    },
+                    WaylandUpdate::Workspace(handle) => {
+                        self.active_workspace = Some(handle);
+                    }
                     WaylandUpdate::ActivationToken {
                         token,
                         exec,
@@ -1370,7 +1365,7 @@ impl cosmic::Application for CosmicAppList {
                         .config
                         .favorites
                         .iter()
-                        .any(|x| app_id_or_fallback_matches(&x, desktop_info));
+                        .any(|x| app_id_or_fallback_matches(x, desktop_info));
 
                     let mut content = column![container(
                         iced::widget::text(&desktop_info.name)

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -431,7 +431,6 @@ const TOPLEVEL_BUTTON_HEIGHT: f32 = 130.0;
 
 pub fn toplevel_button<'a, Msg>(
     img: Option<WaylandImage>,
-    icon: &IconSource,
     on_press: Msg,
     title: String,
     text_size: f32,
@@ -456,11 +455,7 @@ where
                         .content_fit(cosmic::iced_core::ContentFit::Contain),
                     )
                 } else {
-                    Element::from(
-                        icon.as_cosmic_icon()
-                            .width(Length::Fill)
-                            .height(Length::Fill),
-                    )
+                    Image::new(Handle::from_pixels(1, 1, vec![0, 0, 0, 255])).into()
                 })
                 .style(Container::Custom(Box::new(move |theme| {
                     container::Appearance {
@@ -1475,7 +1470,6 @@ impl cosmic::Application for CosmicAppList {
                             };
                             content = content.push(toplevel_button(
                                 img.clone(),
-                                &desktop_info.icon,
                                 Message::Toggle(handle.clone()),
                                 title,
                                 10.0,
@@ -1496,7 +1490,6 @@ impl cosmic::Application for CosmicAppList {
                             };
                             content = content.push(toplevel_button(
                                 img.clone(),
-                                &desktop_info.icon,
                                 Message::Toggle(handle.clone()),
                                 title,
                                 10.0,

--- a/cosmic-app-list/src/wayland_handler.rs
+++ b/cosmic-app-list/src/wayland_handler.rs
@@ -1,5 +1,5 @@
 use crate::wayland_subscription::{
-    ToplevelRequest, ToplevelUpdate, WaylandImage, WaylandRequest, WaylandUpdate, WorkspaceUpdate,
+    ToplevelRequest, ToplevelUpdate, WaylandImage, WaylandRequest, WaylandUpdate,
 };
 use std::{
     os::{
@@ -114,11 +114,9 @@ impl WorkspaceHandler for AppData {
                     .state
                     .contains(&WEnum::Value(WorkspaceUpdateState::Active))
                 {
-                    let _ =
-                        self.tx
-                            .unbounded_send(WaylandUpdate::Workspace(WorkspaceUpdate::Enter(
-                                workspace.handle.clone(),
-                            )));
+                    let _ = self
+                        .tx
+                        .unbounded_send(WaylandUpdate::Workspace(workspace.handle.clone()));
                     break 'workspaces_loop;
                 }
             }

--- a/cosmic-app-list/src/wayland_handler.rs
+++ b/cosmic-app-list/src/wayland_handler.rs
@@ -226,7 +226,6 @@ impl ToplevelInfoHandler for AppData {
                     toplevel.clone(),
                     info.clone(),
                 )));
-            self.send_image(toplevel.clone());
         }
     }
 

--- a/cosmic-app-list/src/wayland_subscription.rs
+++ b/cosmic-app-list/src/wayland_subscription.rs
@@ -99,7 +99,7 @@ pub enum WaylandUpdate {
     Init(calloop::channel::Sender<WaylandRequest>),
     Finished,
     Toplevel(ToplevelUpdate),
-    Workspace(WorkspaceUpdate),
+    Workspace(ZcosmicWorkspaceHandleV1),
     ActivationToken {
         token: Option<String>,
         exec: String,
@@ -113,11 +113,6 @@ pub enum ToplevelUpdate {
     Add(ZcosmicToplevelHandleV1, ToplevelInfo),
     Update(ZcosmicToplevelHandleV1, ToplevelInfo),
     Remove(ZcosmicToplevelHandleV1),
-}
-
-#[derive(Clone, Debug)]
-pub enum WorkspaceUpdate {
-    Enter(ZcosmicWorkspaceHandleV1),
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
There have been numerous reports of compositor crashes following this PR https://github.com/pop-os/cosmic-applets/pull/317.

https://matrix.to/#/!u3Y5dwYi8p48iq7tiq:conduit.rs/$fmkBSi_d0QRuu5drcvDkB_-vZnxlzXnfUl6LpHp3J94?via=nixos.org&via=matrix.org&via=beeper.com

https://github.com/ublue-os/cosmic/issues/22

I also have gotten my own crashes, in particular one from firefox, which caused a spiral of crashes.

This pr: https://github.com/pop-os/cosmic-applets/pull/322 lessened the amount of screencopy requests we are making by a lot, which should mitigate the issue. I think the bug reports from users are people using the previous commit, but I'm not fully satisfied with just doing that. I'd like to use this as an opportunity to harden the wayland handler implementation as much as we can.

I've been trying since yesterday to fix these issues, and will require help from @Drakulix in fully debugging and fixing those issues. But in the meantime, this PR does two things:

1. Adds very simple error logging and graceful exit for the event loops in `cosmic-app-list` and `cosmic-applet-minimize`
2. Removes yet another screencopy condition (on toplevel add, which we pretty much don't need). Now the only remaining screencopy requests are done whenever the multi-window popup is triggered, and that's it.

With this, I might be able to sleep a bit better :sweat_smile: 