### PR TITLE
fix: a11y applet desktop file validation

### DIFF
--- a/cosmic-applet-a11y/data/com.system76.CosmicAppletA11y.desktop
+++ b/cosmic-applet-a11y/data/com.system76.CosmicAppletA11y.desktop
@@ -11,8 +11,5 @@ StartupNotify=true
 NoDisplay=true
 X-CosmicApplet=true
 # Indicates that the auto-hover click should go to the "end" of the hover popup
-X-CosmicHoverPopup=Center
-X-OverflowPriority=10
-X-CosmicApplet=true
 X-CosmicHoverPopup=Auto
 X-OverflowPriority=10


### PR DESCRIPTION
This commit fixes errors when using `desktop-file-validate` on the a11y applet.

Question: @wash2  I removed a duplicate keyword that had =Auto and =Center. Which one is the correct one to remove?