### PR TITLE
add battery percentage indication to connected devices on bluetooth applet

### DIFF
--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -5,6 +5,7 @@ use crate::bluetooth::{BluerDeviceStatus, BluerRequest, BluerState, DeviceProper
 use cosmic::{
     applet::token::subscription::{activation_token_subscription, TokenRequest, TokenUpdate},
     cctk::sctk::reexports::calloop,
+    widget::text::body,
 };
 
 use cosmic::{
@@ -379,7 +380,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
                 };
                 let status = row!(
                     icon::from_name(icon).symbolic(true).size(14),
-                    text(format!("{}%", battery)).size(14)
+                    body(format!("{}%", battery))
                 )
                 .align_items(Alignment::Center)
                 .spacing(2)

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -372,8 +372,13 @@ impl cosmic::Application for CosmicBluetoothApplet {
                 .iter()
                 .find(|p| matches!(p, DeviceProperty::BatteryPercentage(_)))
             {
+                let icon = match *battery {
+                    b if b >= 20 && b < 40 => "battery-low",
+                    b if b < 20 => "battery-caution",
+                    _ => "battery",
+                };
                 let status = row!(
-                    icon::from_name("battery").symbolic(true).size(14),
+                    icon::from_name(icon).symbolic(true).size(14),
                     text(format!("{}%", battery)).size(14)
                 )
                 .align_items(Alignment::Center)

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::bluetooth::{BluerDeviceStatus, BluerRequest, BluerState};
+use crate::bluetooth::{BluerDeviceStatus, BluerRequest, BluerState, DeviceProperty};
 use cosmic::{
     applet::token::subscription::{activation_token_subscription, TokenRequest, TokenUpdate},
     cctk::sctk::reexports::calloop,
@@ -366,6 +366,26 @@ impl cosmic::Application for CosmicBluetoothApplet {
             ]
             .align_items(Alignment::Center)
             .spacing(12);
+
+            if let Some(DeviceProperty::BatteryPercentage(battery)) = dev
+                .properties
+                .iter()
+                .find(|p| matches!(p, DeviceProperty::BatteryPercentage(_)))
+            {
+                let status = row!(
+                    icon::from_name("battery").symbolic(true).size(14),
+                    text(format!("{}%", battery)).size(14)
+                )
+                .align_items(Alignment::Center)
+                .spacing(2)
+                .width(Length::Shrink);
+
+                let content = container(status)
+                    .align_x(Horizontal::Right)
+                    .align_y(Vertical::Center);
+
+                row = row.push(content);
+            }
 
             match &dev.status {
                 BluerDeviceStatus::Connected => {

--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -3,10 +3,12 @@
 
 use std::{collections::HashMap, fmt::Debug, hash::Hash, mem, sync::Arc, time::Duration};
 
+pub use bluer::DeviceProperty;
 use bluer::{
     agent::{Agent, AgentHandle},
-    Adapter, Address, DeviceProperty, Session, Uuid,
+    Adapter, Address, Session, Uuid,
 };
+
 use cosmic::iced::{
     self,
     futures::{SinkExt, StreamExt},


### PR DESCRIPTION
If `DeviceProperty::BatteryPercentage` is known, it gets indicated.

![battery](https://github.com/user-attachments/assets/2b10e947-f960-4361-9e8e-c91b5870f560)
