### PR TITLE
Update applet icons

### DIFF
--- a/cosmic-app-list/data/icons/scalable/apps/com.system76.CosmicAppList.svg
+++ b/cosmic-app-list/data/icons/scalable/apps/com.system76.CosmicAppList.svg
@@ -1,60 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="128px" height="128px" viewBox="0 0 128 128" version="1.1">
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="8" y="40" width="240" height="176" rx="16" fill="url(#paint0_linear_1936_317)"/>
+<rect x="136" y="80" width="96" height="96" rx="16" fill="url(#paint1_linear_1936_317)"/>
+<rect x="24" y="80" width="96" height="96" rx="16" fill="url(#paint2_linear_1936_317)"/>
+<circle cx="184" cy="192" r="8" fill="white"/>
+<circle cx="72" cy="192" r="8" fill="white"/>
 <defs>
-<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
-  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
-</filter>
-<mask id="mask0">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip1">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10632" clip-path="url(#clip1)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 123.503906 236 C 123.503906 268.863281 96.863281 295.503906 64 295.503906 C 31.136719 295.503906 4.496094 268.863281 4.496094 236 C 4.496094 203.136719 31.136719 176.496094 64 176.496094 C 96.863281 176.496094 123.503906 203.136719 123.503906 236 Z M 123.503906 236 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
-<mask id="mask1">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip2">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10635" clip-path="url(#clip2)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 29.195312 180.496094 L 98.804688 180.496094 C 103.609375 180.496094 107.503906 184.046875 107.503906 188.425781 L 107.503906 283.574219 C 107.503906 287.953125 103.609375 291.503906 98.804688 291.503906 L 29.195312 291.503906 C 24.390625 291.503906 20.496094 287.953125 20.496094 283.574219 L 20.496094 188.425781 C 20.496094 184.046875 24.390625 180.496094 29.195312 180.496094 Z M 29.195312 180.496094 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
-<mask id="mask2">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip3">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10638" clip-path="url(#clip3)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 20.417969 184.496094 L 107.582031 184.496094 C 111.957031 184.496094 115.503906 188.042969 115.503906 192.417969 L 115.503906 279.582031 C 115.503906 283.957031 111.957031 287.503906 107.582031 287.503906 L 20.417969 287.503906 C 16.042969 287.503906 12.496094 283.957031 12.496094 279.582031 L 12.496094 192.417969 C 12.496094 188.042969 16.042969 184.496094 20.417969 184.496094 Z M 20.417969 184.496094 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
-<mask id="mask3">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip4">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10641" clip-path="url(#clip4)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 16.425781 200.496094 L 111.574219 200.496094 C 115.953125 200.496094 119.503906 204.390625 119.503906 209.195312 L 119.503906 278.804688 C 119.503906 283.609375 115.953125 287.503906 111.574219 287.503906 L 16.425781 287.503906 C 12.046875 287.503906 8.496094 283.609375 8.496094 278.804688 L 8.496094 209.195312 C 8.496094 204.390625 12.046875 200.496094 16.425781 200.496094 Z M 16.425781 200.496094 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
+<linearGradient id="paint0_linear_1936_317" x1="248" y1="40" x2="6.11676" y2="213.373" gradientUnits="userSpaceOnUse">
+<stop stop-color="#49BAC8"/>
+<stop offset="1" stop-color="#229FAD"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1936_317" x1="136" y1="176" x2="233.977" y2="82.0625" gradientUnits="userSpaceOnUse">
+<stop stop-color="#DDC74C"/>
+<stop offset="1" stop-color="#F7E062"/>
+</linearGradient>
+<linearGradient id="paint2_linear_1936_317" x1="24" y1="176" x2="121.977" y2="82.0625" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C48400"/>
+<stop offset="1" stop-color="#FFAD00"/>
+</linearGradient>
 </defs>
-<g id="surface10578">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(94.117647%,94.117647%,94.117647%);fill-opacity:1;stroke:none;"/>
-<use xlink:href="#surface10632" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask0)"/>
-<use xlink:href="#surface10635" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask1)"/>
-<use xlink:href="#surface10638" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask2)"/>
-<use xlink:href="#surface10641" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask3)"/>
-<path style="fill:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(38.431373%,62.7451%,91.764706%);stroke-opacity:1;stroke-miterlimit:4;" d="M 0 289 L 128 289 " transform="matrix(1,0,0,1,0,-172)"/>
-</g>
 </svg>

