### PR TITLE
fix: reset timeline when a popup is created

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -310,6 +310,7 @@ impl cosmic::Application for Audio {
                     }
                     let new_id = window::Id::unique();
                     self.popup.replace(new_id);
+                    self.timeline = Timeline::new();
 
                     let mut popup_settings = self.core.applet.get_popup_settings(
                         window::Id::MAIN,

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -238,6 +238,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                     if let Some(tx) = &self.screen_sender {
                         let _ = tx.send(ScreenBacklightRequest::Get);
                     }
+                    self.timeline = Timeline::new();
 
                     let new_id = window::Id::unique();
                     self.popup.replace(new_id);

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -118,6 +118,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
                     // TODO request update of state maybe
                     let new_id = window::Id::unique();
                     self.popup.replace(new_id);
+                    self.timeline = Timeline::new();
 
                     let mut popup_settings = self.core.applet.get_popup_settings(
                         window::Id::MAIN,

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -229,6 +229,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     // TODO request update of state maybe
                     let new_id = window::Id::unique();
                     self.popup.replace(new_id);
+                    self.timeline = Timeline::new();
 
                     let mut popup_settings = self.core.applet.get_popup_settings(
                         window::Id::MAIN,

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -186,6 +186,7 @@ impl cosmic::Application for Notifications {
                 } else {
                     let new_id = window::Id::unique();
                     self.popup.replace(new_id);
+                    self.timeline = Timeline::new();
 
                     let mut popup_settings = self.core.applet.get_popup_settings(
                         window::Id::MAIN,


### PR DESCRIPTION
This should ensure all animated widgets appear with the updated state when the popup is created.