### PR TITLE
[workspaces] replace primary button with transparent alternative

### DIFF
--- a/cosmic-applet-workspaces/src/components/app.rs
+++ b/cosmic-applet-workspaces/src/components/app.rs
@@ -209,7 +209,24 @@ impl cosmic::Application for IcedWorkspacesApplet {
             Some(
                 btn.style(match w.1 {
                     Some(zcosmic_workspace_handle_v1::State::Active) => {
-                        cosmic::theme::iced::Button::Primary
+                        let appearance = |theme: &Theme| {
+                            button::Appearance {
+                                background: Some(Background::Color(
+                                    theme.cosmic().icon_button.selected_state_color().into(),
+                                )),
+                                border: Border {
+                                    radius: theme.cosmic().radius_xl().into(),
+                                    ..Default::default()
+                                },
+                                border_radius: theme.cosmic().radius_xl().into(),
+                                text_color: theme.current_container().component.on.into(),
+                                ..button::Appearance::default()
+                            }
+                        };
+                        cosmic::theme::iced::Button::Custom {
+                            active: Box::new(appearance),
+                            hover: Box::new(appearance),
+                        }
                     }
                     Some(zcosmic_workspace_handle_v1::State::Urgent) => {
                         let appearance = |theme: &Theme| {
@@ -231,7 +248,7 @@ impl cosmic::Application for IcedWorkspacesApplet {
                             active: Box::new(appearance),
                             hover: Box::new(move |theme| button::Appearance {
                                 background: Some(Background::Color(
-                                    theme.current_container().component.hover.into(),
+                                    theme.cosmic().icon_button.selected_state_color().into(),
                                 )),
                                 border: Border {
                                     radius: theme.cosmic().radius_xl().into(),
@@ -259,7 +276,7 @@ impl cosmic::Application for IcedWorkspacesApplet {
                             active: Box::new(appearance),
                             hover: Box::new(move |theme| button::Appearance {
                                 background: Some(Background::Color(
-                                    theme.current_container().component.hover.into(),
+                                    theme.cosmic().icon_button.selected_state_color().into(),
                                 )),
                                 border: Border {
                                     radius: theme.cosmic().radius_xl().into(),


### PR DESCRIPTION
I didn't like how much the primary color stood out and figured this better matches the applist/rest of the panel.

If this is a worse default, but you're open to making this configurable, I would be interested in contributing that as well.

### Before
![screenshot-2024-09-05-07-03-30](https://github.com/user-attachments/assets/f62fc76d-430d-4d12-b0b0-36c6e0f94f24)
![screenshot-2024-09-05-07-03-53](https://github.com/user-attachments/assets/4cd21a6b-e54f-478f-9487-7562a36c5a38)

### After
![screenshot-2024-09-05-08-10-19](https://github.com/user-attachments/assets/b53e9737-5bb1-4465-9cfa-f962cf556c6a)
![screenshot-2024-09-05-08-10-34](https://github.com/user-attachments/assets/760cc954-4945-4fea-bfc9-a6301195e8e6)
![screenshot-2024-09-05-08-18-04](https://github.com/user-attachments/assets/22ca6779-bd58-453e-b994-e0a20f47be9c)

