### PR TITLE
feat(i18n): Add Indonesian translations for bluetooth applet 

### DIFF
--- a/cosmic-applet-bluetooth/i18n/id/cosmic_applet_bluetooth.ftl
+++ b/cosmic-applet-bluetooth/i18n/id/cosmic_applet_bluetooth.ftl
@@ -1,0 +1,12 @@
+bluetooth = Bluetooth
+other-devices = Perangkat Bluetooth Lainnya
+settings = Pengaturan Bluetooth...
+connected = Terhubung
+confirm-pin = Mohon konfirmasi bahwa PIN berikut sesuai dengan yang ditampilkan pada {$deviceName}
+confirm = Konfirmasi
+cancel = Batalkan
+unsuccessful = Gagal Terhubung
+check-device = Pastikan {$deviceName} dalam keadaan menyala, dalam jangkauan, dan siap untuk disambungkan.
+try-again = Coba Lagi
+discoverable = Terdeteksi
+pairable = Dapat Disambungkan


### PR DESCRIPTION
## Summary
This PR introduces Indonesian translations for essential terms used within the Bluetooth applets interface. These translations are designed to enhance the accessibility and usability of Bluetooth management features for Indonesian-speaking users.