### PR TITLE
Added interfaces to wifi

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -749,20 +749,27 @@ impl cosmic::Application for CosmicNetworkApplet {
             ]
         } else {
             column![
-                vpn_ethernet_col,
-                padded_control(
-                    anim!(
-                        //toggler
-                        AIRPLANE_MODE,
-                        &self.timeline,
-                        fl!("airplane-mode"),
-                        self.nm_state.airplane_mode,
-                        |_chain, enable| { Message::ToggleAirplaneMode(enable) },
-                    )
-                    .text_size(14)
-                    .width(Length::Fill)
+                // TODO: remove excesive column!
+                Element::from(
+                    column![
+                        vpn_ethernet_col,
+                        padded_control(
+                            anim!(
+                                //toggler
+                                AIRPLANE_MODE,
+                                &self.timeline,
+                                fl!("airplane-mode"),
+                                self.nm_state.airplane_mode,
+                                |_chain, enable| { Message::ToggleAirplaneMode(enable) },
+                            )
+                            .text_size(14)
+                            .width(Length::Fill)
+                        ),
+                        padded_control(divider::horizontal::default())
+                            .padding([space_xxs, space_s]),
+                    ]
+                    .align_x(Alignment::Center)
                 ),
-                padded_control(divider::horizontal::default()).padding([space_xxs, space_s]),
                 padded_control(
                     anim!(
                         //toggler
@@ -840,17 +847,13 @@ impl cosmic::Application for CosmicNetworkApplet {
                         .symbolic(true)
                         .into(),
                 );
-                // todo figure our crash here. It happens if both this thing in content as well as
-                // there is no new connection and we are viewing available networks(see insertion
-                // of `list_col` into `content` on L1083)
                 content = content.push(Element::from(
-                    column![menu_button(
+                    menu_button(
                         Row::with_children(btn_content)
                             .align_y(Alignment::Center)
                             .spacing(8)
                     )
-                    .on_press(Message::OpenHwDevice(Some(hw_device.clone())))]
-                    .align_x(Alignment::Center),
+                    .on_press(Message::OpenHwDevice(Some(hw_device.clone()))),
                 ));
             }
 
@@ -1077,9 +1080,6 @@ impl cosmic::Application for CosmicNetworkApplet {
                 .on_press(Message::SelectWirelessAccessPoint(ap.clone()));
                 list_col.push(button.into());
             }
-            // todo fixup crash that happens if both content gets update here and with such
-            // condition `if wireless_hw_devices.len() > 1 && self.hw_device_to_show.is_none()`
-            // See reference to it on L843
             content = content
                 .push(scrollable(Column::with_children(list_col)).height(Length::Fixed(300.0)));
         }

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -851,7 +851,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     menu_button(
                         Row::with_children(btn_content)
                             .align_y(Alignment::Center)
-                            .spacing(8)
+                            .spacing(8),
                     )
                     .on_press(Message::OpenHwDevice(Some(hw_device.clone()))),
                 ));

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -840,6 +840,9 @@ impl cosmic::Application for CosmicNetworkApplet {
                         .symbolic(true)
                         .into(),
                 );
+                // todo figure our crash here. It happens if both this thing in content as well as
+                // there is no new connection and we are viewing available networks(see insertion
+                // of `list_col` into `content` on L1083)
                 content = content.push(Element::from(
                     column![menu_button(
                         Row::with_children(btn_content)
@@ -1047,7 +1050,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     content = content.push(col);
                 }
             }
-        } else if self.nm_state.wifi_enabled {
+        } else {
             let mut list_col = Vec::with_capacity(self.nm_state.wireless_access_points.len());
             for ap in &self.nm_state.wireless_access_points {
                 if ap.hw_address != self.hw_device_to_show.unwrap_or(ap.hw_address) {
@@ -1074,6 +1077,9 @@ impl cosmic::Application for CosmicNetworkApplet {
                 .on_press(Message::SelectWirelessAccessPoint(ap.clone()));
                 list_col.push(button.into());
             }
+            // todo fixup crash that happens if both content gets update here and with such
+            // condition `if wireless_hw_devices.len() > 1 && self.hw_device_to_show.is_none()`
+            // See reference to it on L843
             content = content
                 .push(scrollable(Column::with_children(list_col)).height(Length::Fixed(300.0)));
         }

--- a/cosmic-applet-network/src/network_manager/available_wifi.rs
+++ b/cosmic-applet-network/src/network_manager/available_wifi.rs
@@ -7,7 +7,10 @@ use itertools::Itertools;
 use std::collections::HashMap;
 use zbus::zvariant::ObjectPath;
 
-pub async fn handle_wireless_device(device: WirelessDevice<'_>) -> zbus::Result<Vec<AccessPoint>> {
+pub async fn handle_wireless_device(
+    device: WirelessDevice<'_>,
+    hw_address: Option<String>,
+) -> zbus::Result<Vec<AccessPoint>> {
     device.request_scan(HashMap::new()).await?;
     let mut scan_changed = device.receive_last_scan_changed().await;
     if let Some(t) = scan_changed.next().await {
@@ -42,6 +45,7 @@ pub async fn handle_wireless_device(device: WirelessDevice<'_>) -> zbus::Result<
                 state,
                 working: false,
                 path: ap.inner().path().to_owned(),
+                hw_address: hw_address.as_ref().unwrap_or(&"".to_string()).clone(),
             },
         );
     }
@@ -59,4 +63,5 @@ pub struct AccessPoint {
     pub state: DeviceState,
     pub working: bool,
     pub path: ObjectPath<'static>,
+    pub hw_address: String,
 }

--- a/cosmic-applet-network/src/network_manager/available_wifi.rs
+++ b/cosmic-applet-network/src/network_manager/available_wifi.rs
@@ -7,6 +7,8 @@ use itertools::Itertools;
 use std::collections::HashMap;
 use zbus::zvariant::ObjectPath;
 
+use super::hw_address::HwAddress;
+
 pub async fn handle_wireless_device(
     device: WirelessDevice<'_>,
     hw_address: Option<String>,
@@ -45,7 +47,10 @@ pub async fn handle_wireless_device(
                 state,
                 working: false,
                 path: ap.inner().path().to_owned(),
-                hw_address: hw_address.as_ref().unwrap_or(&"".to_string()).clone(),
+                hw_address: hw_address
+                    .as_ref()
+                    .and_then(|str_addr| HwAddress::from_str(str_addr))
+                    .unwrap_or_default(),
             },
         );
     }
@@ -63,5 +68,5 @@ pub struct AccessPoint {
     pub state: DeviceState,
     pub working: bool,
     pub path: ObjectPath<'static>,
-    pub hw_address: String,
+    pub hw_address: HwAddress,
 }

--- a/cosmic-applet-network/src/network_manager/hw_address.rs
+++ b/cosmic-applet-network/src/network_manager/hw_address.rs
@@ -1,0 +1,39 @@
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug, PartialOrd, Ord)]
+pub struct HwAddress {
+    address: u64,
+}
+
+impl HwAddress {
+    pub fn from_str(arg: &str) -> Option<Self> {
+        let columnless_vec = arg.split(":").collect::<Vec<&str>>();
+        if columnless_vec.len() * 3 - 1 != arg.len() {
+            return None;
+        }
+        for byte in &columnless_vec {
+            if byte.len() != 2 {
+                return None;
+            }
+        }
+        u64::from_str_radix(columnless_vec.join("").as_str(), 16)
+            .ok()
+            .and_then(|address| Some(HwAddress { address }))
+    }
+    pub fn from_string(arg: &String) -> Option<Self> {
+        HwAddress::from_str(arg.as_str())
+    }
+    pub fn to_string(&self) -> String {
+        // return if self.address > 100000000000000 {
+        //     "Intel Corp".to_string()
+        // } else {
+        //     "TP-Link".to_string()
+        // };
+        format!("{:#x}", self.address)
+            .trim_start_matches("0x")
+            .chars()
+            .collect::<Vec<_>>()
+            .chunks(2)
+            .map(|chunk| chunk.iter().cloned().collect::<String>())
+            .collect::<Vec<String>>()
+            .join(":")
+    }
+}

--- a/cosmic-applet-network/src/network_manager/mod.rs
+++ b/cosmic-applet-network/src/network_manager/mod.rs
@@ -479,15 +479,12 @@ impl NetworkManagerState {
 
         let devices = nm.devices().await?;
         for device in devices {
-            let device_hw_address = device.hw_address().await;
-            if device_hw_address.is_err() {
-                continue;
-            }
-            let device_hw_address = HwAddress::from_string(&device_hw_address.unwrap());
-            if device_hw_address.is_none() {
-                continue;
-            }
-            let device_hw_address = device_hw_address.unwrap();
+            let device_hw_address = device
+                .hw_address()
+                .await
+                .ok()
+                .and_then(|device_address| HwAddress::from_string(&device_address))
+                .unwrap_or_default();
             if device_hw_address != hw_address {
                 continue;
             }

--- a/cosmic-applet-network/src/network_manager/mod.rs
+++ b/cosmic-applet-network/src/network_manager/mod.rs
@@ -353,7 +353,7 @@ impl NetworkManagerState {
                 if let Ok(Some(SpecificDevice::Wireless(wireless_device))) =
                     device.downcast_to_device().await
                 {
-                    handle_wireless_device(wireless_device)
+                    handle_wireless_device(wireless_device, device.hw_address().await.ok())
                         .await
                         .unwrap_or_default()
                 } else {


### PR DESCRIPTION
# issue
Currently, if there are several wireless interfaces, there is no way to figure it out, which connection is being used(see picture below. There is no way to determine difference between 1 and 2 or 3 and 4 or 5 and 6).  
In addition to that, when trying to connect to some ssid, it will ALWAYS use the first wireless interface and so, there is no way to use the second one. So there is no actual way to connect to 2, only to 1
![image](https://github.com/user-attachments/assets/e6c3b153-87bf-416f-932e-c4633629fe62)

# fix
Fix contains several changes:
1) when connecting to wifi, it compares both ssid and iface of the connected wifi
2) it displays iface for ssid that is available on several interfaces
3) same rule applies to already connected wifi(see last image)
![image](https://github.com/user-attachments/assets/7cab976a-478f-48e5-af6f-07bd01c5de24)
![image](https://github.com/user-attachments/assets/18199687-a007-464a-a85b-2ee975adf659)

