### PR TITLE
fix: vertical time applet

### DIFF
--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -490,7 +490,7 @@ impl cosmic::Application for Window {
                         .text(format!("{:02}", self.now.month()))
                         .into(),
                 );
-                
+
                 elements.push(
                     horizontal_rule(2)
                         .width(self.core.applet.suggested_size(true).0)
@@ -502,6 +502,10 @@ impl cosmic::Application for Window {
 
             time_bag.hour = Some(components::Numeric::Numeric);
             time_bag.minute = Some(components::Numeric::Numeric);
+            time_bag.second = self
+                .config
+                .show_seconds
+                .then_some(components::Numeric::Numeric);
 
             let hour_cycle = if self.config.military_time {
                 preferences::HourCycle::H23

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -478,17 +478,19 @@ impl cosmic::Application for Window {
             let mut elements = Vec::new();
 
             if self.config.show_date_in_top_panel {
-                let mut date_bag = Bag::empty();
-
-                date_bag.day = Some(components::Day::NumericDayOfMonth);
-                date_bag.month = Some(components::Month::Short);
-
-                let formated = self.format(date_bag, &self.now);
-
-                for p in formated.split_whitespace() {
-                    elements.push(self.core.applet.text(p.to_owned()).into());
-                }
-
+                elements.push(
+                    self.core
+                        .applet
+                        .text(format!("{:02}", self.now.day()))
+                        .into(),
+                );
+                elements.push(
+                    self.core
+                        .applet
+                        .text(format!("{:02}", self.now.month()))
+                        .into(),
+                );
+                
                 elements.push(
                     horizontal_rule(2)
                         .width(self.core.applet.suggested_size(true).0)

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -481,13 +481,13 @@ impl cosmic::Application for Window {
                 elements.push(
                     self.core
                         .applet
-                        .text(format!("{:02}", self.now.day()))
+                        .text(format!("{:02}", self.now.month()))
                         .into(),
                 );
                 elements.push(
                     self.core
                         .applet
-                        .text(format!("{:02}", self.now.month()))
+                        .text(format!("{:02}", self.now.day()))
                         .into(),
                 );
 


### PR DESCRIPTION
This PR contains 2 fixes to the vertical time applet.
1. Fixed seconds not showing on the time applet when the setting is enabled in the settings
2. Made reading the date more pleasing in the vertical layout. This just makes both the month & day use numbers and take up 2 digits.
| Old Look | New Look |
| --- | --- |
| ![old](https://github.com/user-attachments/assets/fd4272f1-c121-455a-8d27-ac530b57fc64) | ![new](https://github.com/user-attachments/assets/235b18d2-cd0e-4a04-b24c-52a9a694e8f3) |
