### PR TITLE
Bumping freedesktop-desktop-entry to 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,24 +750,24 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cached"
-version = "0.54.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
+checksum = "b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14"
 dependencies = [
  "ahash",
  "cached_proc_macro",
  "cached_proc_macro_types",
  "hashbrown 0.14.5",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "web-time",
 ]
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+checksum = "673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -1078,7 +1078,7 @@ dependencies = [
  "cosmic-app-list-config",
  "cosmic-client-toolkit",
  "cosmic-protocols",
- "freedesktop-desktop-entry 0.7.7",
+ "freedesktop-desktop-entry 0.7.8",
  "futures",
  "i18n-embed",
  "i18n-embed-fl",
@@ -1507,7 +1507,7 @@ name = "cosmic-panel-button"
 version = "0.1.0"
 dependencies = [
  "cosmic-config",
- "freedesktop-desktop-entry 0.7.7",
+ "freedesktop-desktop-entry 0.7.8",
  "libcosmic",
  "once_cell",
  "serde",
@@ -2148,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2464,17 +2464,15 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016f6ee9509f11c985aa402451f4ee900d1fafeb501a4c3d734ebecfc1130e05"
+checksum = "e6a4cdc5571033a6a329b9e8a8430594d1e3b60f42bb79e79686cadef34740ea"
 dependencies = [
  "cached",
- "dirs 5.0.1",
  "gettext-rs",
  "log",
  "memchr",
  "strsim 0.11.1",
- "textdistance",
  "thiserror 2.0.11",
  "xdg",
 ]
@@ -3948,7 +3946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5532,7 +5530,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6057,7 +6055,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6068,12 +6066,6 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textdistance"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa672c55ab69f787dbc9126cc387dbe57fdd595f585e4524cf89018fa44ab819"
 
 [[package]]
 name = "thiserror"
@@ -6996,7 +6988,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ tracing-log = "0.2.0"
 tokio = { version = "1.43.0", features = ["full"] }
 cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 serde = { version = "1.0.217", features = ["derive"] }
-freedesktop-desktop-entry = "0.7.7"
+freedesktop-desktop-entry = "0.7.8"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
this specifically allows the icon & actions to show in `cosmic-app-list` for librewolf - sorry for the spam!