### PR TITLE
[feat] add new format to display day name in panel applet

### DIFF
--- a/cosmic-applet-time/src/config.rs
+++ b/cosmic-applet-time/src/config.rs
@@ -10,6 +10,7 @@ pub struct TimeAppletConfig {
     pub military_time: bool,
     pub first_day_of_week: u8,
     pub show_date_in_top_panel: bool,
+    pub show_day_name_in_top_panel: bool,
 }
 
 impl Default for TimeAppletConfig {
@@ -18,6 +19,7 @@ impl Default for TimeAppletConfig {
             military_time: false,
             first_day_of_week: 6,
             show_date_in_top_panel: true,
+            show_day_name_in_top_panel: false,
         }
     }
 }

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -242,11 +242,14 @@ impl cosmic::Application for Window {
             let format = match (
                 self.config.military_time,
                 self.config.show_date_in_top_panel,
+                self.config.show_day_name_in_top_panel,
             ) {
-                (true, true) => "%b %-d %H:%M",
-                (true, false) => "%H:%M",
-                (false, true) => "%b %-d %-I:%M %p",
-                (false, false) => "%-I:%M %p",
+                (true, true, false) => "%b %-d %H:%M",
+                (true, true, true) => "%A %-d %b %H:%M",
+                (true, false, false) => "%H:%M",
+                (false, true, false) => "%b %-d %-I:%M %p",
+                (false, false, false) => "%-I:%M %p",
+                _ => "%H:%M"
             };
             Element::from(
                 row!(


### PR DESCRIPTION
Hey,

I'm like to see what's the day is today ^^ Instead of changing format alone I just added new format with simple toggle to cosmic-settings (PR: https://github.com/pop-os/cosmic-settings/pull/306).