### PR TITLE
time: Try LC_TIME before LANG

### DIFF
--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -114,7 +114,7 @@ impl cosmic::Application for Window {
         _flags: Self::Flags,
     ) -> (Self, cosmic::iced::Command<app::Message<Self::Message>>) {
         fn get_local() -> Result<Locale, Box<dyn std::error::Error>> {
-            let locale = std::env::var("LANG")?;
+            let locale = std::env::var("LC_TIME").or_else(|_| std::env::var("LANG"))?;
             let locale = locale
                 .split('.')
                 .next()


### PR DESCRIPTION
See: [POSIX spec](https://pubs.opengroup.org/onlinepubs/9799919799/)

I noticed that GNOME used `LC_TIME` before checking `LANG` while working on my last two patches for greeter. It seems like the expected behavior as well even though it will usually be set to `LANG`.

I may have to annoyingly open a few very small PRs across COSMIC. :sweat_smile: 