### PR TITLE
[App Tray] Update defaults

### DIFF
--- a/cosmic-app-list/data/default_schema/com.system76.CosmicAppList/v1/favorites
+++ b/cosmic-app-list/data/default_schema/com.system76.CosmicAppList/v1/favorites
@@ -3,5 +3,6 @@
     "com.system76.CosmicFiles",
     "com.system76.CosmicEdit",
     "com.system76.CosmicTerm",
-    "com.system76.CosmicSettings"
+    "com.system76.CosmicStore",
+    "com.system76.CosmicSettings",
 ]


### PR DESCRIPTION
This adds COSMIC Store to the default configuration, which should complete the App Tray portion of pop-os/iso#332.