### PR TITLE
[Network] Don't show the visible networks button when Wi-Fi is off

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1241,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#d5fc4ddef106bf2bdaf983028f78b9d8e432b3ae"
+source = "git+https://github.com/pop-os/cosmic-panel#e184d10535e43dfc3e470a481f81f9fe24359521"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1352,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.12.1"
-source = "git+https://github.com/pop-os/cosmic-text.git#58c2ccd1fb3daf0abc792f9dd52b5766b7125ccd"
+source = "git+https://github.com/pop-os/cosmic-text.git#e16b39f29c84773a05457fe39577a602de27855c"
 dependencies = [
  "bitflags 2.6.0",
  "fontdb",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2819,7 +2819,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2828,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "futures",
  "iced_core",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2899,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2913,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2949,7 +2949,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2995,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -3676,7 +3676,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4f77edd249e1c9cd525232050cec00c752ce7860"
+source = "git+https://github.com/pop-os/libcosmic#c9f8f485373e02ef849c83d3bbdf0fdd2bf4a24c"
 dependencies = [
  "apply",
  "ashpd 0.9.1",
@@ -3711,7 +3711,6 @@ dependencies = [
  "shlex",
  "slotmap",
  "taffy",
- "textdistance",
  "thiserror",
  "tokio",
  "tracing",
@@ -6857,7 +6856,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#d5fc4ddef106bf2bdaf983028f78b9d8e432b3ae"
+source = "git+https://github.com/pop-os/cosmic-panel#e184d10535e43dfc3e470a481f81f9fe24359521"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -883,7 +883,7 @@ impl cosmic::Application for Audio {
                 .text_size(14)
                 .width(Length::Fill)
             )
-            .padding([4, 24]),
+            .padding([8, 24]),
             padded_control(divider::horizontal::default()),
             menu_button(text(fl!("sound-settings")).size(14)).on_press(Message::OpenSettings)
         ]

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -387,6 +387,7 @@ impl cosmic::Application for Notifications {
             )
             .width(Length::Fill)
             .align_x(Horizontal::Center)]
+            .padding([8, 0])
             .spacing(12)
         } else {
             let mut notifs: Vec<Element<_>> = Vec::with_capacity(self.cards.len());

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -448,12 +448,13 @@ impl cosmic::Application for Window {
 
         let month_controls = row![
             button::icon(icon::from_name("go-previous-symbolic"))
-                .padding([0, 12])
+                .padding(8)
                 .on_press(Message::PreviousMonth),
             button::icon(icon::from_name("go-next-symbolic"))
-                .padding([0, 12])
+                .padding(8)
                 .on_press(Message::NextMonth)
-        ];
+        ]
+        .spacing(8);
 
         // Calender
 
@@ -505,6 +506,7 @@ impl cosmic::Application for Window {
                 Space::with_width(Length::Fill),
                 month_controls,
             ]
+            .align_items(Alignment::Center)
             .padding([12, 20]),
             calender.padding([0, 12].into()),
             padded_control(divider::horizontal::default()),


### PR DESCRIPTION
Airplane mode can be off when Wi-Fi is off (e.g. when using Bluetooth), so this hides the non-functional visible networks button when both Wi-Fi and airplane mode are off.
Also includes minor fixes to better match designs, and makes the notifications applet a bit less squished.