### PR TITLE
[Audio] Add settings button

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -867,9 +867,9 @@ impl cosmic::Application for Audio {
                 .text_size(14)
                 .width(Length::Fill)
             )
-            .padding([8, 24]),
-            // padded_control(divider::horizontal::default()),
-            // menu_button(text(fl!("sound-settings")).size(14)).on_press(Message::OpenSettings)
+            .padding([4, 24]),
+            padded_control(divider::horizontal::default()),
+            menu_button(text(fl!("sound-settings")).size(14)).on_press(Message::OpenSettings)
         ]
         .align_items(Alignment::Start)
         .padding([8, 0]);


### PR DESCRIPTION
The original padding was 0, but 4 looks closer to the designs, while not leaving too much unclickable space.
The commit message should say audio instead of sound.