### PR TITLE
fix(battery): default to the balanced profile with PPD backend

### DIFF
--- a/cosmic-applet-battery/src/backend/mod.rs
+++ b/cosmic-applet-battery/src/backend/mod.rs
@@ -73,9 +73,8 @@ pub async fn get_power_profile(daemon: Backend<'_>) -> Result<Power> {
             let power = ppd.active_profile().await?;
             match power.as_str() {
                 "power-saver" => Ok(Power::Battery),
-                "balanced" => Ok(Power::Balanced),
                 "performance" => Ok(Power::Performance),
-                _ => panic!("Unknown power profile: {}", power),
+                _ => Ok(Power::Balanced),
             }
         }
     }


### PR DESCRIPTION
TuneD provides a compatibility daemon (tuned-ppd) which replaces power-profiles-daemon in Fedora 41 [1]. However, the new daemon can report an "unknown" profile in case the user manipulates with underlying TuneD profiles directly; see [2].

Before this change, the "unknown" profile makes the battery applet panic. With this change, the applet reports the balanced profile. This is in line with the behavior of cosmic-settings [3].

[1] https://pagure.io/fesco/issue/3222
[2] https://github.com/redhat-performance/tuned/pull/669
[3] https://github.com/pop-os/cosmic-settings/blob/6f05e9e/cosmic-settings/src/pages/power/backend/mod.rs#L65