--- a/cosmic-applet-status-area/data/icons/scalable/apps/com.system76.CosmicAppletStatusArea.svg
+++ b/cosmic-applet-status-area/data/icons/scalable/apps/com.system76.CosmicAppletStatusArea.svg
@@ -1,60 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="128px" height="128px" viewBox="0 0 128 128" version="1.1">
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 40C24 31.1634 31.1634 24 40 24H216C224.837 24 232 31.1634 232 40V216C232 224.837 224.837 232 216 232H40C31.1634 232 24 224.837 24 216V40Z" fill="url(#paint0_linear_1933_1660)"/>
+<circle cx="192" cy="192" r="56" fill="url(#paint1_linear_1933_1660)"/>
 <defs>
-<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
-  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
-</filter>
-<mask id="mask0">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip1">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10632" clip-path="url(#clip1)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 123.503906 236 C 123.503906 268.863281 96.863281 295.503906 64 295.503906 C 31.136719 295.503906 4.496094 268.863281 4.496094 236 C 4.496094 203.136719 31.136719 176.496094 64 176.496094 C 96.863281 176.496094 123.503906 203.136719 123.503906 236 Z M 123.503906 236 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
-<mask id="mask1">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip2">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10635" clip-path="url(#clip2)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 29.195312 180.496094 L 98.804688 180.496094 C 103.609375 180.496094 107.503906 184.046875 107.503906 188.425781 L 107.503906 283.574219 C 107.503906 287.953125 103.609375 291.503906 98.804688 291.503906 L 29.195312 291.503906 C 24.390625 291.503906 20.496094 287.953125 20.496094 283.574219 L 20.496094 188.425781 C 20.496094 184.046875 24.390625 180.496094 29.195312 180.496094 Z M 29.195312 180.496094 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
-<mask id="mask2">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip3">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10638" clip-path="url(#clip3)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 20.417969 184.496094 L 107.582031 184.496094 C 111.957031 184.496094 115.503906 188.042969 115.503906 192.417969 L 115.503906 279.582031 C 115.503906 283.957031 111.957031 287.503906 107.582031 287.503906 L 20.417969 287.503906 C 16.042969 287.503906 12.496094 283.957031 12.496094 279.582031 L 12.496094 192.417969 C 12.496094 188.042969 16.042969 184.496094 20.417969 184.496094 Z M 20.417969 184.496094 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
-<mask id="mask3">
-  <g filter="url(#alpha)">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(0%,0%,0%);fill-opacity:0.1;stroke:none;"/>
-  </g>
-</mask>
-<clipPath id="clip4">
-  <rect x="0" y="0" width="192" height="152"/>
-</clipPath>
-<g id="surface10641" clip-path="url(#clip4)">
-<path style="fill:none;stroke-width:0.99;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-dasharray:0.99,0.99;stroke-miterlimit:4;" d="M 16.425781 200.496094 L 111.574219 200.496094 C 115.953125 200.496094 119.503906 204.390625 119.503906 209.195312 L 119.503906 278.804688 C 119.503906 283.609375 115.953125 287.503906 111.574219 287.503906 L 16.425781 287.503906 C 12.046875 287.503906 8.496094 283.609375 8.496094 278.804688 L 8.496094 209.195312 C 8.496094 204.390625 12.046875 200.496094 16.425781 200.496094 Z M 16.425781 200.496094 " transform="matrix(1,0,0,1,8,-156)"/>
-</g>
+<linearGradient id="paint0_linear_1933_1660" x1="24" y1="232" x2="232" y2="24" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9E9E9E"/>
+<stop offset="1" stop-color="#BEBEBE"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1933_1660" x1="136" y1="248" x2="248" y2="136" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9D2329"/>
+<stop offset="1" stop-color="#CF484A"/>
+</linearGradient>
 </defs>
-<g id="surface10578">
-<rect x="0" y="0" width="128" height="128" style="fill:rgb(94.117647%,94.117647%,94.117647%);fill-opacity:1;stroke:none;"/>
-<use xlink:href="#surface10632" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask0)"/>
-<use xlink:href="#surface10635" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask1)"/>
-<use xlink:href="#surface10638" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask2)"/>
-<use xlink:href="#surface10641" transform="matrix(1,0,0,1,-8,-16)" mask="url(#mask3)"/>
-<path style="fill:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(38.431373%,62.7451%,91.764706%);stroke-opacity:1;stroke-miterlimit:4;" d="M 0 289 L 128 289 " transform="matrix(1,0,0,1,0,-172)"/>
-</g>
 </svg>

