### PR TITLE
chore(license): clarify GPL-3.0 license as GPL-3.0-only

### DIFF
--- a/cosmic-app-list/Cargo.toml
+++ b/cosmic-app-list/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-app-list"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 cosmic-app-list-config = { path = "cosmic-app-list-config" }

--- a/cosmic-applet-audio/Cargo.toml
+++ b/cosmic-applet-audio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-audio"
 version = "0.1.1"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 cosmic-settings-subscriptions.workspace = true

--- a/cosmic-applet-battery/Cargo.toml
+++ b/cosmic-applet-battery/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-battery"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 cosmic-settings-subscriptions.workspace = true

--- a/cosmic-applet-bluetooth/Cargo.toml
+++ b/cosmic-applet-bluetooth/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-bluetooth"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 anyhow.workspace = true

--- a/cosmic-applet-input-sources/Cargo.toml
+++ b/cosmic-applet-input-sources/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-input-sources"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 cosmic-time.workspace = true

--- a/cosmic-applet-minimize/Cargo.toml
+++ b/cosmic-applet-minimize/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-minimize"
 version = "0.1.1"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 anyhow.workspace = true

--- a/cosmic-applet-notifications/Cargo.toml
+++ b/cosmic-applet-notifications/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-notifications"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 anyhow.workspace = true

--- a/cosmic-applet-power/Cargo.toml
+++ b/cosmic-applet-power/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-power"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 i18n-embed-fl.workspace = true

--- a/cosmic-applet-status-area/Cargo.toml
+++ b/cosmic-applet-status-area/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-status-area"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 futures.workspace = true

--- a/cosmic-applet-tiling/Cargo.toml
+++ b/cosmic-applet-tiling/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-tiling"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 libcosmic.workspace = true

--- a/cosmic-applet-time/Cargo.toml
+++ b/cosmic-applet-time/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applet-time"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 chrono = { version = "0.4.35", features = ["clock"] }

--- a/cosmic-applet-workspaces/Cargo.toml
+++ b/cosmic-applet-workspaces/Cargo.toml
@@ -3,7 +3,7 @@ name = "cosmic-applet-workspaces"
 version = "0.1.1"
 authors = ["Ashley Wulber <ashley@system76.com>"]
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 libcosmic.workspace = true

--- a/cosmic-applets/Cargo.toml
+++ b/cosmic-applets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-applets"
 version = "0.1.1"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 cosmic-app-list = { path = "../cosmic-app-list" }

--- a/cosmic-panel-button/Cargo.toml
+++ b/cosmic-panel-button/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cosmic-panel-button"
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 
 [dependencies]
 freedesktop-desktop-entry.workspace = true


### PR DESCRIPTION
Fedora downstream packaging requires `GPL-3.0` to be clarified as either `GPL-3.0-or-later` or `GPL-3.0-only`