### PR TITLE
feat(time): Option to show seconds on the clock applet

### DIFF
--- a/cosmic-applet-time/src/config.rs
+++ b/cosmic-applet-time/src/config.rs
@@ -7,6 +7,7 @@ use cosmic::cosmic_config::{self, cosmic_config_derive::CosmicConfigEntry, Cosmi
 #[version = 1]
 pub struct TimeAppletConfig {
     pub military_time: bool,
+    pub show_seconds: bool,
     pub first_day_of_week: u8,
     pub show_date_in_top_panel: bool,
     pub show_weekday: bool,
@@ -16,6 +17,7 @@ impl Default for TimeAppletConfig {
     fn default() -> Self {
         Self {
             military_time: false,
+            show_seconds: false,
             first_day_of_week: 6,
             show_date_in_top_panel: true,
             show_weekday: false,


### PR DESCRIPTION
Closes: #496
Requires: pop-os/cosmic-settings#509

I based some of this code off of [i3status-rust](https://github.com/greshake/i3status-rust) to double check that I handled it efficiently.

![settings](https://github.com/user-attachments/assets/154fa1ef-6033-47d8-9143-0045ec2fc3de)
![time](https://github.com/user-attachments/assets/69f571a2-91a1-44f3-a6f7-a68451c7cc08)