--- a/cosmic-panel-app-button/data/icons/scalable/apps/com.system76.CosmicPanelAppButton.svg
+++ b/cosmic-panel-app-button/data/icons/scalable/apps/com.system76.CosmicPanelAppButton.svg
@@ -1,99 +1,49 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="Layer_1"
-   data-name="Layer 1"
-   width="210"
-   height="210"
-   viewBox="0 0 210 210"
-   version="1.1"
-   sodipodi:docname="pop_icon.svg"
-   inkscape:version="0.92+devel unknown">
-  <metadata
-     id="metadata25">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Pop_icon</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs23" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     inkscape:document-rotation="0"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2560"
-     inkscape:window-height="1376"
-     id="namedview21"
-     showgrid="false"
-     fit-margin-top="5"
-     fit-margin-left="5"
-     fit-margin-right="5"
-     fit-margin-bottom="5"
-     inkscape:zoom="4.249208"
-     inkscape:cx="42.52691"
-     inkscape:cy="89.544373"
-     inkscape:window-x="0"
-     inkscape:window-y="31"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Layer_1" />
-  <title
-     id="title2">Pop_icon</title>
-  <g
-     id="g18"
-     transform="matrix(0.21141649,0,0,0.21141649,5,4.7885835)">
-    <g
-       id="g8">
-      <circle
-         cx="473"
-         cy="474"
-         r="473"
-         style="fill:#48b9c7"
-         id="circle4" />
-      <rect
-         x="223"
-         y="726"
-         width="500"
-         height="76.959999"
-         rx="37"
-         ry="37"
-         style="fill:#ffffff"
-         id="rect6" />
-    </g>
-    <path
-       d="m 536,357 c -24,51 -64,92 -120,112 l 48,125 c 9,23 17,47 10,69 -7,22 -39,29 -62,5 -44,-47 -192,-343 -203,-365 -11,-22 -23,-40 -23,-62 1,-33 52,-67 77,-84 25,-17 74,-40 117,-41 43,-1 61,9 86,25 38,25 65,64 75,109 10,45 7,80 -5,105 M 423,301 c -9,-31 -28,-61 -53,-81 -5,-4 -11,-9 -18,-11 -46,-15 -26,62 -19,82 7,20 26,62 47,83 5,5 10,9 16,10 6,1 18,-5 23,-13 5,-8 6,-14 6,-22 a 128,128 0 0 0 -2,-48 z"
-       style="fill:#ffffff"
-       id="path10"
-       inkscape:connector-curvature="0" />
-    <g
-       id="g16">
-      <path
-         d="m 625,664 c -2,9 -7,17 -15,22 -8,5 -27,5 -38,-4 -11,-9 -13,-24 -10,-36 3,-12 13,-25 27,-29 29,-9 42,23 36,47 z"
-         style="fill:#ffffff"
-         id="path12"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 607,573 c -18,-7 -12,-103 5,-220 5,-32 13,-48 22,-56 9,-8 36,-12 52,-9 a 90,90 0 0 1 49,24 c 12,11 13,23 9,38 -4,15 -18,47 -29,70 l -28,53 c -54,96 -65,106 -80,100 z"
-         style="fill:#ffffff"
-         id="path14"
-         inkscape:connector-curvature="0" />
-    </g>
-  </g>
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 40C24 31.1634 31.1634 24 40 24H72C80.8366 24 88 31.1634 88 40V72C88 80.8366 80.8366 88 72 88H40C31.1634 88 24 80.8366 24 72V40Z" fill="url(#paint0_linear_1928_658)"/>
+<path d="M96 184C96 175.163 103.163 168 112 168H144C152.837 168 160 175.163 160 184V216C160 224.837 152.837 232 144 232H112C103.163 232 96 224.837 96 216V184Z" fill="url(#paint1_linear_1928_658)"/>
+<path d="M96 112C96 103.163 103.163 96 112 96H144C152.837 96 160 103.163 160 112V144C160 152.837 152.837 160 144 160H112C103.163 160 96 152.837 96 144V112Z" fill="url(#paint2_linear_1928_658)"/>
+<path d="M168 112C168 103.163 175.163 96 184 96H216C224.837 96 232 103.163 232 112V144C232 152.837 224.837 160 216 160H184C175.163 160 168 152.837 168 144V112Z" fill="url(#paint3_linear_1928_658)"/>
+<path d="M24 184C24 175.163 31.1634 168 40 168H72C80.8366 168 88 175.163 88 184V216C88 224.837 80.8366 232 72 232H40C31.1634 232 24 224.837 24 216V184Z" fill="url(#paint4_linear_1928_658)"/>
+<path d="M168 40C168 31.1634 175.163 24 184 24H216C224.837 24 232 31.1634 232 40V72C232 80.8366 224.837 88 216 88H184C175.163 88 168 80.8366 168 72V40Z" fill="url(#paint5_linear_1928_658)"/>
+<path d="M96 40C96 31.1634 103.163 24 112 24H144C152.837 24 160 31.1634 160 40V72C160 80.8366 152.837 88 144 88H112C103.163 88 96 80.8366 96 72V40Z" fill="url(#paint6_linear_1928_658)"/>
+<path d="M24 112C24 103.163 31.1634 96 40 96H72C80.8366 96 88 103.163 88 112V144C88 152.837 80.8366 160 72 160H40C31.1634 160 24 152.837 24 144V112Z" fill="url(#paint7_linear_1928_658)"/>
+<path d="M168 184C168 175.163 175.163 168 184 168H216C224.837 168 232 175.163 232 184V216C232 224.837 224.837 232 216 232H184C175.163 232 168 224.837 168 216V184Z" fill="url(#paint8_linear_1928_658)"/>
+<defs>
+<linearGradient id="paint0_linear_1928_658" x1="24" y1="88" x2="89.3183" y2="25.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#229FAD"/>
+<stop offset="1" stop-color="#49BAC8"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1928_658" x1="96" y1="232" x2="161.318" y2="169.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#229FAD"/>
+<stop offset="1" stop-color="#49BAC8"/>
+</linearGradient>
+<linearGradient id="paint2_linear_1928_658" x1="96" y1="160" x2="161.318" y2="97.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A252D2"/>
+<stop offset="1" stop-color="#BE6DEE"/>
+</linearGradient>
+<linearGradient id="paint3_linear_1928_658" x1="168" y1="160" x2="233.318" y2="97.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#DDC74C"/>
+<stop offset="1" stop-color="#F7E062"/>
+</linearGradient>
+<linearGradient id="paint4_linear_1928_658" x1="24" y1="232" x2="89.3183" y2="169.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A252D2"/>
+<stop offset="1" stop-color="#BE6DEE"/>
+</linearGradient>
+<linearGradient id="paint5_linear_1928_658" x1="168" y1="88" x2="233.318" y2="25.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#229FAD"/>
+<stop offset="1" stop-color="#49BAC8"/>
+</linearGradient>
+<linearGradient id="paint6_linear_1928_658" x1="96" y1="88" x2="161.318" y2="25.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C48400"/>
+<stop offset="1" stop-color="#FFAD00"/>
+</linearGradient>
+<linearGradient id="paint7_linear_1928_658" x1="24" y1="160" x2="89.3183" y2="97.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C48400"/>
+<stop offset="1" stop-color="#FFAD00"/>
+</linearGradient>
+<linearGradient id="paint8_linear_1928_658" x1="168" y1="232" x2="233.318" y2="169.375" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C48400"/>
+<stop offset="1" stop-color="#FFAD00"/>
+</linearGradient>
+</defs>
 </svg>

--- a/cosmic-panel-launcher-button/data/icons/scalable/apps/com.system76.CosmicPanelLauncherButton.svg
+++ b/cosmic-panel-launcher-button/data/icons/scalable/apps/com.system76.CosmicPanelLauncherButton.svg
@@ -1,99 +1,29 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="Layer_1"
-   data-name="Layer 1"
-   width="210"
-   height="210"
-   viewBox="0 0 210 210"
-   version="1.1"
-   sodipodi:docname="pop_icon.svg"
-   inkscape:version="0.92+devel unknown">
-  <metadata
-     id="metadata25">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Pop_icon</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs23" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     inkscape:document-rotation="0"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2560"
-     inkscape:window-height="1376"
-     id="namedview21"
-     showgrid="false"
-     fit-margin-top="5"
-     fit-margin-left="5"
-     fit-margin-right="5"
-     fit-margin-bottom="5"
-     inkscape:zoom="4.249208"
-     inkscape:cx="42.52691"
-     inkscape:cy="89.544373"
-     inkscape:window-x="0"
-     inkscape:window-y="31"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Layer_1" />
-  <title
-     id="title2">Pop_icon</title>
-  <g
-     id="g18"
-     transform="matrix(0.21141649,0,0,0.21141649,5,4.7885835)">
-    <g
-       id="g8">
-      <circle
-         cx="473"
-         cy="474"
-         r="473"
-         style="fill:#48b9c7"
-         id="circle4" />
-      <rect
-         x="223"
-         y="726"
-         width="500"
-         height="76.959999"
-         rx="37"
-         ry="37"
-         style="fill:#ffffff"
-         id="rect6" />
-    </g>
-    <path
-       d="m 536,357 c -24,51 -64,92 -120,112 l 48,125 c 9,23 17,47 10,69 -7,22 -39,29 -62,5 -44,-47 -192,-343 -203,-365 -11,-22 -23,-40 -23,-62 1,-33 52,-67 77,-84 25,-17 74,-40 117,-41 43,-1 61,9 86,25 38,25 65,64 75,109 10,45 7,80 -5,105 M 423,301 c -9,-31 -28,-61 -53,-81 -5,-4 -11,-9 -18,-11 -46,-15 -26,62 -19,82 7,20 26,62 47,83 5,5 10,9 16,10 6,1 18,-5 23,-13 5,-8 6,-14 6,-22 a 128,128 0 0 0 -2,-48 z"
-       style="fill:#ffffff"
-       id="path10"
-       inkscape:connector-curvature="0" />
-    <g
-       id="g16">
-      <path
-         d="m 625,664 c -2,9 -7,17 -15,22 -8,5 -27,5 -38,-4 -11,-9 -13,-24 -10,-36 3,-12 13,-25 27,-29 29,-9 42,23 36,47 z"
-         style="fill:#ffffff"
-         id="path12"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 607,573 c -18,-7 -12,-103 5,-220 5,-32 13,-48 22,-56 9,-8 36,-12 52,-9 a 90,90 0 0 1 49,24 c 12,11 13,23 9,38 -4,15 -18,47 -29,70 l -28,53 c -54,96 -65,106 -80,100 z"
-         style="fill:#ffffff"
-         id="path14"
-         inkscape:connector-curvature="0" />
-    </g>
-  </g>
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 40C24 31.1634 31.1634 24 40 24H104C112.837 24 120 31.1634 120 40V104C120 112.837 112.837 120 104 120H40C31.1634 120 24 112.837 24 104V40Z" fill="url(#paint0_linear_1924_275)"/>
+<path d="M24 152C24 143.163 31.1634 136 40 136H104C112.837 136 120 143.163 120 152V216C120 224.837 112.837 232 104 232H40C31.1634 232 24 224.837 24 216V152Z" fill="url(#paint1_linear_1924_275)"/>
+<path d="M136 40C136 31.1634 143.163 24 152 24H216C224.837 24 232 31.1634 232 40V104C232 112.837 224.837 120 216 120H152C143.163 120 136 112.837 136 104V40Z" fill="url(#paint2_linear_1924_275)"/>
+<path d="M167.899 160L186.284 178.385L176.385 188.284L158 169.899L167.899 160Z" fill="#9E9E9E"/>
+<path d="M184 128C184 158.928 158.928 184 128 184C97.072 184 72 158.928 72 128C72 97.072 97.072 72 128 72C158.928 72 184 97.072 184 128Z" fill="white"/>
+<path d="M173 128C173 152.853 152.853 173 128 173C103.147 173 83 152.853 83 128C83 103.147 103.147 83 128 83C152.853 83 173 103.147 173 128Z" fill="url(#paint3_linear_1924_275)"/>
+<path d="M109.001 168.001C135.51 168.001 157.001 146.511 157.001 120.001C157.001 106.335 151.29 94.0039 142.125 85.2622C160.058 91.186 173 108.082 173 128.001C173 152.854 152.853 173.001 128 173.001C120.539 173.001 113.502 171.185 107.308 167.972C107.87 167.991 108.434 168.001 109.001 168.001Z" fill="#BE6DEE"/>
+<path d="M107 162.5C111.305 164.892 96.0003 146 96.0003 129C96.0003 109 107.5 95.0011 104.5 95.5002C101.624 95.9788 87.5002 109.5 86.9998 129C86.5891 145.003 98.0003 157.5 107 162.5Z" fill="#E9C9FF"/>
+<path d="M186.921 174.662C187.796 173.777 189.212 173.779 190.084 174.668L225.414 210.69C230.209 215.578 230.194 223.489 225.38 228.359C220.566 233.227 212.777 233.212 207.982 228.323L172.652 192.302C171.781 191.413 171.783 189.975 172.658 189.089L186.921 174.662Z" fill="#FFAD00"/>
+<defs>
+<linearGradient id="paint0_linear_1924_275" x1="24" y1="120" x2="121.977" y2="26.0625" gradientUnits="userSpaceOnUse">
+<stop stop-color="#229FAD"/>
+<stop offset="1" stop-color="#49BAC8"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1924_275" x1="24" y1="232" x2="121.977" y2="138.062" gradientUnits="userSpaceOnUse">
+<stop stop-color="#229FAD"/>
+<stop offset="1" stop-color="#49BAC8"/>
+</linearGradient>
+<linearGradient id="paint2_linear_1924_275" x1="136" y1="120" x2="233.977" y2="26.0625" gradientUnits="userSpaceOnUse">
+<stop stop-color="#229FAD"/>
+<stop offset="1" stop-color="#49BAC8"/>
+</linearGradient>
+<linearGradient id="paint3_linear_1924_275" x1="173" y1="83" x2="83" y2="173" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CF7DFF"/>
+<stop offset="1" stop-color="#BE6DEE"/>
+</linearGradient>
+</defs>
 </svg>

--- a/cosmic-panel-workspaces-button/data/icons/scalable/apps/com.system76.CosmicPanelWorkspacesButton.svg
+++ b/cosmic-panel-workspaces-button/data/icons/scalable/apps/com.system76.CosmicPanelWorkspacesButton.svg
@@ -1,99 +1,21 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="Layer_1"
-   data-name="Layer 1"
-   width="210"
-   height="210"
-   viewBox="0 0 210 210"
-   version="1.1"
-   sodipodi:docname="pop_icon.svg"
-   inkscape:version="0.92+devel unknown">
-  <metadata
-     id="metadata25">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Pop_icon</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs23" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     inkscape:document-rotation="0"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2560"
-     inkscape:window-height="1376"
-     id="namedview21"
-     showgrid="false"
-     fit-margin-top="5"
-     fit-margin-left="5"
-     fit-margin-right="5"
-     fit-margin-bottom="5"
-     inkscape:zoom="4.249208"
-     inkscape:cx="42.52691"
-     inkscape:cy="89.544373"
-     inkscape:window-x="0"
-     inkscape:window-y="31"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Layer_1" />
-  <title
-     id="title2">Pop_icon</title>
-  <g
-     id="g18"
-     transform="matrix(0.21141649,0,0,0.21141649,5,4.7885835)">
-    <g
-       id="g8">
-      <circle
-         cx="473"
-         cy="474"
-         r="473"
-         style="fill:#48b9c7"
-         id="circle4" />
-      <rect
-         x="223"
-         y="726"
-         width="500"
-         height="76.959999"
-         rx="37"
-         ry="37"
-         style="fill:#ffffff"
-         id="rect6" />
-    </g>
-    <path
-       d="m 536,357 c -24,51 -64,92 -120,112 l 48,125 c 9,23 17,47 10,69 -7,22 -39,29 -62,5 -44,-47 -192,-343 -203,-365 -11,-22 -23,-40 -23,-62 1,-33 52,-67 77,-84 25,-17 74,-40 117,-41 43,-1 61,9 86,25 38,25 65,64 75,109 10,45 7,80 -5,105 M 423,301 c -9,-31 -28,-61 -53,-81 -5,-4 -11,-9 -18,-11 -46,-15 -26,62 -19,82 7,20 26,62 47,83 5,5 10,9 16,10 6,1 18,-5 23,-13 5,-8 6,-14 6,-22 a 128,128 0 0 0 -2,-48 z"
-       style="fill:#ffffff"
-       id="path10"
-       inkscape:connector-curvature="0" />
-    <g
-       id="g16">
-      <path
-         d="m 625,664 c -2,9 -7,17 -15,22 -8,5 -27,5 -38,-4 -11,-9 -13,-24 -10,-36 3,-12 13,-25 27,-29 29,-9 42,23 36,47 z"
-         style="fill:#ffffff"
-         id="path12"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 607,573 c -18,-7 -12,-103 5,-220 5,-32 13,-48 22,-56 9,-8 36,-12 52,-9 a 90,90 0 0 1 49,24 c 12,11 13,23 9,38 -4,15 -18,47 -29,70 l -28,53 c -54,96 -65,106 -80,100 z"
-         style="fill:#ffffff"
-         id="path14"
-         inkscape:connector-curvature="0" />
-    </g>
-  </g>
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 56C8 47.1634 15.1634 40 24 40H232C240.837 40 248 47.1634 248 56V200C248 208.837 240.837 216 232 216H24C15.1634 216 8 208.837 8 200V56Z" fill="url(#paint0_linear_1928_961)"/>
+<path d="M32 60C32 55.5817 35.5817 52 40 52H128C132.418 52 136 55.5817 136 60V116C136 120.418 132.418 124 128 124H40C35.5817 124 32 120.418 32 116V60Z" fill="white"/>
+<path d="M76 140C76 135.582 79.5817 132 84 132H172C176.418 132 180 135.582 180 140V196C180 200.418 176.418 204 172 204H84C79.5817 204 76 200.418 76 196V140Z" fill="white"/>
+<path d="M152 68C152 63.5817 155.582 60 160 60H216C220.418 60 224 63.5817 224 68V108C224 112.418 220.418 116 216 116H160C155.582 116 152 112.418 152 108V68Z" fill="white"/>
+<path d="M220 68C220 70.2091 218.209 72 216 72C213.791 72 212 70.2091 212 68C212 65.7909 213.791 64 216 64C218.209 64 220 65.7909 220 68Z" fill="#229FAD"/>
+<path d="M210 68C210 70.2091 208.209 72 206 72C203.791 72 202 70.2091 202 68C202 65.7909 203.791 64 206 64C208.209 64 210 65.7909 210 68Z" fill="#229FAD"/>
+<path d="M200 68C200 70.2091 198.209 72 196 72C193.791 72 192 70.2091 192 68C192 65.7909 193.791 64 196 64C198.209 64 200 65.7909 200 68Z" fill="#229FAD"/>
+<path d="M132 60C132 62.2091 130.209 64 128 64C125.791 64 124 62.2091 124 60C124 57.7909 125.791 56 128 56C130.209 56 132 57.7909 132 60Z" fill="#229FAD"/>
+<path d="M122 60C122 62.2091 120.209 64 118 64C115.791 64 114 62.2091 114 60C114 57.7909 115.791 56 118 56C120.209 56 122 57.7909 122 60Z" fill="#229FAD"/>
+<path d="M112 60C112 62.2091 110.209 64 108 64C105.791 64 104 62.2091 104 60C104 57.7909 105.791 56 108 56C110.209 56 112 57.7909 112 60Z" fill="#229FAD"/>
+<path d="M176 140C176 142.209 174.209 144 172 144C169.791 144 168 142.209 168 140C168 137.791 169.791 136 172 136C174.209 136 176 137.791 176 140Z" fill="#229FAD"/>
+<path d="M166 140C166 142.209 164.209 144 162 144C159.791 144 158 142.209 158 140C158 137.791 159.791 136 162 136C164.209 136 166 137.791 166 140Z" fill="#229FAD"/>
+<path d="M156 140C156 142.209 154.209 144 152 144C149.791 144 148 142.209 148 140C148 137.791 149.791 136 152 136C154.209 136 156 137.791 156 140Z" fill="#229FAD"/>
+<defs>
+<linearGradient id="paint0_linear_1928_961" x1="248" y1="40" x2="6.11676" y2="213.373" gradientUnits="userSpaceOnUse">
+<stop stop-color="#49BAC8"/>
+<stop offset="1" stop-color="#229FAD"/>
+</linearGradient>
+</defs>
 </svg>


### PR DESCRIPTION
Updated: App Tray, Notifications Tray and all panel button applets.

Tried adding the Input Sources icon, but the preview just showed the code, and not the icon.
Not sure how to have the tiling applet icon show up in Settings.
There may have to be some changes in Settings, so that the colored icons can be visible.