### PR TITLE
feat(i18n): Add Indonesian translations for sound applet

### DIFF
--- a/cosmic-applet-audio/i18n/id/cosmic_applet_audio.ftl
+++ b/cosmic-applet-audio/i18n/id/cosmic_applet_audio.ftl
@@ -1,0 +1,7 @@
+output = Keluaran
+input = Masukan
+show-media-controls = Tampilkan Kontrol Media di Panel Atas
+sound-settings = Pengaturan Suara...
+disconnected = PulseAudio Terputus
+no-device = Tidak ada perangkat yang dipilih
+unknown-artist = Artis Tidak Dikenal


### PR DESCRIPTION
## Summary

This PR adds Indonesian translations for key terms used within the Linux sound applets interface. These translations are aimed at improving the accessibility and usability of sound management features for Indonesian-speaking users.


