### PR TITLE
[BUGFIX] Made it so that when dragging active apps out of the dock they are added to active list

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -878,6 +878,9 @@ impl cosmic::Application for CosmicAppList {
                                 &t.original_app_id,
                                 &Config::new(APP_ID, AppListConfig::VERSION).unwrap(),
                             );
+                            if !t.toplevels.is_empty() {
+                                self.active_list.push(t.clone());
+                            }
                             Some((true, t))
                         } else {
                             None


### PR DESCRIPTION
Original Behavior: When dragging an active app out of the dock it was not added to the active list. This meant if the app was removed from the dock this way it would not be appended to the active app list which led to issues with the dock losing track of open instances of a given application. See here: https://github.com/pop-os/cosmic-panel/issues/247#issuecomment-2701097706

The Fix: When initiating a drag the app is added to the active list if it is an active application. This is similar to how active apps are added to the pinned list and aren't removed from the active list until after the drag is finished.

Notes: While this solution may be deemed to be fine. It appears in the source code that the behavior of adding unpinned apps via drag to the active list was supposed to work via the DragFinished Message. In my testing this function is never called and I believe there may be a different underlying issue with how the message is handled if the desire is to keep with the intent of the original code.