### PR TITLE
Update volume sliders when changing volume with media keys

### DIFF
--- a/cosmic-applet-audio/src/pulse.rs
+++ b/cosmic-applet-audio/src/pulse.rs
@@ -173,6 +173,8 @@ pub enum Message {
     SetDefaultSource(DeviceInfo),
     SetSinkVolumeByName(String, ChannelVolumes),
     SetSourceVolumeByName(String, ChannelVolumes),
+    SetSinkMuteByName(String, bool),
+    SetSourceMuteByName(String, bool),
 }
 
 struct PulseHandle {
@@ -289,6 +291,27 @@ impl PulseHandle {
                                     None => continue,
                                 };
                                 server.set_source_volume_by_name(&name, &channel_volumes)
+                            }
+                            Message::SetSinkMuteByName(name, mute) => {
+                                let server = match server.as_mut() {
+                                    Some(s) => s,
+                                    None => continue,
+                                };
+
+                                let op =
+                                    server.introspector.set_sink_mute_by_name(&name, mute, None);
+                                server.wait_for_result(op).ok();
+                            }
+                            Message::SetSourceMuteByName(name, mute) => {
+                                let server = match server.as_mut() {
+                                    Some(s) => s,
+                                    None => continue,
+                                };
+
+                                let op = server
+                                    .introspector
+                                    .set_source_mute_by_name(&name, mute, None);
+                                server.wait_for_result(op).ok();
                             }
                             Message::UpdateConnection => {
                                 tracing::info!(


### PR DESCRIPTION
Recently a change was made to update the audio applet icons when the volume changes by an action from outside the applet, but the volume sliders still didn't update.

So for example, if you have the audio applet open, and use media keys on your keyboard to change the volume, the volume sliders will now update in the applet to reflect the change.

This also adds the ability to mute/unmute by clicking on the icons left of the volume sliders. I was going to implement this in a separate PR, but it relies on the other changes.