### PR TITLE
improv(app-list): get app icons from icon theme

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -181,8 +181,7 @@ impl DockItem {
 
         let app_icon = AppletIconData::new(applet);
 
-        let cosmic_icon = IconSource::from_unknown(desktop_info.icon().unwrap_or_default())
-            .as_cosmic_icon()
+        let cosmic_icon = cosmic::widget::icon::from_name(desktop_info.icon().unwrap_or_default())
             .size(app_icon.icon_size);
 
         let dots = if toplevels.is_empty() {


### PR DESCRIPTION
cosmic-launcher and cosmic-app-libary use widget::icon_from_name, so those have different app icons, which does not look good and is confusing.