### PR TITLE
fix(inputs): Use env vars and extra layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7602,9 +7602,9 @@ dependencies = [
 
 [[package]]
 name = "xkb-data"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294a599fc9e6a43c9f44f5d6c560b89fd751be413717442b31c17fa367d3c764"
+checksum = "ddbaf7dc9e1a13a8a6dd4beb794d463ae16d150879092c757f4aea2d17b81305"
 dependencies = [
  "serde",
  "serde-xml-rs",

--- a/cosmic-applet-input-sources/Cargo.toml
+++ b/cosmic-applet-input-sources/Cargo.toml
@@ -18,4 +18,4 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 serde = { version = "1.0.197", features = ["derive"] }
 once_cell = "1.19.0"
-xkb-data = "0.1.0"
+xkb-data = "0.2"

--- a/cosmic-applet-input-sources/src/lib.rs
+++ b/cosmic-applet-input-sources/src/lib.rs
@@ -12,7 +12,7 @@ mod window;
 pub fn run() -> cosmic::iced::Result {
     localize::localize();
 
-    let layouts = match xkb_data::keyboard_layouts() {
+    let layouts = match xkb_data::all_keyboard_layouts() {
         Ok(layouts) => layouts,
         Err(why) => {
             tracing::error!("could not get keyboard layouts data: {:?}", why);

--- a/cosmic-applet-tiling/Cargo.toml
+++ b/cosmic-applet-tiling/Cargo.toml
@@ -19,4 +19,4 @@ tokio = { version = "1.36.0", features = ["sync", "rt"] }
 tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-xkb-data = "0.1.0"
+xkb-data = "0.2"


### PR DESCRIPTION
Closes: #725

The inputs applet uses an outdated `xkb-data` which causes some configs to fail which in turn leads to an empty list.

See: https://github.com/lilyinstarlight/nixos-cosmic/issues/74#issuecomment-2353273156