### PR TITLE
feat(panel-button): add cosmic config for panel button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,8 +1242,13 @@ dependencies = [
 name = "cosmic-panel-button"
 version = "0.1.0"
 dependencies = [
+ "cosmic-config",
  "freedesktop-desktop-entry",
  "libcosmic",
+ "serde",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1249,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#683a204ef81bd17c2b35264521e5145df3518ee5"
+source = "git+https://github.com/pop-os/cosmic-panel#e3ea8e0ec7d5d7a0ac66eef41d56d11b117f2f30"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2776,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "bitflags 2.5.0",
  "dnd",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "futures",
  "iced_core",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2870,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2896,7 +2896,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2906,7 +2906,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2923,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -3220,7 +3220,7 @@ checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#3927a553fba7ecf0dbd66fffaaa96836e0428973"
+source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
 dependencies = [
  "apply",
  "ashpd 0.7.0",
@@ -6254,7 +6254,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/xdg-shell-wrapper#224ada13d8ac53fec7854e82a731919366f5c74c"
+source = "git+https://github.com/pop-os/xdg-shell-wrapper#4e1da2cab5a9dc7067d51b3def4d85c9dd94667f"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "bitflags 2.5.0",
  "dnd",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "futures",
  "iced_core",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -2849,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2861,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2901,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2911,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2928,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -3225,7 +3225,7 @@ checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#fec71fdda4c5d48741e5ff8cdb66d9b3d2d52b9b"
+source = "git+https://github.com/pop-os/libcosmic#23f6fc8358e9e117bac372468f230f493f3cea5b"
 dependencies = [
  "apply",
  "ashpd 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ zbus = { version = "3.15", default-features = false, features = ["tokio"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-log = "0.2.0"
+cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
+serde = { version = "1.0.152", features = ["derive"] }
 
 [profile.release]
 lto = "fat"

--- a/cosmic-panel-button/Cargo.toml
+++ b/cosmic-panel-button/Cargo.toml
@@ -7,3 +7,8 @@ license = "GPL-3.0"
 [dependencies]
 freedesktop-desktop-entry = "0.5.1"
 libcosmic.workspace = true
+tracing-log.workspace = true
+tracing-subscriber.workspace = true
+tracing.workspace = true
+cosmic-config.workspace = true
+serde.workspace = true

--- a/cosmic-panel-button/src/config.rs
+++ b/cosmic-panel-button/src/config.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+use cosmic_config::{cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, CosmicConfigEntry)]
+#[version = 1]
+#[serde(deny_unknown_fields)]
+pub struct CosmicPanelButtonConfig {
+    /// configs indexed by panel name
+    pub configs: HashMap<String, IndividualConfig>,
+}
+
+impl Default for CosmicPanelButtonConfig {
+    fn default() -> Self {
+        Self {
+            configs: HashMap::from([
+                (
+                    "Panel".to_string(),
+                    IndividualConfig {
+                        force_presentation: None,
+                    },
+                ),
+                (
+                    "Dock".to_string(),
+                    IndividualConfig {
+                        force_presentation: Some(Override::Icon),
+                    },
+                ),
+            ]),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default, Clone)]
+pub struct IndividualConfig {
+    pub force_presentation: Option<Override>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum Override {
+    Icon,
+    Text,
+}

--- a/cosmic-panel-button/src/main.rs
+++ b/cosmic-panel-button/src/main.rs
@@ -98,9 +98,9 @@ impl cosmic::Application for Button {
             )
             || matches!(self.config.force_presentation, Some(Override::Icon))
         {
-            self.core
-                .applet
-                .icon_button(self.desktop.icon.as_ref().unwrap())
+            self.core.applet.icon_button_from_handle(
+                cosmic::widget::icon::from_name(self.desktop.icon.clone().unwrap()).handle(),
+            )
         } else {
             let content = row!(
                 text(&self.desktop.name).size(14.0),


### PR DESCRIPTION
This PR adds an optional environment variable to the cosmic-panel-button that allows us to specify how a panel button should present itself (either as 'icon' or as 'text').

This is before I add any overrides:

![screenshot-2024-05-06-07-08-12](https://github.com/pop-os/cosmic-applets/assets/56272643/324b5f72-b070-4905-b7f1-95db8b0e4af7)

This is after overriding the presentation of the launcher button and the workspaces button to be an icon, even though this is a horizontal panel:

![screenshot-2024-05-06-08-20-40](https://github.com/pop-os/cosmic-applets/assets/56272643/00b3699a-e563-4d95-aa9d-f966226eb07a)

This enables us in the future to expose an option in cosmic-settings to force an icon or text in a panel button, if we so choose. Otherwise, it can remain a niche configuration option.

Discussion: This option could also be presented as a command line argument instead of an environment variable. I chose an environment variable because it makes more sense for when there could be many different configuration options for an applet, to simply use an environment variable. I'm open to changing this though, but that's my justification. Also, if the env variable name should be something different, let me know!

The PR also adds the same tracing log that the other applets have, with an initial message notifying that the applet has started.