### PR TITLE
audio: Mpris media control fixes

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -50,7 +50,7 @@ const PLAY: &str = "media-playback-start-symbolic";
 
 pub fn run() -> cosmic::iced::Result {
     localize();
-    cosmic::applet::run::<Audio>(false, ())
+    cosmic::applet::run::<Audio>(true, ())
 }
 
 #[derive(Default)]
@@ -160,7 +160,13 @@ impl Audio {
                 .map(|s| s.can_go_previous)
                 .unwrap_or_default()
             {
-                elements.push(self.core.applet.icon_button(GO_BACK).into())
+                elements.push(
+                    self.core
+                        .applet
+                        .icon_button(GO_BACK)
+                        .on_press(Message::MprisRequest(MprisRequest::Previous))
+                        .into(),
+                )
             }
             if let Some(play) = self.is_play() {
                 elements.push(
@@ -181,7 +187,13 @@ impl Audio {
                 .map(|s| s.can_go_next)
                 .unwrap_or_default()
             {
-                elements.push(self.core.applet.icon_button(GO_NEXT).into())
+                elements.push(
+                    self.core
+                        .applet
+                        .icon_button(GO_NEXT)
+                        .on_press(Message::MprisRequest(MprisRequest::Next))
+                        .into(),
+                )
             }
 
             Some(match self.core.applet.anchor {

--- a/cosmic-applet-audio/src/pulse.rs
+++ b/cosmic-applet-audio/src/pulse.rs
@@ -19,8 +19,6 @@ use libpulse_binding::{
     volume::ChannelVolumes,
 };
 
-use std::time::{Duration, Instant};
-
 use tokio::sync::{mpsc, Mutex};
 
 pub static FROM_PULSE: Lazy<Mutex<Option<(mpsc::Receiver<Message>, mpsc::Sender<Message>)>>> =


### PR DESCRIPTION
The panel buttons for next/previous didn't do anything since `on_press` wasn't set. Now they work.

Fixed `autosize` which I had accidentally committed after using it for testing. (It would be good to figure out why the applets don't work properly with autosize when run outside of the panel, since that's handy for testing.)

I noticed with VLC, skipping a track makes the media controls disappear very briefly, and sometimes the pause button didn't return. I guess `can_play` (etc.) are temporarily set to false, probably expecting the controls to be greyed out and not hidden from a panel. Anyway, monitoring for changes to these properties as well will hopefully fix the part where it could remain missing. Though I can't reproduce that consistently.