### PR TITLE
fix(panel-button): use icon on large panel size

### DIFF
--- a/cosmic-panel-button/src/main.rs
+++ b/cosmic-panel-button/src/main.rs
@@ -1,4 +1,5 @@
-use cosmic::applet::cosmic_panel_config::PanelAnchor;
+use cosmic::applet::cosmic_panel_config::{PanelAnchor, PanelSize};
+use cosmic::applet::Size;
 use cosmic::iced::Length;
 use cosmic::iced_widget::{row, text};
 use cosmic::widget::vertical_space;
@@ -55,10 +56,13 @@ impl cosmic::Application for Button {
     }
 
     fn view(&self) -> cosmic::Element<Msg> {
-        if matches!(
+        if (matches!(
             self.core.applet.anchor,
             PanelAnchor::Left | PanelAnchor::Right
-        ) && self.desktop.icon.is_some()
+        ) || !matches!(
+            self.core.applet.size,
+            Size::PanelSize(PanelSize::XS) | Size::PanelSize(PanelSize::S)
+        )) && self.desktop.icon.is_some()
         {
             self.core
                 .applet


### PR DESCRIPTION
Displays icon when panel size is M or larger.

![screenshot-2024-04-11-20-26-23](https://github.com/pop-os/cosmic-applets/assets/153014021/7540e9e0-3bf2-4a9e-9442-6e5b9c3c6232)
![screenshot-2024-04-11-20-26-52](https://github.com/pop-os/cosmic-applets/assets/153014021/de08e1a3-fe66-4507-85d1-ca7a98b4e659)
