### PR TITLE
[App Tray] Use context menu radius from theme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ freedesktop-desktop-entry = "0.7.5"
 [profile.release]
 lto = "fat"
 
-
 [workspace.metadata.cargo-machete]
 ignored = ["libcosmic"]
 # [patch."https://github.com/pop-os/libcosmic"]

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -31,10 +31,7 @@ use cosmic::{
         window, Color, Limits, Subscription,
     },
     iced_core::{Border, Padding, Shadow},
-    iced_runtime::{
-        core::{alignment::Horizontal, event},
-        dnd::peek_dnd,
-    },
+    iced_runtime::{core::event, dnd::peek_dnd},
     theme::{self, Button, Container},
     widget::{
         button, divider, dnd_source, horizontal_space,
@@ -215,28 +212,28 @@ impl DockItem {
                 horizontal_space().width(Length::Fixed(1.0)).into(),
                 cosmic_icon.clone().into(),
             ])
-            .align_y(iced::Alignment::Center)
+            .align_y(Alignment::Center)
             .into(),
             PanelAnchor::Right => row(vec![
                 cosmic_icon.clone().into(),
                 horizontal_space().width(Length::Fixed(1.0)).into(),
                 column(dots).into(),
             ])
-            .align_y(iced::Alignment::Center)
+            .align_y(Alignment::Center)
             .into(),
             PanelAnchor::Top => column(vec![
                 row(dots).into(),
                 vertical_space().height(Length::Fixed(1.0)).into(),
                 cosmic_icon.clone().into(),
             ])
-            .align_x(iced::Alignment::Center)
+            .align_x(Alignment::Center)
             .into(),
             PanelAnchor::Bottom => column(vec![
                 cosmic_icon.clone().into(),
                 vertical_space().height(Length::Fixed(1.0)).into(),
                 row(dots).into(),
             ])
-            .align_x(iced::Alignment::Center)
+            .align_x(Alignment::Center)
             .into(),
         };
 
@@ -467,15 +464,12 @@ where
                 .padding(border as u16)
                 .height(Length::Fill)
                 .width(Length::Fill),
-                container(text::body(title).align_x(Horizontal::Center),).center_x(Length::Fill),
+                container(text::body(title).align_x(Alignment::Center)).center_x(Length::Fill),
             ]
             .spacing(4)
             .align_x(Alignment::Center),
         )
-        .align_x(cosmic::iced_core::alignment::Horizontal::Center)
-        .align_y(cosmic::iced_core::alignment::Vertical::Center)
-        .height(Length::Fill)
-        .width(Length::Fill),
+        .center(Length::Fill),
     )
     .on_press(on_press)
     .class(window_menu_style(is_focused))
