### PR TITLE
Fixes for Status Area applet

### DIFF
--- a/cosmic-applet-status-area/src/components/app.rs
+++ b/cosmic-applet-status-area/src/components/app.rs
@@ -150,6 +150,8 @@ impl cosmic::Application for App {
                     None
                 };
                 if self.open_menu.is_some() {
+                    self.menus[&id].about_to_show();
+
                     let mut cmds = Vec::new();
                     if let Some(id) = self.popup.take() {
                         cmds.push(destroy_popup(id));

--- a/cosmic-applet-status-area/src/components/app.rs
+++ b/cosmic-applet-status-area/src/components/app.rs
@@ -150,11 +150,11 @@ impl cosmic::Application for App {
                     None
                 };
                 if self.open_menu.is_some() {
-                    self.menus[&id].about_to_show();
+                    self.menus[&id].opened();
 
                     let mut cmds = Vec::new();
-                    if let Some(id) = self.popup.take() {
-                        cmds.push(destroy_popup(id));
+                    if let Some(popup_id) = self.popup.take() {
+                        cmds.push(destroy_popup(popup_id));
                     }
                     let popup_id = self.next_popup_id();
                     let mut popup_settings = self.core.applet.get_popup_settings(
@@ -180,8 +180,10 @@ impl cosmic::Application for App {
                     }
                     cmds.push(get_popup(popup_settings));
                     return Command::batch(cmds);
-                } else if let Some(id) = self.popup {
-                    return destroy_popup(id);
+                } else if let Some(popup_id) = self.popup {
+                    self.menus[&id].closed();
+
+                    return destroy_popup(popup_id);
                 }
                 Command::none()
             }

--- a/cosmic-applet-status-area/src/components/status_menu.rs
+++ b/cosmic-applet-status-area/src/components/status_menu.rs
@@ -84,10 +84,18 @@ impl State {
         self.item.layout_subscription().map(Msg::Layout)
     }
 
-    pub fn about_to_show(&self) {
+    pub fn opened(&self) {
         let menu_proxy = self.item.menu_proxy().clone();
         tokio::spawn(async move {
+            let _ = menu_proxy.event(0, "opened", &0i32.into(), 0).await;
             let _ = menu_proxy.about_to_show(0).await;
+        });
+    }
+
+    pub fn closed(&self) {
+        let menu_proxy = self.item.menu_proxy().clone();
+        tokio::spawn(async move {
+            let _ = menu_proxy.event(0, "closed", &0i32.into(), 0).await;
         });
     }
 }

--- a/cosmic-applet-status-area/src/components/status_menu.rs
+++ b/cosmic-applet-status-area/src/components/status_menu.rs
@@ -83,6 +83,13 @@ impl State {
     pub fn subscription(&self) -> iced::Subscription<Msg> {
         self.item.layout_subscription().map(Msg::Layout)
     }
+
+    pub fn about_to_show(&self) {
+        let menu_proxy = self.item.menu_proxy().clone();
+        tokio::spawn(async move {
+            let _ = menu_proxy.about_to_show(0).await;
+        });
+    }
 }
 
 fn layout_view(layout: &Layout, expanded: Option<i32>) -> cosmic::Element<Msg> {

--- a/cosmic-applet-status-area/src/subscriptions/status_notifier_item.rs
+++ b/cosmic-applet-status-area/src/subscriptions/status_notifier_item.rs
@@ -156,7 +156,10 @@ pub struct LayoutProps {
     #[zvariant(rename = "icon-name")]
     icon_name: Option<String>,
     disposition: Option<String>,
-    shortcut: Option<String>,
+    // If this field has a different type, this causes the whole type to fail
+    // to parse, due to a zvariant bug.
+    // https://github.com/dbus2/zbus/issues/856
+    // shortcut: Option<String>,
 }
 
 impl zvariant::Type for LayoutProps {
@@ -217,10 +220,6 @@ impl Layout {
 
     pub fn disposition(&self) -> Option<&str> {
         self.1.disposition.as_deref()
-    }
-
-    pub fn shortcut(&self) -> Option<&str> {
-        self.1.shortcut.as_deref()
     }
 }
 

--- a/cosmic-applet-status-area/src/subscriptions/status_notifier_item.rs
+++ b/cosmic-applet-status-area/src/subscriptions/status_notifier_item.rs
@@ -235,6 +235,8 @@ trait DBusMenu {
     fn event(&self, id: i32, event_id: &str, data: &OwnedValue, timestamp: u32)
         -> zbus::Result<()>;
 
+    fn about_to_show(&self, id: i32) -> zbus::Result<bool>;
+
     #[zbus(signal)]
     fn layout_updated(&self, revision: u32, parent: i32) -> zbus::Result<()>;
 }

--- a/cosmic-applet-status-area/src/subscriptions/status_notifier_watcher/server.rs
+++ b/cosmic-applet-status-area/src/subscriptions/status_notifier_watcher/server.rs
@@ -7,7 +7,6 @@
 
 use futures::prelude::*;
 use zbus::{
-    dbus_interface,
     fdo::{DBusProxy, RequestNameFlags, RequestNameReply},
     names::{BusName, UniqueName, WellKnownName},
     MessageHeader, Result, SignalContext,
@@ -22,7 +21,7 @@ struct StatusNotifierWatcher {
     items: Vec<(UniqueName<'static>, String)>,
 }
 
-#[dbus_interface(name = "org.kde.StatusNotifierWatcher")]
+#[zbus::interface(name = "org.kde.StatusNotifierWatcher")]
 impl StatusNotifierWatcher {
     async fn register_status_notifier_item(
         &mut self,
@@ -47,35 +46,35 @@ impl StatusNotifierWatcher {
         // XXX emit registed/unregistered
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn registered_status_notifier_items(&self) -> Vec<String> {
         self.items.iter().map(|(_, x)| x.clone()).collect()
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn is_status_notifier_host_registered(&self) -> bool {
         true
     }
 
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn protocol_version(&self) -> i32 {
         0
     }
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn status_notifier_item_registered(ctxt: &SignalContext<'_>, service: &str)
         -> Result<()>;
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn status_notifier_item_unregistered(
         ctxt: &SignalContext<'_>,
         service: &str,
     ) -> Result<()>;
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn status_notifier_host_registered(ctxt: &SignalContext<'_>) -> Result<()>;
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn status_notifier_host_unregistered(ctxt: &SignalContext<'_>) -> Result<()>;
 }
 


### PR DESCRIPTION
This fixes Slack, and probably some other applications.

Dropbox still doesn't seem to work. `gnome-shell-extension-appindicator` has three different comments about Dropbox, so it seems to be notorious about doing things wrong and may need special workarounds.