### PR TITLE
Update for `spawn_desktop_exec` that calls `SpawnTransientUnit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,26 @@ dependencies = [
  "serde_repr",
  "tokio",
  "url",
+ "zbus 4.3.1",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe7e0dd0ac5a401dc116ed9f9119cf9decc625600474cb41f0fc0a0050abc9a"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "zbus 4.3.1",
 ]
 
@@ -1185,7 +1202,7 @@ source = "git+https://github.com/pop-os/cosmic-protocols?rev=c8d3a1c#c8d3a1c3d40
 dependencies = [
  "cosmic-protocols",
  "libc",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "wayland-client",
 ]
 
@@ -1202,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1224,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1282,15 +1299,15 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#05420b20035cdb9f2fa52517e9c5abce9e0f0bb5"
+source = "git+https://github.com/pop-os/cosmic-panel#d5fc4ddef106bf2bdaf983028f78b9d8e432b3ae"
 dependencies = [
  "anyhow",
  "cosmic-config",
  "ron",
  "serde",
- "smithay-client-toolkit 0.18.0",
+ "smithay-client-toolkit",
  "tracing",
- "wayland-protocols-wlr 0.2.0",
+ "wayland-protocols-wlr",
  "xdg-shell-wrapper-config",
 ]
 
@@ -1302,8 +1319,8 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.2",
- "wayland-protocols-wlr 0.3.2",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "wayland-server",
 ]
@@ -1335,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/cosmic-text.git#0e2d050a8d87c2e97e94ae205c9beda5858123b6"
+source = "git+https://github.com/pop-os/cosmic-text.git#4f316658050536c4254fb70639f4b5203c31dbce"
 dependencies = [
  "bitflags 2.6.0",
  "fontdb",
@@ -1357,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1789,7 +1806,7 @@ dependencies = [
  "bitflags 2.6.0",
  "mime 0.1.0",
  "raw-window-handle",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "smithay-clipboard",
 ]
 
@@ -2203,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.14.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a78dd758a47a7305478e0e054f9fde4e983b9f9eccda162bf7ca03b79e9d40"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
@@ -2784,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2802,7 +2819,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2811,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -2822,7 +2839,7 @@ dependencies = [
  "palette",
  "raw-window-handle",
  "serde",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "smol_str",
  "thiserror",
  "web-time",
@@ -2833,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "futures",
  "iced_core",
@@ -2846,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2870,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2882,13 +2899,13 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "dnd",
  "iced_accessibility",
  "iced_core",
  "iced_futures",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "thiserror",
  "window_clipboard",
 ]
@@ -2896,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2908,11 +2925,11 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "raw-window-handle",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "thiserror",
  "tracing",
  "wayland-backend",
- "wayland-protocols 0.32.2",
+ "wayland-protocols",
  "window_clipboard",
  "xkbcommon",
  "xkbcommon-dl",
@@ -2922,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2932,7 +2949,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2949,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2965,11 +2982,11 @@ dependencies = [
  "raw-window-handle",
  "resvg",
  "rustix 0.38.34",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "tiny-xlib",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.2",
+ "wayland-protocols",
  "wayland-sys",
  "wgpu",
  "x11rb",
@@ -2978,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2986,7 +3003,7 @@ dependencies = [
  "iced_style",
  "num-traits",
  "ouroboros",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "thiserror",
  "unicode-segmentation",
  "window_clipboard",
@@ -3659,10 +3676,10 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
 dependencies = [
  "apply",
- "ashpd",
+ "ashpd 0.9.1",
  "chrono",
  "cosmic-client-toolkit",
  "cosmic-config",
@@ -3684,11 +3701,12 @@ dependencies = [
  "iced_tiny_skia",
  "iced_widget",
  "lazy_static",
+ "libc",
  "mime 0.3.17",
- "nix 0.27.1",
  "palette",
  "rfd",
  "ron",
+ "rustix 0.38.34",
  "serde",
  "shlex",
  "slotmap",
@@ -4074,17 +4092,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -4919,7 +4926,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251"
 dependencies = [
- "ashpd",
+ "ashpd 0.8.1",
  "block",
  "dispatch",
  "js-sys",
@@ -5338,33 +5345,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.0"
-source = "git+https://github.com/smithay/client-toolkit?rev=3bed072#3bed072b966022f5f929d12f3aff089b1ace980b"
-dependencies = [
- "bitflags 2.6.0",
- "bytemuck",
- "calloop",
- "calloop-wayland-source",
- "cursor-icon",
- "libc",
- "log",
- "memmap2 0.9.4",
- "pkg-config",
- "rustix 0.38.34",
- "thiserror",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols 0.31.2",
- "wayland-protocols-wlr 0.2.0",
- "wayland-scanner",
- "xkbcommon",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-client-toolkit"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
@@ -5384,8 +5364,8 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.2",
- "wayland-protocols-wlr 0.3.2",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkbcommon",
  "xkeysym",
@@ -5394,11 +5374,11 @@ dependencies = [
 [[package]]
 name = "smithay-clipboard"
 version = "0.8.0"
-source = "git+https://github.com/pop-os/smithay-clipboard?tag=pop-dnd-5#d099e82a4c1e7d3e88dc34b7333de21928b1b22c"
+source = "git+https://github.com/pop-os/smithay-clipboard?tag=pop-dnd-5#5a3007def49eb678d1144850c9ee04b80707c56a"
 dependencies = [
  "libc",
  "raw-window-handle",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "wayland-backend",
 ]
 
@@ -6398,19 +6378,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
- "wayland-server",
-]
-
-[[package]]
-name = "wayland-protocols"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1794d82d869f38439d15c24b26f06f6c8603d27d47b4f786d5197c99044de415"
@@ -6424,20 +6391,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.31.2",
- "wayland-scanner",
- "wayland-server",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa43c961473aed713d44c1f616f775186249dfca657f256d8841ca0690366aba"
@@ -6445,7 +6398,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.2",
+ "wayland-protocols",
  "wayland-scanner",
  "wayland-server",
 ]
@@ -6904,10 +6857,10 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/xdg-shell-wrapper#b5480042615ecfcf30262d5a40625e8f430b474a"
+source = "git+https://github.com/pop-os/cosmic-panel#d5fc4ddef106bf2bdaf983028f78b9d8e432b3ae"
 dependencies = [
  "serde",
- "wayland-protocols-wlr 0.2.0",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -1178,6 +1178,7 @@ impl cosmic::Application for CosmicAppList {
                     },
                     WaylandUpdate::ActivationToken {
                         token,
+                        app_id,
                         exec,
                         gpu_idx,
                     } => {
@@ -1194,8 +1195,8 @@ impl cosmic::Application for CosmicAppList {
                                     .map(|(k, v)| (k.clone(), v.clone())),
                             );
                         }
-                        tokio::task::spawn_blocking(|| {
-                            cosmic::desktop::spawn_desktop_exec(exec, envs);
+                        tokio::spawn(async move {
+                            cosmic::desktop::spawn_desktop_exec(exec, envs, app_id.as_deref()).await
                         });
                     }
                 }

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -49,7 +49,7 @@ use cosmic::{
         rectangle_tracker::{rectangle_tracker_subscription, RectangleTracker, RectangleUpdate},
         text, Image,
     },
-    Apply, Command, Element, Theme,
+    Command, Element, Theme,
 };
 use cosmic_app_list_config::{AppListConfig, APP_ID};
 use cosmic_protocols::{

--- a/cosmic-app-list/src/wayland_handler.rs
+++ b/cosmic-app-list/src/wayland_handler.rs
@@ -179,6 +179,7 @@ impl ActivationHandler for AppData {
     fn new_token(&mut self, token: String, data: &ExecRequestData) {
         let _ = self.tx.unbounded_send(WaylandUpdate::ActivationToken {
             token: Some(token),
+            app_id: data.app_id().map(|x| x.to_owned()),
             exec: data.exec.clone(),
             gpu_idx: data.gpu_idx,
         });
@@ -678,6 +679,7 @@ pub(crate) fn wayland_handler(
                     } else {
                         let _ = state.tx.unbounded_send(WaylandUpdate::ActivationToken {
                             token: None,
+                            app_id: Some(app_id),
                             exec,
                             gpu_idx,
                         });

--- a/cosmic-app-list/src/wayland_subscription.rs
+++ b/cosmic-app-list/src/wayland_subscription.rs
@@ -107,6 +107,7 @@ pub enum WaylandUpdate {
     Output(OutputUpdate),
     ActivationToken {
         token: Option<String>,
+        app_id: Option<String>,
         exec: String,
         gpu_idx: Option<usize>,
     },

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -590,7 +590,7 @@ impl cosmic::Application for Audio {
                         cmd.env("XDG_ACTIVATION_TOKEN", &token);
                         cmd.env("DESKTOP_STARTUP_ID", &token);
                     }
-                    cosmic::process::spawn(cmd);
+                    tokio::spawn(cosmic::process::spawn(cmd));
                 }
             },
             Message::PulseSub(event) => match event {

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -341,7 +341,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                         cmd.env("XDG_ACTIVATION_TOKEN", &token);
                         cmd.env("DESKTOP_STARTUP_ID", &token);
                     }
-                    cosmic::process::spawn(cmd);
+                    tokio::spawn(cosmic::process::spawn(cmd));
                 }
             },
             Message::GpuOn(path, name, app_list) => {

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -319,7 +319,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
                         cmd.env("XDG_ACTIVATION_TOKEN", &token);
                         cmd.env("DESKTOP_STARTUP_ID", &token);
                     }
-                    cosmic::process::spawn(cmd);
+                    tokio::spawn(cosmic::process::spawn(cmd));
                 }
             },
             Message::Frame(instant) => self.timeline.now(instant),

--- a/cosmic-applet-input-sources/src/window.rs
+++ b/cosmic-applet-input-sources/src/window.rs
@@ -127,7 +127,7 @@ impl cosmic::Application for Window {
             Message::KeyboardSettings => {
                 let mut cmd = std::process::Command::new("cosmic-settings");
                 cmd.arg("keyboard");
-                cosmic::process::spawn(cmd);
+                tokio::spawn(cosmic::process::spawn(cmd));
             }
             Message::SetActiveLayout(active_layout) => {
                 let Some(i) = self

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -382,7 +382,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                         let mut browser = std::process::Command::new("xdg-open");
                         browser.arg("http://204.pop-os.org/");
 
-                        cosmic::process::spawn(browser);
+                        tokio::spawn(cosmic::process::spawn(browser));
                     }
 
                     self.update_nm_state(state);
@@ -500,7 +500,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                         cmd.env("XDG_ACTIVATION_TOKEN", &token);
                         cmd.env("DESKTOP_STARTUP_ID", &token);
                     }
-                    cosmic::process::spawn(cmd);
+                    tokio::spawn(cosmic::process::spawn(cmd));
                 }
             },
             Message::ResetFailedKnownSsid(ssid) => {

--- a/cosmic-applet-network/src/network_manager/mod.rs
+++ b/cosmic-applet-network/src/network_manager/mod.rs
@@ -23,7 +23,7 @@ use futures::{
 };
 use tokio::process::Command;
 use zbus::{
-    zvariant::{self, OwnedValue, Value},
+    zvariant::{self, Value},
     Connection,
 };
 

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -350,7 +350,7 @@ impl cosmic::Application for Notifications {
                         cmd.env("XDG_ACTIVATION_TOKEN", &token);
                         cmd.env("DESKTOP_STARTUP_ID", &token);
                     }
-                    cosmic::process::spawn(cmd);
+                    tokio::spawn(cosmic::process::spawn(cmd));
                 }
             },
         };

--- a/cosmic-applet-power/src/lib.rs
+++ b/cosmic-applet-power/src/lib.rs
@@ -30,7 +30,7 @@ use cosmic::{
     iced_widget::mouse_area,
     theme,
     widget::{button, divider, horizontal_space, icon, vertical_space, Column},
-    Element, Renderer, Theme,
+    Element, Theme,
 };
 
 use logind_zbus::{

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -297,7 +297,7 @@ impl cosmic::Application for Window {
                             cmd.env("XDG_ACTIVATION_TOKEN", &token);
                             cmd.env("DESKTOP_STARTUP_ID", &token);
                         }
-                        cosmic::process::spawn(cmd);
+                        tokio::spawn(cosmic::process::spawn(cmd));
                     }
                 }
                 Command::none()


### PR DESCRIPTION
Allows `xdg-desktop-portal` to get app id from PID.

Depends on https://github.com/pop-os/libcosmic/pull/548.