@@ -1797,7 +1791,7 @@ impl cosmic::Application for CosmicAppList {
                                         text_color: Some(component.on.into()),
                                         background: Some(Background::Color(component.base.into())),
                                         border: Border {
-                                            radius: 8.0.into(),
+                                            radius: cosmic.radius_s().into(),
                                             width: 1.0,
                                             color: component.divider.into(),
                                         },

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -23,7 +23,6 @@ use cosmic::{
         widget::{self, column, row, slider},
         window, Alignment, Length, Limits, Subscription,
     },
-    iced_runtime::core::alignment::Horizontal,
     theme,
     widget::{button, divider, horizontal_space, icon, text, Column, Row},
     Element, Renderer, Task, Theme,
@@ -753,7 +752,7 @@ impl cosmic::Application for Audio {
             column![padded_control(
                 text::title3(fl!("disconnected"))
                     .width(Length::Fill)
-                    .align_x(Horizontal::Center)
+                    .align_x(Alignment::Center)
             )]
         } else {
             column![
@@ -773,7 +772,7 @@ impl cosmic::Application for Audio {
                         text(&self.output_volume_text)
                             .size(16)
                             .width(Length::FillPortion(1))
-                            .align_x(Horizontal::Right)
+                            .align_x(Alignment::End)
                     ]
                     .spacing(12)
                     .align_y(Alignment::Center)
@@ -794,7 +793,7 @@ impl cosmic::Application for Audio {
                         text(&self.input_volume_text)
                             .size(16)
                             .width(Length::FillPortion(1))
-                            .align_x(Horizontal::Right)
+                            .align_x(Alignment::End)
                     ]
                     .spacing(12)
                     .align_y(Alignment::Center)
@@ -848,8 +847,8 @@ impl cosmic::Application for Audio {
             }
 
             let title = if let Some(title) = s.title.as_ref() {
-                if title.chars().count() > 15 {
-                    let mut title_trunc = title.chars().take(15).collect::<String>();
+                if title.chars().count() > 22 {
+                    let mut title_trunc = title.chars().take(20).collect::<String>();
                     title_trunc.push_str("...");
                     title_trunc
                 } else {
@@ -861,8 +860,8 @@ impl cosmic::Application for Audio {
 
             let artists = if let Some(artists) = s.artists.as_ref() {
                 let artists = artists.join(", ");
-                if artists.chars().count() > 15 {
-                    let mut artists_trunc = artists.chars().take(15).collect::<String>();
+                if artists.chars().count() > 27 {
+                    let mut artists_trunc = artists.chars().take(25).collect::<String>();
                     artists_trunc.push_str("...");
                     artists_trunc
                 } else {

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -19,12 +19,11 @@ use cosmic::{
     cctk::sctk::reexports::calloop,
     cosmic_theme::Spacing,
     iced::{
-        alignment::Horizontal,
         platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup},
         widget::{column, container, row, slider},
-        window, Alignment, Length, Subscription,
+        window, Length, Subscription,
     },
-    iced_core::{alignment::Vertical, Background, Border, Color, Shadow},
+    iced_core::{Alignment, Background, Border, Color, Shadow},
     iced_runtime::core::layout::Limits,
     iced_widget::{Column, Row},
     theme,
@@ -578,7 +577,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                             ))
                             .size(16)
                             .width(Length::Fixed(40.0))
-                            .align_x(Horizontal::Right)
+                            .align_x(Alignment::End)
                         ]
                         .spacing(12),
                     )
@@ -606,7 +605,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                             ))
                             .size(16)
                             .width(Length::Fixed(40.0))
-                            .align_x(Horizontal::Right)
+                            .align_x(Alignment::End)
                         ]
                         .spacing(12),
                     )
@@ -628,7 +627,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                         text(fl!("dgpu-running"))
                             .size(16)
                             .width(Length::Fill)
-                            .align_x(Horizontal::Left),
+                            .align_x(Alignment::Start),
                         container(vertical_space().width(Length::Fixed(0.0)))
                             .padding(4)
                             .class(cosmic::style::Container::Custom(Box::new(|theme| {
@@ -671,7 +670,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                             gpu_name = format!("\"{}\"", gpu.name.trim())
                         ))
                         .width(Length::Fill)
-                        .align_y(Vertical::Center),
+                        .align_y(Alignment::Center),
                         container(
                             icon::from_name(if gpu.toggled {
                                 "go-down-symbolic"
@@ -681,10 +680,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                             .size(14)
                             .symbolic(true)
                         )
-                        .align_x(Horizontal::Center)
-                        .align_y(Vertical::Center)
-                        .width(Length::Fixed(24.0))
-                        .height(Length::Fixed(24.0)),
+                        .center(Length::Fixed(24.0)),
                     ]
                     .align_y(Alignment::Center),
                 )

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -16,11 +16,7 @@ use cosmic::{
         widget::{column, container, row, scrollable, Column},
         Alignment, Length, Subscription,
     },
-    iced_runtime::core::{
-        alignment::{Horizontal, Vertical},
-        layout::Limits,
-        window,
-    },
+    iced_runtime::core::{layout::Limits, window},
     theme,
     widget::{button, divider, icon, text},
     Element, Task,
@@ -364,8 +360,8 @@ impl cosmic::Application for CosmicBluetoothApplet {
             let mut row = row![
                 icon::from_name(dev.icon.as_str()).size(16).symbolic(true),
                 text::body(dev.name.clone())
-                    .align_x(Horizontal::Left)
-                    .align_y(Vertical::Center)
+                    .align_x(Alignment::Start)
+                    .align_y(Alignment::Center)
                     .width(Length::Fill)
             ]
             .align_y(Alignment::Center)
@@ -390,8 +386,8 @@ impl cosmic::Application for CosmicBluetoothApplet {
                 .width(Length::Shrink);
 
                 let content = container(status)
-                    .align_x(Horizontal::Right)
-                    .align_y(Vertical::Center);
+                    .align_x(Alignment::End)
+                    .align_y(Alignment::Center);
 
                 row = row.push(content);
             }
@@ -400,8 +396,8 @@ impl cosmic::Application for CosmicBluetoothApplet {
                 BluerDeviceStatus::Connected => {
                     row = row.push(
                         text::body(fl!("connected"))
-                            .align_x(Horizontal::Right)
-                            .align_y(Vertical::Center),
+                            .align_x(Alignment::End)
+                            .align_y(Alignment::Center),
                     );
                 }
                 BluerDeviceStatus::Paired => {}
@@ -465,12 +461,9 @@ impl cosmic::Application for CosmicBluetoothApplet {
             text::body(fl!("other-devices"))
                 .width(Length::Fill)
                 .height(Length::Fixed(24.0))
-                .align_y(Vertical::Center),
+                .align_y(Alignment::Center),
             container(icon::from_name(dropdown_icon).size(16).symbolic(true))
-                .align_x(Horizontal::Center)
-                .align_y(Vertical::Center)
-                .width(Length::Fixed(24.0))
-                .height(Length::Fixed(24.0))
+                .center(Length::Fixed(24.0))
         ])
         .on_press(Message::ToggleVisibleDevices(!self.show_visible_devices));
         if self.bluer_state.bluetooth_enabled {
@@ -488,8 +481,8 @@ impl cosmic::Application for CosmicBluetoothApplet {
                         .size(16)
                         .symbolic(true),
                     text::body(&device.name)
-                        .align_x(Horizontal::Left)
-                        .align_y(Vertical::Center)
+                        .align_x(Alignment::Start)
+                        .align_y(Alignment::Center)
                         .width(Length::Fill)
                 ]),
                 padded_control(
@@ -497,43 +490,30 @@ impl cosmic::Application for CosmicBluetoothApplet {
                         "confirm-pin",
                         HashMap::from_iter(vec![("deviceName", device.name.clone())])
                     ))
-                    .align_x(Horizontal::Left)
-                    .align_y(Vertical::Center)
+                    .align_x(Alignment::Start)
+                    .align_y(Alignment::Center)
                     .width(Length::Fill)
                 ),
-                padded_control(
-                    text::title3(pin)
-                        .align_x(Horizontal::Center)
-                        .align_y(Vertical::Center)
-                        .width(Length::Fixed(280.0)) //.size(22)
-                )
-                .align_x(Horizontal::Center),
+                padded_control(text::title3(pin).center().width(Length::Fixed(280.0)))
+                    .align_x(Alignment::Center),
                 padded_control(
                     row![
-                        button::custom(
-                            text::body(fl!("cancel"))
-                                .align_y(Vertical::Center)
-                                .align_x(Horizontal::Center)
-                        )
-                        .padding([4, 0])
-                        .height(Length::Fixed(28.0))
-                        .width(Length::Fixed(105.0))
-                        .on_press(Message::Cancel),
-                        button::custom(
-                            text::body(fl!("confirm"))
-                                .align_y(Vertical::Center)
-                                .align_x(Horizontal::Center)
-                        )
-                        .padding([4, 0])
-                        .height(Length::Fixed(28.0))
-                        .width(Length::Fixed(105.0))
-                        .on_press(Message::Confirm),
+                        button::custom(text::body(fl!("cancel")).center())
+                            .padding([4, 0])
+                            .height(Length::Fixed(28.0))
+                            .width(Length::Fixed(105.0))
+                            .on_press(Message::Cancel),
+                        button::custom(text::body(fl!("confirm")).center())
+                            .padding([4, 0])
+                            .height(Length::Fixed(28.0))
+                            .width(Length::Fixed(105.0))
+                            .on_press(Message::Confirm),
                     ]
                     .spacing(self.core.system_theme().cosmic().space_xxs())
                     .width(Length::Shrink)
                     .align_y(Alignment::Center)
                 )
-                .align_x(Horizontal::Center)
+                .align_x(Alignment::Center)
             ];
             list_column.push(row.into());
         }
@@ -551,7 +531,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
             }) {
                 let row = row![
                     icon::from_name(dev.icon.as_str()).size(16).symbolic(true),
-                    text::body(dev.name.clone()).align_x(Horizontal::Left),
+                    text::body(dev.name.clone()).align_x(Alignment::Start),
                 ]
                 .align_y(Alignment::Center)
                 .spacing(12);

--- a/cosmic-applet-input-sources/src/window.rs
+++ b/cosmic-applet-input-sources/src/window.rs
@@ -5,7 +5,7 @@ use crate::config::{Config, CONFIG_VERSION};
 #[allow(unused_imports)]
 use crate::fl;
 #[allow(unused_imports)]
-use cosmic::iced::{alignment, Alignment, Length};
+use cosmic::iced::{Alignment, Length};
 use cosmic::{
     app::Core,
     applet::{self},

--- a/cosmic-applet-minimize/src/wayland_subscription.rs
+++ b/cosmic-applet-minimize/src/wayland_subscription.rs
@@ -19,7 +19,7 @@ use futures::{
 };
 use image::EncodableLayout;
 use once_cell::sync::Lazy;
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 use tokio::sync::Mutex;
 
 use crate::wayland_handler::wayland_handler;

--- a/cosmic-applet-minimize/src/window_image.rs
+++ b/cosmic-applet-minimize/src/window_image.rs
@@ -63,10 +63,7 @@ where
                     .height(Length::Shrink)
                     .width(Length::Shrink),
                 )
-                .align_x(cosmic::iced_core::alignment::Horizontal::Center)
-                .align_y(cosmic::iced_core::alignment::Vertical::Center)
-                .height(Length::Fixed(size + padding as f32 * 2.0))
-                .width(Length::Fixed(size + padding as f32 * 2.0))
+                .center(Length::Fixed(size + padding as f32 * 2.0))
                 .padding(padding),
             )
             .on_press(on_press)

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -13,11 +13,7 @@ use cosmic::{
         widget::{column, row},
         Alignment, Length, Subscription,
     },
