### PR TITLE
fix(time): Update applet timezone on change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,16 +1163,19 @@ name = "cosmic-applet-time"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "i18n-embed 0.14.1",
  "i18n-embed-fl 0.8.0",
  "icu",
  "libcosmic",
  "once_cell",
  "rust-embed 8.5.0",
+ "timedate-zbus",
  "tokio",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "zbus 4.3.1",
 ]
 
 [[package]]
@@ -4438,6 +4463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4456,6 +4490,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
  "phf_shared",
 ]
 
@@ -5704,6 +5748,14 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timedate-zbus"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#cd21ddcb1b5cbfc80ab84b34d3c8b1ff3d81179a"
+dependencies = [
+ "zbus 4.3.1",
 ]
 
 [[package]]

--- a/cosmic-applet-time/Cargo.toml
+++ b/cosmic-applet-time/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPL-3.0"
 
 [dependencies]
 chrono = { version = "0.4.35", features = ["clock"] }
+chrono-tz = "0.9"
 i18n-embed-fl.workspace = true
 i18n-embed.workspace = true
 libcosmic.workspace = true
@@ -16,3 +17,5 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 icu = { version = "1.4.0", features = ["experimental", "compiled_data", "icu_datetime_experimental"]}
+zbus.workspace = true
+timedate-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }


### PR DESCRIPTION
Closes: #582

The `chrono` crate [caches the local timezone](https://github.com/chronotope/chrono/blob/37ec019f8671d4c2c66d9b836d7eeea7b4709f89/src/offset/local/unix.rs#L31-L35) but doesn't update it. This makes sense because it'd be inefficient to constantly evaluate the local timezone.

Instead of using the local timezone, this patch changes the applet to use a fixed offset internally which is updated if the external timezone changes.

I added two new dependencies to the `time` applet.
* [pop-os/dbus-settings-bindings](https://github.com/pop-os/dbus-settings-bindings) for a wrapper around the D-Bus interface for timezone updates
* [chronotope/chrono-tz](https://github.com/chronotope/chrono-tz) for timezone information and parsing. This crate is maintained by the same developers as `chrono`, and the documentation recommends using it for situations like this.