### PR TITLE
Minor fixes

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -17,12 +17,12 @@ use cosmic::{
     cosmic_config::CosmicConfigEntry,
     iced::{
         self,
-        widget::{self, column, row, slider, text},
+        widget::{self, column, row, slider, text as iced_text},
         window, Alignment, Length, Limits, Rectangle, Subscription,
     },
     iced_runtime::core::alignment::Horizontal,
     iced_style::application,
-    widget::{button, divider, horizontal_space, icon, Column, Row},
+    widget::{button, divider, horizontal_space, icon, text, Column, Row},
     Element, Renderer, Theme,
 };
 use cosmic_settings_subscriptions::pulse as sub_pulse;
@@ -819,8 +819,8 @@ impl cosmic::Application for Audio {
 
             elements.push(
                 column![
-                    text(title).size(14).width(Length::Shrink),
-                    text(artists).size(10).width(Length::Shrink),
+                    text::body(title).width(Length::Shrink),
+                    text::caption(artists).width(Length::Shrink),
                 ]
                 .width(Length::FillPortion(5))
                 .into(),
@@ -885,7 +885,7 @@ impl cosmic::Application for Audio {
             )
             .padding([8, 24]),
             padded_control(divider::horizontal::default()),
-            menu_button(text(fl!("sound-settings")).size(14)).on_press(Message::OpenSettings)
+            menu_button(text::body(fl!("sound-settings"))).on_press(Message::OpenSettings)
         ]
         .align_items(Alignment::Start)
         .padding([8, 0]);
@@ -911,7 +911,7 @@ fn revealer(
             column![revealer_head(open, title, selected, toggle)].width(Length::Fill),
             |col, (id, name)| {
                 col.push(
-                    menu_button(text(name).size(14))
+                    menu_button(iced_text(name).size(14))
                         .on_press(change(id.clone()))
                         .width(Length::Fill)
                         .padding([8, 48]),
@@ -930,8 +930,8 @@ fn revealer_head(
     toggle: Message,
 ) -> cosmic::widget::Button<'static, Message> {
     menu_button(column![
-        text(title).width(Length::Fill).size(14),
-        text(selected).size(10),
+        text::body(title).width(Length::Fill),
+        text::caption(selected),
     ])
     .on_press(toggle)
 }

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -17,7 +17,7 @@ use cosmic::{
     cosmic_config::CosmicConfigEntry,
     iced::{
         self,
-        widget::{self, column, row, slider, text as iced_text},
+        widget::{self, column, row, slider},
         window, Alignment, Length, Limits, Rectangle, Subscription,
     },
     iced_runtime::core::alignment::Horizontal,
@@ -911,7 +911,7 @@ fn revealer(
             column![revealer_head(open, title, selected, toggle)].width(Length::Fill),
             |col, (id, name)| {
                 col.push(
-                    menu_button(iced_text(name).size(14))
+                    menu_button(text::body(name.clone()))
                         .on_press(change(id.clone()))
                         .width(Length::Fill)
                         .padding([8, 48]),

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -17,14 +17,14 @@ use cosmic::{
     iced::{
         alignment::Horizontal,
         wayland::popup::{destroy_popup, get_popup},
-        widget::{column, container, row, slider, text},
+        widget::{column, container, row, slider},
         window, Alignment, Length, Subscription,
     },
     iced_core::{alignment::Vertical, Background, Border, Color, Shadow},
     iced_runtime::core::layout::Limits,
     iced_style::application,
     iced_widget::{Column, Row},
-    widget::{divider, horizontal_space, icon, scrollable, vertical_space},
+    widget::{divider, horizontal_space, icon, scrollable, text, vertical_space},
     Command, Element, Theme,
 };
 use cosmic_settings_subscriptions::{
@@ -428,8 +428,8 @@ impl cosmic::Application for CosmicBatteryApplet {
     }
 
     fn view_window(&self, _id: window::Id) -> Element<Message> {
-        let name = text(fl!("battery")).size(14);
-        let description = text(if !self.on_battery {
+        let name = text::body(fl!("battery"));
+        let description = text::caption(if !self.on_battery {
             format!("{:.0}%", self.battery_percent)
         } else {
             format!(
@@ -438,8 +438,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                 fl!("until-empty"),
                 self.battery_percent
             )
-        })
-        .size(10);
+        });
 
         let mut content = vec![
             padded_control(
@@ -455,8 +454,8 @@ impl cosmic::Application for CosmicBatteryApplet {
             menu_button(
                 row![
                     column![
-                        text(fl!("battery")).size(14),
-                        text(fl!("battery-desc")).size(10)
+                        text::body(fl!("battery")),
+                        text::caption(fl!("battery-desc"))
                     ]
                     .width(Length::Fill),
                     if matches!(self.power_profile, Power::Battery) {
@@ -476,8 +475,8 @@ impl cosmic::Application for CosmicBatteryApplet {
             menu_button(
                 row![
                     column![
-                        text(fl!("balanced")).size(14),
-                        text(fl!("balanced-desc")).size(10)
+                        text::body(fl!("balanced")),
+                        text::caption(fl!("balanced-desc"))
                     ]
                     .width(Length::Fill),
                     if matches!(self.power_profile, Power::Balanced) {
@@ -497,8 +496,8 @@ impl cosmic::Application for CosmicBatteryApplet {
             menu_button(
                 row![
                     column![
-                        text(fl!("performance")).size(14),
-                        text(fl!("performance-desc")).size(10)
+                        text::body(fl!("performance")),
+                        text::caption(fl!("performance-desc"))
                     ]
                     .width(Length::Fill),
                     if matches!(self.power_profile, Power::Performance) {
@@ -631,11 +630,10 @@ impl cosmic::Application for CosmicBatteryApplet {
             content.push(
                 menu_button(
                     row![
-                        text(fl!(
+                        text::body(fl!(
                             "dgpu-applications",
                             gpu_name = format!("\"{}\"", gpu.name.trim())
                         ))
-                        .size(14)
                         .width(Length::Fill)
                         .vertical_alignment(Vertical::Center),
                         container(
@@ -675,7 +673,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                                 } else {
                                     container(horizontal_space(12.0))
                                 },
-                                column![text(&app.name).size(14), text(&app.secondary).size(10)]
+                                column![text::body(&app.name), text::caption(&app.secondary)]
                                     .width(Length::Fill),
                             ]
                             .spacing(8)
@@ -694,7 +692,7 @@ impl cosmic::Application for CosmicBatteryApplet {
         }
 
         content.push(
-            menu_button(text(fl!("power-settings")).size(14).width(Length::Fill))
+            menu_button(text::body(fl!("power-settings")).width(Length::Fill))
                 .on_press(Message::OpenSettings)
                 .into(),
         );

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -5,7 +5,6 @@ use crate::bluetooth::{BluerDeviceStatus, BluerRequest, BluerState, DeviceProper
 use cosmic::{
     applet::token::subscription::{activation_token_subscription, TokenRequest, TokenUpdate},
     cctk::sctk::reexports::calloop,
-    widget::text::body,
 };
 
 use cosmic::{
@@ -13,7 +12,7 @@ use cosmic::{
     iced::{
         self,
         wayland::popup::{destroy_popup, get_popup},
-        widget::{column, container, row, scrollable, text, Column},
+        widget::{column, container, row, scrollable, Column},
         Alignment, Length, Subscription,
     },
     iced_runtime::core::{
@@ -22,7 +21,7 @@ use cosmic::{
         window,
     },
     iced_style::application,
-    widget::{button, divider, icon},
+    widget::{button, divider, icon, text},
     Command, Element, Theme,
 };
 use cosmic_time::{anim, chain, id, once_cell::sync::Lazy, Instant, Timeline};
@@ -359,8 +358,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
         }) {
             let mut row = row![
                 icon::from_name(dev.icon.as_str()).size(16).symbolic(true),
-                text(dev.name.clone())
-                    .size(14)
+                text::body(dev.name.clone())
                     .horizontal_alignment(Horizontal::Left)
                     .vertical_alignment(Vertical::Center)
                     .width(Length::Fill)
@@ -380,7 +378,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
                 };
                 let status = row!(
                     icon::from_name(icon).symbolic(true).size(14),
-                    body(format!("{}%", battery))
+                    text::body(format!("{}%", battery))
                 )
                 .align_items(Alignment::Center)
                 .spacing(2)
@@ -396,8 +394,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
             match &dev.status {
                 BluerDeviceStatus::Connected => {
                     row = row.push(
-                        text(fl!("connected"))
-                            .size(14)
+                        text::body(fl!("connected"))
                             .horizontal_alignment(Horizontal::Right)
                             .vertical_alignment(Vertical::Center),
                     );
@@ -459,8 +456,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
             "go-next-symbolic"
         };
         let available_connections_btn = menu_button(row![
-            text(fl!("other-devices"))
-                .size(14)
+            text::body(fl!("other-devices"))
                 .width(Length::Fill)
                 .height(Length::Fixed(24.0))
                 .vertical_alignment(Vertical::Center),
@@ -471,8 +467,10 @@ impl cosmic::Application for CosmicBluetoothApplet {
                 .height(Length::Fixed(24.0))
         ])
         .on_press(Message::ToggleVisibleDevices(!self.show_visible_devices));
-        content = content.push(padded_control(divider::horizontal::default()));
-        content = content.push(available_connections_btn);
+        if self.bluer_state.bluetooth_enabled {
+            content = content.push(padded_control(divider::horizontal::default()));
+            content = content.push(available_connections_btn);
+        }
         let mut list_column: Vec<Element<'_, Message>> =
             Vec::with_capacity(self.bluer_state.devices.len());
 
@@ -482,56 +480,50 @@ impl cosmic::Application for CosmicBluetoothApplet {
                     icon::from_name(device.icon.as_str())
                         .size(16)
                         .symbolic(true),
-                    text(&device.name)
-                        .size(14)
+                    text::body(&device.name)
                         .horizontal_alignment(Horizontal::Left)
                         .vertical_alignment(Vertical::Center)
                         .width(Length::Fill)
                 ]),
                 padded_control(
-                    text(fl!(
+                    text::body(fl!(
                         "confirm-pin",
                         HashMap::from_iter(vec![("deviceName", device.name.clone())])
                     ))
                     .horizontal_alignment(Horizontal::Left)
                     .vertical_alignment(Vertical::Center)
                     .width(Length::Fill)
-                    .size(14)
                 ),
                 padded_control(
-                    text(pin)
+                    text::title3(pin)
                         .horizontal_alignment(Horizontal::Center)
                         .vertical_alignment(Vertical::Center)
-                        .width(Length::Fixed(280.0))
-                        .size(22)
+                        .width(Length::Fixed(280.0)) //.size(22)
                 )
                 .align_x(Horizontal::Center),
                 padded_control(
                     row![
                         button(
-                            text(fl!("cancel"))
-                                .size(14)
-                                .width(Length::Fill)
-                                .height(Length::Fixed(24.0))
+                            text::body(fl!("cancel"))
                                 .vertical_alignment(Vertical::Center)
                                 .horizontal_alignment(Horizontal::Center)
                         )
-                        .padding([8, 24])
-                        .width(Length::Fill)
+                        .padding([4, 0])
+                        .height(Length::Fixed(28.0))
+                        .width(Length::Fixed(105.0))
                         .on_press(Message::Cancel),
                         button(
-                            text(fl!("confirm"))
-                                .size(14)
-                                .height(Length::Fixed(24.0))
+                            text::body(fl!("confirm"))
                                 .vertical_alignment(Vertical::Center)
                                 .horizontal_alignment(Horizontal::Center)
                         )
-                        .padding([8, 24])
-                        .width(Length::Fill)
+                        .padding([4, 0])
+                        .height(Length::Fixed(28.0))
+                        .width(Length::Fixed(105.0))
                         .on_press(Message::Confirm),
                     ]
                     .spacing(self.core.system_theme().cosmic().space_xxs())
-                    .width(Length::Fill)
+                    .width(Length::Shrink)
                     .align_items(Alignment::Center)
                 )
                 .align_x(Horizontal::Center)
@@ -552,9 +544,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
             }) {
                 let row = row![
                     icon::from_name(dev.icon.as_str()).size(16).symbolic(true),
-                    text(dev.name.clone())
-                        .horizontal_alignment(Horizontal::Left)
-                        .size(14),
+                    text::body(dev.name.clone()).horizontal_alignment(Horizontal::Left),
                 ]
                 .align_items(Alignment::Center)
                 .spacing(12);

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -556,7 +556,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     let mut ipv4 = Vec::with_capacity(ip_addresses.len() + 1);
                     ipv4.push(text::body(name).into());
                     for addr in ip_addresses {
-                        ipv4.push(text(format!("{}: {}", fl!("ipv4"), addr)).size(10).into());
+                        ipv4.push(text::caption(format!("{}: {}", fl!("ipv4"), addr)).into());
                     }
                     vpn_ethernet_col = vpn_ethernet_col.push(column![
                         row![
@@ -584,7 +584,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     ip_addresses,
                 } => {
                     let mut ipv4 = Vec::with_capacity(ip_addresses.len() + 1);
-                    ipv4.push(text(name).size(14).into());
+                    ipv4.push(text::body(name).into());
                     for addr in ip_addresses {
                         ipv4.push(text(format!("{}: {}", fl!("ipv4"), addr)).size(12).into());
                     }
@@ -628,7 +628,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                             .size(24)
                             .symbolic(true)
                             .into(),
-                        column![text(name).size(14), Column::with_children(ipv4)]
+                        column![text::body(name), Column::with_children(ipv4)]
                             .width(Length::Fill)
                             .into(),
                     ];
@@ -709,7 +709,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     icon::from_name("airplane-mode-symbolic")
                         .size(48)
                         .symbolic(true),
-                    text(fl!("airplane-mode-on")).size(14),
+                    text::body(fl!("airplane-mode-on")),
                     text(fl!("turn-off-airplane-mode")).size(12)
                 )
                 .spacing(8)
@@ -722,7 +722,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                 content = content.push(padded_control(divider::horizontal::default()));
                 for known in &self.nm_state.known_access_points {
                     let mut btn_content = Vec::with_capacity(2);
-                    let ssid = text(&known.ssid).size(14).width(Length::Fill);
+                    let ssid = text::body(&known.ssid).width(Length::Fill);
                     if known.working {
                         btn_content.push(
                             icon::from_name("network-wireless-acquiring-symbolic")
@@ -858,7 +858,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                             icon::from_name("network-wireless-acquiring-symbolic")
                                 .size(24)
                                 .symbolic(true),
-                            text(&access_point.ssid).size(14),
+                            text::body(&access_point.ssid),
                         ]
                         .align_items(Alignment::Center)
                         .width(Length::Fill)
@@ -880,7 +880,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                                 icon::from_name("network-wireless-error-symbolic")
                                     .size(24)
                                     .symbolic(true),
-                                text(&access_point.ssid).size(14),
+                                text::body(&access_point.ssid),
                             ]
                             .align_items(Alignment::Center)
                             .spacing(12),

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -12,20 +12,17 @@ use cosmic::{
     cosmic_config::{Config, CosmicConfigEntry},
     iced::{
         wayland::popup::{destroy_popup, get_popup},
-        widget::{column, row, text},
+        widget::{column, row, text as iced_text},
         window, Alignment, Length, Limits, Subscription,
     },
     iced_core::alignment::Horizontal,
-    Command,
+    iced_widget::{scrollable, Column},
+    widget::{button, container, divider, icon, text},
+    Command, Element, Theme,
 };
 
 use cosmic::{iced_futures::futures::executor::block_on, iced_style::application};
 
-use cosmic::{
-    iced_widget::{scrollable, Column},
-    widget::{button, container, divider, icon},
-    Element, Theme,
-};
 use cosmic_notifications_config::NotificationsConfig;
 use cosmic_notifications_util::{Image, Notification};
 use cosmic_time::{anim, chain, id, once_cell::sync::Lazy, Instant, Timeline};
@@ -381,7 +378,7 @@ impl cosmic::Application for Notifications {
             row![container(
                 column![
                     text_icon("cosmic-applet-notification-symbolic", 40),
-                    text(&fl!("no-notifications")).size(14)
+                    iced_text(&fl!("no-notifications")).size(14.0)
                 ]
                 .align_items(Alignment::Center)
             )
@@ -421,7 +418,7 @@ impl cosmic::Application for Notifications {
                         .size(12)
                         .width(Length::Fill);
 
-                        let duration_since = text(duration_ago_msg(n)).size(10);
+                        let duration_since = text::caption(duration_ago_msg(n));
 
                         let close_notif = button(
                             icon::from_name("window-close-symbolic")
@@ -474,9 +471,8 @@ impl cosmic::Application for Notifications {
                                         .align_items(Alignment::Center),
                                 },
                                 column![
-                                    text(n.summary.lines().next().unwrap_or_default())
-                                        .width(Length::Fill)
-                                        .size(14),
+                                    text::body(n.summary.lines().next().unwrap_or_default())
+                                        .width(Length::Fill),
                                     text(n.body.lines().next().unwrap_or_default())
                                         .width(Length::Fill)
                                         .size(12)

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -12,7 +12,7 @@ use cosmic::{
     cosmic_config::{Config, CosmicConfigEntry},
     iced::{
         wayland::popup::{destroy_popup, get_popup},
-        widget::{column, row, text as iced_text},
+        widget::{column, row},
         window, Alignment, Length, Limits, Subscription,
     },
     iced_core::alignment::Horizontal,
@@ -375,10 +375,11 @@ impl cosmic::Application for Notifications {
         .width(Length::Fill)]);
 
         let notifications = if self.cards.is_empty() {
+            let no_notifications = String::from(fl!("no-notifications"));
             row![container(
                 column![
                     text_icon("cosmic-applet-notification-symbolic", 40),
-                    iced_text(&fl!("no-notifications")).size(14.0)
+                    text::body(no_notifications)
                 ]
                 .align_items(Alignment::Center)
             )

--- a/cosmic-applet-power/src/lib.rs
+++ b/cosmic-applet-power/src/lib.rs
@@ -19,7 +19,7 @@ use cosmic::{
             actions::layer_surface::SctkLayerSurfaceSettings,
             popup::{destroy_popup, get_popup},
         },
-        widget::{self, column, container, row, space::Space, text},
+        widget::{self, column, container, row, space::Space},
         window, Alignment, Length, Subscription,
     },
     iced_runtime::core::layout::Limits,
@@ -29,7 +29,7 @@ use cosmic::{
     iced_style::application,
     iced_widget::mouse_area,
     theme,
-    widget::{button, divider, horizontal_space, icon, vertical_space, Column},
+    widget::{button, divider, horizontal_space, icon, text, vertical_space, Column},
     Element, Theme,
 };
 
@@ -248,15 +248,15 @@ impl cosmic::Application for Power {
 
     fn view_window(&self, id: window::Id) -> Element<Message> {
         if matches!(self.popup, Some(p) if p == id) {
-            let settings = menu_button(text(fl!("settings")).size(14)).on_press(Message::Settings);
+            let settings = menu_button(text::body(fl!("settings"))).on_press(Message::Settings);
 
             let session = column![
                 menu_button(
                     row![
                         text_icon("system-lock-screen-symbolic", 24),
-                        text(fl!("lock-screen")).size(14),
+                        text::body(fl!("lock-screen")),
                         Space::with_width(Length::Fill),
-                        text(fl!("lock-screen-shortcut")).size(14),
+                        text::body(fl!("lock-screen-shortcut")),
                     ]
                     .align_items(Alignment::Center)
                     .spacing(8)
@@ -265,9 +265,9 @@ impl cosmic::Application for Power {
                 menu_button(
                     row![
                         text_icon("system-log-out-symbolic", 24),
-                        text(fl!("log-out")).size(14),
+                        text::body(fl!("log-out")),
                         Space::with_width(Length::Fill),
-                        text(fl!("log-out-shortcut")).size(14),
+                        text::body(fl!("log-out-shortcut")),
                     ]
                     .align_items(Alignment::Center)
                     .spacing(8)
@@ -320,8 +320,7 @@ impl cosmic::Application for Power {
                 ))
                 .primary_action(
                     button(min_width_and_height(
-                        text(fl!("confirm", HashMap::from_iter(vec![("action", action)])))
-                            .size(14)
+                        text::body(fl!("confirm", HashMap::from_iter(vec![("action", action)])))
                             .into(),
                         142.0,
                         32.0,
@@ -333,7 +332,7 @@ impl cosmic::Application for Power {
                 )
                 .secondary_action(
                     button(min_width_and_height(
-                        text(fl!("cancel")).size(14).into(),
+                        text::body(fl!("cancel")).into(),
                         142.0,
                         32.0,
                     ))
@@ -382,7 +381,7 @@ impl cosmic::Application for Power {
 
 fn power_buttons(name: &str, msg: String) -> cosmic::widget::Button<Message> {
     cosmic::widget::button(
-        column![text_icon(name, 40), text(msg).size(14)]
+        column![text_icon(name, 40), text::body(msg)]
             .spacing(4)
             .align_items(Alignment::Center)
             .width(Length::Fill),

--- a/cosmic-applet-tiling/src/window.rs
+++ b/cosmic-applet-tiling/src/window.rs
@@ -298,29 +298,26 @@ impl cosmic::Application for Window {
             .width(Length::Fill),
             padded_control(divider::horizontal::default(),),
             padded_control(column![
-                text(fl!("new-workspace")).size(14),
+                text::body(fl!("new-workspace")),
                 new_workspace_behavior_button,
             ]),
             padded_control(divider::horizontal::default()),
             padded_control(row!(
-                text(fl!("navigate-windows")).size(14).width(Length::Fill),
-                text(format!("{} + {}", fl!("super"), fl!("arrow-keys"))).size(14),
+                text::body(fl!("navigate-windows")).width(Length::Fill),
+                text::body(format!("{} + {}", fl!("super"), fl!("arrow-keys"))),
             )),
             padded_control(row!(
-                text(fl!("move-window")).size(14).width(Length::Fill),
-                text(format!(
+                text::body(fl!("move-window")).width(Length::Fill),
+                text::body(format!(
                     "{} + {} + {}",
                     fl!("shift"),
                     fl!("super"),
                     fl!("arrow-keys")
-                ))
-                .size(14),
+                )),
             )),
             padded_control(row!(
-                text(fl!("toggle-floating-window"))
-                    .size(14)
-                    .width(Length::Fill),
-                text(format!("{} + G", fl!("super"))).size(14),
+                text::body(fl!("toggle-floating-window")).width(Length::Fill),
+                text::body(format!("{} + G", fl!("super"))),
             )),
             padded_control(divider::horizontal::default()),
             padded_control(

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -12,15 +12,15 @@ use cosmic::{
         futures::{channel::mpsc, SinkExt, StreamExt, TryFutureExt},
         subscription,
         wayland::popup::{destroy_popup, get_popup},
-        widget::{column, row, text, vertical_space},
+        widget::{column, row, vertical_space},
         window, Alignment, Length, Rectangle, Subscription,
     },
     iced_core::alignment::{Horizontal, Vertical},
     iced_style::application,
     iced_widget::{horizontal_rule, Column},
     widget::{
-        button, container, divider, grid, horizontal_space, icon, rectangle_tracker::*, Button,
-        Grid, Space,
+        button, container, divider, grid, horizontal_space, icon, rectangle_tracker::*, text,
+        Button, Grid, Space,
     },
     Command, Element, Theme,
 };
@@ -565,7 +565,7 @@ impl cosmic::Application for Window {
         let mut day_of_week_bag = Bag::empty();
         day_of_week_bag.weekday = Some(components::Text::Long);
 
-        let day_of_week = text(self.format(day_of_week_bag, &self.date_selected)).size(14);
+        let day_of_week = text::body(self.format(day_of_week_bag, &self.date_selected));
 
         let month_controls = row![
             button::icon(icon::from_name("go-previous-symbolic"))
@@ -631,7 +631,7 @@ impl cosmic::Application for Window {
             .padding([12, 20]),
             calender.padding([0, 12].into()),
             padded_control(divider::horizontal::default()),
-            menu_button(text(fl!("datetime-settings")).size(14))
+            menu_button(text::body(fl!("datetime-settings")))
                 .on_press(Message::OpenDateTimeSettings),
         ]
         .padding([8, 0]);


### PR DESCRIPTION
Makes the Bluetooth pairing Confirm and Cancel button more closely match the design, and hides the **Other Bluetooth Devices** button if Bluetooth is off.
![screenshot-2024-09-01-14-30-44](https://github.com/user-attachments/assets/0d51b8c2-af89-4678-9ad7-9f8b1005a6d0)![screenshot-2024-09-01-14-08-25](https://github.com/user-attachments/assets/ee3d70cf-8065-46f1-8424-8da57802985e)


Switches most things to use `cosmic::widget::text`, instead of `cosmic::iced::widget::text`.
The iced version seems to be required in 2 places (audio and notifications; imported as `iced_text`), otherwise this error message is shown:
```
rustc: cannot return value referencing function parameter `options`
returns a value referencing data owned by the current function
```