-    iced_runtime::core::{
-        alignment::{Horizontal, Vertical},
-        layout::Limits,
-        window,
-    },
+    iced_runtime::core::{layout::Limits, window},
     iced_widget::Row,
     theme,
     widget::{
@@ -576,7 +572,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                             Column::with_children(ipv4),
                             text::body(fl!("connected"))
                                 .width(Length::Fill)
-                                .align_x(Horizontal::Right),
+                                .align_x(Alignment::End),
                         ]
                         .align_y(Alignment::Center)
                         .spacing(8)
@@ -612,7 +608,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                                 fl!("megabits-per-second")
                             ))
                             .width(Length::Fill)
-                            .align_x(Horizontal::Right),
+                            .align_x(Alignment::End),
                         ]
                         .align_y(Alignment::Center)
                         .spacing(8)
@@ -652,8 +648,8 @@ impl cosmic::Application for CosmicNetworkApplet {
                         }
                         ActiveConnectionState::Activated => btn_content.push(
                             text::body(fl!("connected"))
-                                .align_x(Horizontal::Right)
-                                .align_y(Vertical::Center)
+                                .align_x(Alignment::End)
+                                .align_y(Alignment::Center)
                                 .into(),
                         ),
                         _ => {}
@@ -816,12 +812,9 @@ impl cosmic::Application for CosmicNetworkApplet {
                     text::body(fl!("visible-wireless-networks"))
                         .width(Length::Fill)
                         .height(Length::Fixed(24.0))
-                        .align_y(Vertical::Center),
+                        .align_y(Alignment::Center),
                     container(icon::from_name(dropdown_icon).size(16).symbolic(true))
-                        .align_x(Horizontal::Center)
-                        .align_y(Vertical::Center)
-                        .width(Length::Fixed(24.0))
-                        .height(Length::Fixed(24.0)),
+                        .center(Length::Fixed(24.0))
                 ])
                 .on_press(Message::ToggleVisibleNetworks);
                 content = content.push(available_connections_btn);
