### PR TITLE
fix: use `on_press_down` to toggle time applet

### DIFF
--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -550,7 +550,7 @@ impl cosmic::Application for Window {
         } else {
             [self.core.applet.suggested_padding(true), 0]
         })
-        .on_press(Message::TogglePopup)
+        .on_press_down(Message::TogglePopup)
         .class(cosmic::theme::Button::AppletIcon);
 
         autosize::autosize(


### PR DESCRIPTION
Fix regression from #568 