### PR TITLE
Update for toplevel-info cctk changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=29ab323#29ab32305c6457fccf0728caaaf79fcac4cca665"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=178eb0b#178eb0b14a0e5c192f64f6dee6c40341a8e5ee51"
 dependencies = [
  "cosmic-protocols",
  "libc",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=29ab323#29ab32305c6457fccf0728caaaf79fcac4cca665"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=178eb0b#178eb0b14a0e5c192f64f6dee6c40341a8e5ee51"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2961,7 +2961,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "futures",
  "iced_core",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.8.0",
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3877,7 +3877,7 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#f59eb77252d1730319d532fc0a0c50ce860edd9d"
+source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
 dependencies = [
  "apply",
  "ashpd 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0.81"
-cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit", rev = "29ab323" }
+cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit", rev = "178eb0b" }
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", default-features = false, features = [
     "client",
-], rev = "29ab323" }
+], rev = "178eb0b" }
 cosmic-settings-subscriptions = { git = "https://github.com/pop-os/cosmic-settings-subscriptions" }
 # cosmic-settings-subscriptions = { path = "../cosmic-settings-subscriptions" }
 

--- a/cosmic-app-list/src/wayland_subscription.rs
+++ b/cosmic-app-list/src/wayland_subscription.rs
@@ -6,15 +6,13 @@ use cctk::{
     sctk::{output::OutputInfo, reexports::calloop},
     toplevel_info::ToplevelInfo,
     wayland_client::protocol::wl_output::WlOutput,
+    wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
 };
 use cosmic::{
     iced::{self, stream, Subscription},
     iced_core::image::Bytes,
 };
-use cosmic_protocols::{
-    toplevel_info::v1::client::zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
-    workspace::v1::client::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
-};
+use cosmic_protocols::workspace::v1::client::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1;
 use image::EncodableLayout;
 
 use futures::{
@@ -120,14 +118,14 @@ pub enum WaylandUpdate {
         exec: String,
         gpu_idx: Option<usize>,
     },
-    Image(ZcosmicToplevelHandleV1, WaylandImage),
+    Image(ExtForeignToplevelHandleV1, WaylandImage),
 }
 
 #[derive(Clone, Debug)]
 pub enum ToplevelUpdate {
-    Add(ZcosmicToplevelHandleV1, ToplevelInfo),
-    Update(ZcosmicToplevelHandleV1, ToplevelInfo),
-    Remove(ZcosmicToplevelHandleV1),
+    Add(ToplevelInfo),
+    Update(ToplevelInfo),
+    Remove(ExtForeignToplevelHandleV1),
 }
 
 #[derive(Clone, Debug)]
@@ -145,12 +143,12 @@ pub enum WaylandRequest {
         exec: String,
         gpu_idx: Option<usize>,
     },
-    Screencopy(ZcosmicToplevelHandleV1),
+    Screencopy(ExtForeignToplevelHandleV1),
 }
 
 #[derive(Debug, Clone)]
 pub enum ToplevelRequest {
-    Activate(ZcosmicToplevelHandleV1),
-    Minimize(ZcosmicToplevelHandleV1),
-    Quit(ZcosmicToplevelHandleV1),
+    Activate(ExtForeignToplevelHandleV1),
+    Minimize(ExtForeignToplevelHandleV1),
+    Quit(ExtForeignToplevelHandleV1),
 }

--- a/cosmic-applet-minimize/src/wayland_subscription.rs
+++ b/cosmic-applet-minimize/src/wayland_subscription.rs
@@ -7,12 +7,14 @@
 //! Source: `Interface '/org/freedesktop/UPower/KbdBacklight' from service 'org.freedesktop.UPower' on system bus`.
 use cctk::{sctk::reexports::calloop, toplevel_info::ToplevelInfo};
 use cosmic::{
-    cctk::{self, cosmic_protocols},
+    cctk::{
+        self,
+        wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+    },
     iced::{self, Subscription},
     iced_core::image::Bytes,
     iced_futures::{futures, stream},
 };
-use cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1;
 use futures::SinkExt;
 use image::EncodableLayout;
 use std::fmt::Debug;
@@ -45,7 +47,7 @@ pub enum WaylandUpdate {
     Init(calloop::channel::Sender<WaylandRequest>),
     Finished,
     Toplevel(ToplevelUpdate),
-    Image(ZcosmicToplevelHandleV1, WaylandImage),
+    Image(ExtForeignToplevelHandleV1, WaylandImage),
 }
 
 #[derive(Debug, Clone)]
@@ -73,9 +75,9 @@ impl AsRef<[u8]> for WaylandImage {
 
 #[derive(Clone, Debug)]
 pub enum ToplevelUpdate {
-    Add(ZcosmicToplevelHandleV1, ToplevelInfo),
-    Update(ZcosmicToplevelHandleV1, ToplevelInfo),
-    Remove(ZcosmicToplevelHandleV1),
+    Add(ToplevelInfo),
+    Update(ToplevelInfo),
+    Remove(ExtForeignToplevelHandleV1),
 }
 
 #[derive(Clone, Debug)]
@@ -85,5 +87,5 @@ pub enum WaylandRequest {
 
 #[derive(Debug, Clone)]
 pub enum ToplevelRequest {
-    Activate(ZcosmicToplevelHandleV1),
+    Activate(ExtForeignToplevelHandleV1),
 }

--- a/cosmic-applet-tiling/src/wayland.rs
+++ b/cosmic-applet-tiling/src/wayland.rs
@@ -11,13 +11,11 @@ use cctk::{
     },
     toplevel_info::{ToplevelInfoHandler, ToplevelInfoState},
     wayland_client::WEnum,
+    wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
     workspace::{WorkspaceHandler, WorkspaceState},
 };
 use cosmic::iced::futures;
-use cosmic_protocols::{
-    toplevel_info::v1::client::zcosmic_toplevel_handle_v1,
-    workspace::v1::client::zcosmic_workspace_handle_v1::{self, TilingState},
-};
+use cosmic_protocols::workspace::v1::client::zcosmic_workspace_handle_v1::{self, TilingState};
 use futures::{channel::mpsc, executor::block_on, SinkExt};
 use std::{
     collections::HashSet,
@@ -274,7 +272,7 @@ impl ToplevelInfoHandler for State {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        toplevel: &ExtForeignToplevelHandleV1,
     ) {
         let Some(w) = self
             .toplevel_info_state
@@ -290,7 +288,7 @@ impl ToplevelInfoHandler for State {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        toplevel: &ExtForeignToplevelHandleV1,
     ) {
         let Some(w) = self
             .toplevel_info_state
@@ -306,7 +304,7 @@ impl ToplevelInfoHandler for State {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        _toplevel: &ExtForeignToplevelHandleV1,
     ) {
     }
 }


### PR DESCRIPTION
Requires pop-os/cosmic-protocols#49.

The duplication between applets, and
cosmic-workspace/xdg-desktop-portal-cosmic, should be moved to shared abstractions. But that can be done after moving to `ext-image-copy-capture`.