### PR TITLE
Show empty dropdown menu when no app uses dGPU

### DIFF
--- a/cosmic-applet-battery/src/dgpu.rs
+++ b/cosmic-applet-battery/src/dgpu.rs
@@ -222,7 +222,8 @@ impl Gpu {
                 Some(
                     smi_output
                         .lines()
-                        .filter(|line| { // smi shows an empty line filled with - when no app is running
+                        .filter(|line| {
+                            // smi shows an empty line filled with - when no app is running
                             let components = line.split_whitespace().collect::<Vec<_>>();
                             components[1].trim().ne("-") && !line.starts_with('#')
                         })

--- a/cosmic-applet-battery/src/dgpu.rs
+++ b/cosmic-applet-battery/src/dgpu.rs
@@ -222,7 +222,10 @@ impl Gpu {
                 Some(
                     smi_output
                         .lines()
-                        .filter(|line| !line.starts_with('#'))
+                        .filter(|line| { // smi shows an empty line filled with - when no app is running
+                            let components = line.split_whitespace().collect::<Vec<_>>();
+                            components[1].trim().ne("-") && !line.starts_with('#')
+                        })
                         .map(|line| {
                             let components = line.split_whitespace().collect::<Vec<_>>();
                             let pid = components[1].trim();


### PR DESCRIPTION
Current dropdown menu when there is no application using the discrete GPU:
![image](https://github.com/user-attachments/assets/088ad0e8-30bf-44ba-b14b-9df4412b0b4a)

This is caused by the strange nvidia-smi output when nothing is running:
```
~$ nvidia-smi pmon --id 0:01:00.0 --count 1
# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
# Idx           #    C/G      %      %      %      %      %      %    name 
    0          -     -      -      -      -      -      -      -    -              
```