### PR TITLE
feat: toggle popups on press down

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -646,7 +646,7 @@ impl cosmic::Application for Audio {
             .core
             .applet
             .icon_button(self.output_icon_name())
-            .on_press(Message::TogglePopup);
+            .on_press_down(Message::TogglePopup);
         let btn = crate::mouse_area::MouseArea::new(btn).on_mouse_wheel(|delta| {
             let change = match delta {
                 iced::mouse::ScrollDelta::Lines { x, y } => (x + y) * 5.,

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -393,7 +393,7 @@ impl cosmic::Application for CosmicBatteryApplet {
             .core
             .applet
             .icon_button(&self.icon_name)
-            .on_press(Message::TogglePopup)
+            .on_press_down(Message::TogglePopup)
             .into();
 
         if !self.gpus.is_empty() {

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -344,7 +344,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
         self.core
             .applet
             .icon_button(&self.icon_name)
-            .on_press(Message::TogglePopup)
+            .on_press_down(Message::TogglePopup)
             .into()
     }
 

--- a/cosmic-applet-input-sources/src/window.rs
+++ b/cosmic-applet-input-sources/src/window.rs
@@ -194,7 +194,7 @@ impl cosmic::Application for Window {
             .width(Length::Shrink)
             .height(Length::Shrink),
         )
-        .on_press(Message::TogglePopup)
+        .on_press_down(Message::TogglePopup)
         .style(cosmic::theme::Button::AppletIcon)
         .into()
     }

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -543,7 +543,7 @@ impl cosmic::Application for CosmicNetworkApplet {
         self.core
             .applet
             .icon_button(&self.icon_name)
-            .on_press(Message::TogglePopup)
+            .on_press_down(Message::TogglePopup)
             .into()
     }
 

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -362,7 +362,7 @@ impl cosmic::Application for Notifications {
         self.core
             .applet
             .icon_button(&self.icon_name)
-            .on_press(Message::TogglePopup)
+            .on_press_down(Message::TogglePopup)
             .into()
     }
 

--- a/cosmic-applet-power/src/lib.rs
+++ b/cosmic-applet-power/src/lib.rs
@@ -242,7 +242,7 @@ impl cosmic::Application for Power {
         self.core
             .applet
             .icon_button(&self.icon_name)
-            .on_press(Message::TogglePopup)
+            .on_press_down(Message::TogglePopup)
             .into()
     }
 

--- a/cosmic-applet-tiling/src/window.rs
+++ b/cosmic-applet-tiling/src/window.rs
@@ -275,7 +275,7 @@ impl cosmic::Application for Window {
         self.core
             .applet
             .icon_button(if self.autotiled { ON } else { OFF })
-            .on_press(Message::TogglePopup)
+            .on_press_down(Message::TogglePopup)
             .into()
     }
 

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -423,7 +423,7 @@ impl cosmic::Application for Window {
         } else {
             [self.core.applet.suggested_padding(true), 0]
         })
-        .on_press(Message::TogglePopup)
+        .on_press_down(Message::TogglePopup)
         .style(cosmic::theme::Button::AppletIcon);
 
         if let Some(tracker) = self.rectangle_tracker.as_ref() {


### PR DESCRIPTION
Hi!

This PR simply makes the applets toggle their popup on button pressdown instead of on button release. This is similar to what GNOME does and it overall makes the applets and panel feel snappier. I don't think toggling popups is an action that would make a user hesitate and cancel when pressing the button so using `on_press_down()` should be fine.

Thanks!