### PR TITLE
[App Tray] Fix toplevel preview styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "cosmic-notifications-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-notifications#76c237b0509ea6f724076db2195a7fab6942f33c"
+source = "git+https://github.com/pop-os/cosmic-notifications#df1d1de03468b0be9f0c971d0edd0b1938203a4e"
 dependencies = [
  "cosmic-config",
  "serde",
@@ -1478,7 +1478,7 @@ dependencies = [
 [[package]]
 name = "cosmic-notifications-util"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-notifications#76c237b0509ea6f724076db2195a7fab6942f33c"
+source = "git+https://github.com/pop-os/cosmic-notifications#df1d1de03468b0be9f0c971d0edd0b1938203a4e"
 dependencies = [
  "bytemuck",
  "fast_image_resize",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#fcaaeaf3b9dbaea7458b69de5742a4ae97909d73"
+source = "git+https://github.com/pop-os/cosmic-panel#4a777bc4f6c77b409d1fd3aa5b09ecfb1c25ded1"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#fcaaeaf3b9dbaea7458b69de5742a4ae97909d73"
+source = "git+https://github.com/pop-os/cosmic-panel#4a777bc4f6c77b409d1fd3aa5b09ecfb1c25ded1"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -40,7 +40,7 @@ use cosmic::{
         rectangle_tracker::{rectangle_tracker_subscription, RectangleTracker, RectangleUpdate},
         svg, text, DndDestination, Image,
     },
-    Element, Task,
+    Apply, Element, Task,
 };
 use cosmic_app_list_config::{AppListConfig, APP_ID};
 use cosmic_protocols::{
@@ -442,12 +442,11 @@ where
         container(
             column![
                 container(if let Some(img) = img {
-                    Element::from(
-                        Image::new(Handle::from_rgba(img.width, img.height, img.img.clone()))
-                            .width(Length::Fill)
-                            .height(Length::Fill)
-                            .content_fit(cosmic::iced_core::ContentFit::Contain),
-                    )
+                    Element::from(Image::new(Handle::from_rgba(
+                        img.width,
+                        img.height,
+                        img.img.clone(),
+                    )))
                 } else {
                     Image::new(Handle::from_rgba(1, 1, vec![0, 0, 0, 255])).into()
                 })
@@ -462,9 +461,11 @@ where
                     }
                 })))
                 .padding(border as u16)
-                .height(Length::Fill)
-                .width(Length::Fill),
-                container(text::body(title).align_x(Alignment::Center)).center_x(Length::Fill),
+                .height(Length::Shrink)
+                .width(Length::Shrink)
+                .apply(container)
+                .center_y(Length::Fixed(90.0)),
+                text::body(title),
             ]
             .spacing(4)
             .align_x(Alignment::Center),
@@ -479,10 +480,14 @@ where
 }
 
 fn window_menu_style(selected: bool) -> cosmic::theme::Button {
+    let radius = theme::active()
+        .cosmic()
+        .radius_m()
+        .map(|x| if x < 8.0 { x } else { x - 4.0 });
+
     Button::Custom {
         active: Box::new(move |focused, theme| {
             let a = button::Catalog::active(theme, focused, selected, &Button::AppletMenu);
-            let rad_s = theme.cosmic().corner_radii.radius_s;
             button::Style {
                 background: if selected {
                     Some(Background::Color(
@@ -491,39 +496,33 @@ fn window_menu_style(selected: bool) -> cosmic::theme::Button {
                 } else {
                     a.background
                 },
-                border_radius: rad_s.into(),
+                border_radius: radius.into(),
                 outline_width: 0.0,
                 ..a
             }
         }),
         hovered: Box::new(move |focused, theme| {
             let focused = selected || focused;
-            let rad_s = theme.cosmic().corner_radii.radius_s;
-
             let text = button::Catalog::hovered(theme, focused, focused, &Button::AppletMenu);
             button::Style {
-                border_radius: rad_s.into(),
+                border_radius: radius.into(),
                 outline_width: 0.0,
                 ..text
             }
         }),
-        disabled: Box::new(|theme| {
-            let rad_s = theme.cosmic().corner_radii.radius_s;
-
+        disabled: Box::new(move |theme| {
             let text = button::Catalog::disabled(theme, &Button::AppletMenu);
             button::Style {
-                border_radius: rad_s.into(),
+                border_radius: radius.into(),
                 outline_width: 0.0,
                 ..text
             }
         }),
         pressed: Box::new(move |focused, theme| {
             let focused = selected || focused;
-            let rad_s = theme.cosmic().corner_radii.radius_s;
-
             let text = button::Catalog::pressed(theme, focused, focused, &Button::AppletMenu);
             button::Style {
-                border_radius: rad_s.into(),
+                border_radius: radius.into(),
                 outline_width: 0.0,
                 ..text
             }


### PR DESCRIPTION
Fixes #456.
Also makes the border around the screencopy follow the edges of the image, rather than having a fixed size.
![screenshot-2025-01-04-20-04-34](https://github.com/user-attachments/assets/35368518-2c29-4982-bdbc-60c784e738ab)
