### PR TITLE
fix: password hide/show on wifi authentication

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -992,7 +992,6 @@ impl cosmic::Application for CosmicNetworkApplet {
                         .on_input(Message::Password)
                         .on_paste(Message::Password)
                         .on_submit(Message::SubmitPassword)
-                        .password(),
                     ]
                     .push_maybe(
                         access_point


### PR DESCRIPTION
This fixes the issue described here https://github.com/pop-os/cosmic-applets/issues/805

The .password() attribute on the secure_input was forcing the password to always be hidden regardless of setting. Removing this fixes the issue.