@@ -865,7 +858,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                             .spacing(8)
                             .align_x(Alignment::Center),
                         )
-                        .align_x(Horizontal::Center);
+                        .align_x(Alignment::Center);
                         content = content.push(col);
                     }
                     NewConnectionState::Waiting(access_point) => {
@@ -900,7 +893,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                             .align_y(Alignment::Center)
                             .spacing(12),
                         )
-                        .align_x(Horizontal::Center);
+                        .align_x(Alignment::Center);
                         content = content.push(id);
                         let col = padded_control(
                             column![
@@ -918,7 +911,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                             .spacing(16)
                             .align_x(Alignment::Center),
                         )
-                        .align_x(Horizontal::Center);
+                        .align_x(Alignment::Center);
                         content = content.push(col);
                     }
                 }
@@ -938,7 +931,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                             icon::from_name(wifi_icon(ap.strength))
                                 .size(16)
                                 .symbolic(true),
-                            text::body(&ap.ssid).align_y(Vertical::Center)
+                            text::body(&ap.ssid).align_y(Alignment::Center)
                         ]
                         .align_y(Alignment::Center)
                         .spacing(12),

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -16,7 +16,6 @@ use cosmic::{
         widget::{column, row},
         window, Alignment, Length, Limits, Subscription,
     },
