### PR TITLE
fix: prevent time remaining showing 0 after unplugging

### DIFF
--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -504,16 +504,18 @@ impl cosmic::Application for CosmicBatteryApplet {
         } = theme::active().cosmic().spacing;
 
         let name = text::body(fl!("battery"));
-        let description = text::caption(if !self.on_battery {
-            format!("{:.0}%", self.battery_percent)
-        } else {
-            format!(
-                "{} {} ({:.0}%)",
-                format_duration(self.time_remaining),
-                fl!("until-empty"),
-                self.battery_percent
-            )
-        });
+        let description = text::caption(
+            if !self.on_battery || self.time_remaining == Duration::from_secs(0u64) {
+                format!("{:.0}%", self.battery_percent)
+            } else {
+                format!(
+                    "{} {} ({:.0}%)",
+                    format_duration(self.time_remaining),
+                    fl!("until-empty"),
+                    self.battery_percent
+                )
+            },
+        );
 
         let mut content = vec![
             padded_control(


### PR DESCRIPTION
Time remaining is briefly 0 after unplugging until the applet can calculate the remaining time. This fix prevents the time remaining showing if it's at 0 as this would only be just after unplugging (which is incorrect) or when the laptop is already dead.