### PR TITLE
Update app.rs to accomodate different languages

### DIFF
--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -400,7 +400,7 @@ impl cosmic::Application for CosmicBatteryApplet {
     }
 
     fn view_window(&self, _id: window::Id) -> Element<Message> {
-        let name = text(fl!("battery")).size(14);
+        let name = text(fl!("battery-percentage")).size(14);
         let description = text(if !self.on_battery {
             format!("{}%", self.battery_percent)
         } else {


### PR DESCRIPTION
Fluent "battery" variable is used two times in actual code. In one case it's percentage of battery left, in second case it's used in power-saving mode context.

In english, it's one and the same. In other languages it's not always the case. For example in Polish, first use case would be better as (100%) Baterii, while second one could be translated as Na Baterii (On Battery) or (Tryb) Bateryjny (Battery [Mode]) or Oszczędzanie Baterii (Power-Save mode, roughly but not exactly). Anyway, there is no chance to use one simple word for both use-cases.

It would require updating EN i18n, too. And maybe other bits i didn't noticed.