### PR TITLE
feat: audio applet over-amplification support

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -43,6 +43,12 @@ mod config;
 mod mpris_subscription;
 mod pulse;
 
+// Full, in this case, means 100%.
+static FULL_VOLUME: f64 = Volume::NORMAL.0 as f64;
+
+// Max volume is 150% volume.
+static MAX_VOLUME: f64 = FULL_VOLUME + (FULL_VOLUME * 0.5);
+
 static SHOW_MEDIA_CONTROLS: Lazy<id::Toggler> = Lazy::new(id::Toggler::unique);
 
 const GO_BACK: &str = "media-skip-backward-symbolic";
@@ -712,7 +718,7 @@ impl cosmic::Application for Audio {
                 .current_output
                 .as_ref()
                 .map_or(0f64, |v| volume_to_percent(v.volume.avg()) + change as f64)
-                .clamp(0.0, 100.0);
+                .clamp(0.0, 150.0);
             Message::SetOutputVolume(new_volume)
         });
         let playback_buttons = (!self.core.applet.configure.as_ref().is_some_and(|c| {
@@ -767,8 +773,9 @@ impl cosmic::Application for Audio {
                         .icon_size(24)
                         .line_height(24)
                         .on_press(Message::SetOutputMute(!out_mute)),
-                        slider(0.0..=100.0, self.output_volume, Message::SetOutputVolume)
-                            .width(Length::FillPortion(5)),
+                        slider(0.0..=150.0, self.output_volume, Message::SetOutputVolume)
+                            .width(Length::FillPortion(5))
+                            .breakpoints(&[100.]),
                         text(&self.output_volume_text)
                             .size(16)
                             .width(Length::FillPortion(1))
@@ -788,8 +795,9 @@ impl cosmic::Application for Audio {
                         .icon_size(24)
                         .line_height(24)
                         .on_press(Message::SetInputMute(!in_mute)),
-                        slider(0.0..=100.0, self.input_volume, Message::SetInputVolume)
-                            .width(Length::FillPortion(5)),
+                        slider(0.0..=150.0, self.input_volume, Message::SetInputVolume)
+                            .width(Length::FillPortion(5))
+                            .breakpoints(&[100.]),
                         text(&self.input_volume_text)
                             .size(16)
                             .width(Length::FillPortion(1))
@@ -1034,13 +1042,9 @@ impl Default for IsOpen {
 }
 
 fn volume_to_percent(volume: Volume) -> f64 {
-    volume.0 as f64 * 100. / Volume::NORMAL.0 as f64
+    volume.0 as f64 * 100. / FULL_VOLUME
 }
 
 fn percent_to_volume(percent: f64) -> Volume {
-    Volume(
-        (percent / 100. * Volume::NORMAL.0 as f64)
-            .clamp(0., Volume::NORMAL.0 as f64)
-            .round() as u32,
-    )
+    Volume((percent / 100. * FULL_VOLUME).clamp(0., MAX_VOLUME).round() as u32)
 }


### PR DESCRIPTION
The COSMIC system settings provide a choice between 0-150% for the volume of both output and input. The COSMIC audio applet does not. 

This proposed change aligns the audio applet UI/UX with the system settings, allowing the user to "over-amplify" volume directly from the audio applet.

### Updated COSMIC Audio Applet (this PR)

![screenshot-2024-10-29-16-40-24](https://github.com/user-attachments/assets/d6328828-10c2-4ed7-87ca-c65fc6c1df96)

### Existing COSMIC System Settings

![screenshot-2024-10-29-04-41-27](https://github.com/user-attachments/assets/7972655b-dd87-476c-ab29-bef1b865fe35)

This change relates to the following issues:

* pop-os/cosmic-settings#484
* pop-os/cosmic-applets#625

## Considerations

### Bug/Bad experience?
Without this proposed change, or one of similar impact/change, a user could set volume to 150% in COSMIC settings and afterward, when adjusting volume via the audio applet, the volume will snap-back/cap to 100 and restrict volume to between 0-100%.

### Forward thinking
I understand there is a broader topic of how exactly to support "over-amplification", however, at minimum, the COSMIC audio applet should at least align with the COSMIC system settings so that whether audio is set via settings, or audio applet, the user has the same "choice" (0-150%).