### PR TITLE
Use text button for Restart in Shutdown dialog

### DIFF
--- a/cosmic-applet-power/src/lib.rs
+++ b/cosmic-applet-power/src/lib.rs
@@ -354,14 +354,7 @@ impl cosmic::Application for Power {
 
             if matches!(power_action, PowerAction::Shutdown) {
                 dialog = dialog.tertiary_action(
-                    button(min_width_and_height(
-                        text(fl!("restart")).size(14).into(),
-                        Length::Shrink,
-                        32.0,
-                    ))
-                    .padding([0, cosmic_theme.space_s()])
-                    .style(theme::Button::Link)
-                    .on_press(Message::Action(PowerAction::Restart)),
+                    button::text(fl!("restart")).on_press(Message::Action(PowerAction::Restart)),
                 );
             }
 


### PR DESCRIPTION
This makes the button have a highlight on hover.
![screenshot-2024-07-31-22-50-32](https://github.com/user-attachments/assets/9e44e3bc-67f6-4770-ae4f-d043f991dfa6)