-    iced_core::alignment::Horizontal,
     iced_widget::{scrollable, Column},
     theme,
     widget::{button, container, divider, icon, text},
@@ -389,8 +388,7 @@ impl cosmic::Application for Notifications {
                 ]
                 .align_x(Alignment::Center)
             )
-            .width(Length::Fill)
-            .align_x(Horizontal::Center)]
+            .center_x(Length::Fill)]
             .padding([8, 0])
             .spacing(12)
         } else {
@@ -401,7 +399,7 @@ impl cosmic::Application for Notifications {
                         .on_press(Message::ClearAll(None)),
                 )
                 .width(Length::Fill)
-                .align_x(Horizontal::Right)
+                .align_x(Alignment::End)
                 .into(),
             );
             for c in self.cards.iter().rev() {

--- a/cosmic-applet-notifications/src/subscriptions/dbus.rs
+++ b/cosmic-applet-notifications/src/subscriptions/dbus.rs
@@ -1,8 +1,6 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::ops::Sub;
-
 use crate::subscriptions::freedesktop_proxy::NotificationsProxy;
 use cosmic::{
     iced::futures::{self, SinkExt},

--- a/cosmic-applet-power/src/lib.rs
+++ b/cosmic-applet-power/src/lib.rs
@@ -9,7 +9,6 @@ use cosmic::{
     cosmic_theme::Spacing,
     iced::{
         self,
-        alignment::{Horizontal, Vertical},
         event::{
             listen_with,
             wayland::{self, LayerEvent},
@@ -372,16 +371,10 @@ impl cosmic::Application for Power {
             }
 
             Element::from(
-                mouse_area(
-                    container(dialog)
-                        .align_x(Horizontal::Center)
-                        .align_y(Vertical::Center)
-                        .width(Length::Fill)
-                        .height(Length::Fill),
-                )
-                .on_press(Message::Cancel)
-                .on_right_press(Message::Cancel)
-                .on_middle_press(Message::Cancel),
+                mouse_area(container(dialog).center(Length::Fill))
+                    .on_press(Message::Cancel)
+                    .on_right_press(Message::Cancel)
+                    .on_middle_press(Message::Cancel),
             )
         } else {
             //panic!("no view for window {}", id.0)

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -17,7 +17,6 @@ use cosmic::{
         widget::{column, row, vertical_space},
         window, Alignment, Length, Rectangle, Subscription,
     },
-    iced_core::alignment::{Horizontal, Vertical},
     iced_widget::{horizontal_rule, Column},
     theme,
     widget::{
@@ -613,7 +612,7 @@ impl cosmic::Application for Window {
                 text(self.format(weekday_bag, &day_iter.next().unwrap()))
                     .size(12)
                     .width(Length::Fixed(36.0))
-                    .align_x(Horizontal::Center),
+                    .align_x(Alignment::Center),
             );
 
             first_day_of_week = first_day_of_week.succ();
@@ -669,14 +668,10 @@ fn date_button(day: u32, is_month: bool, is_day: bool) -> Button<'static, Messag
         button::ButtonClass::Text
     };
 
-    let button = button::custom(
-        text::body(format!("{day}"))
-            .align_x(Horizontal::Center)
-            .align_y(Vertical::Center),
-    )
-    .class(style)
-    .height(Length::Fixed(36.0))
-    .width(Length::Fixed(36.0));
+    let button = button::custom(text::body(format!("{day}")).center())
+        .class(style)
+        .height(Length::Fixed(36.0))
+        .width(Length::Fixed(36.0));
 
     if is_month {
         button.on_press(Message::SelectDay(day))

--- a/cosmic-applet-workspaces/src/components/app.rs
+++ b/cosmic-applet-workspaces/src/components/app.rs
@@ -5,10 +5,10 @@ use cctk::sctk::reexports::{calloop::channel::SyncSender, client::backend::Objec
 use cosmic::{
     applet::cosmic_panel_config::PanelAnchor,
     iced::{
-        alignment::{Horizontal, Vertical},
         event,
         mouse::{self, ScrollDelta},
         widget::{button, column, row},
+        Alignment,
         Event::Mouse,
         Length, Limits, Subscription,
     },
@@ -190,15 +190,15 @@ impl cosmic::Application for IcedWorkspacesApplet {
             };
 
             let content = row!(content, vertical_space().height(Length::Fixed(height)))
-                .align_y(cosmic::iced::Alignment::Center);
+                .align_y(Alignment::Center);
 
             let content = column!(content, horizontal_space().width(Length::Fixed(width)))
-                .align_x(cosmic::iced::Alignment::Center);
+                .align_x(Alignment::Center);
 
             let btn = button(
                 container(content)
-                    .align_x(Horizontal::Center)
-                    .align_y(Vertical::Center),
+                    .align_x(Alignment::Center)
+                    .align_y(Alignment::Center),
             )
             .padding(if horizontal {
                 [0, self.core.applet.suggested_padding(true)]


### PR DESCRIPTION
Makes the App Tray context menu use `@radius_s`, and also increases the truncate limit for the now playing title and artist in the audio applet.
The border at the corners still looks slightly weird with the Round style. Might be some rendering artifact.

Also includes some minor code cleanup.