### PR TITLE
Fix time applet calendar alignment

### DIFF
--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -617,7 +617,7 @@ impl cosmic::Application for Window {
             calender = calender.push(
                 text(self.format(weekday_bag, &day_iter.next().unwrap()))
                     .size(12)
-                    .width(Length::Fixed(36.0))
+                    .width(Length::Fixed(44.0))
                     .align_x(Alignment::Center),
             );
 
@@ -678,8 +678,8 @@ fn date_button(day: u32, is_month: bool, is_day: bool, is_today: bool) -> Button
 
     let button = button::custom(text::body(format!("{day}")).center())
         .class(style)
-        .height(Length::Fixed(36.0))
-        .width(Length::Fixed(36.0));
+        .height(Length::Fixed(44.0))
+        .width(Length::Fixed(44.0));
 
     if is_month {
         button.on_press(Message::SelectDay(day))


### PR DESCRIPTION
The calendar in the time applet is misaligned.

![image](https://github.com/user-attachments/assets/f7469d6b-8194-42f7-9c9d-c0ede5b8b7a1)

This PR fixes it.

![image](https://github.com/user-attachments/assets/e8a8daae-c701-4e82-b612-6a2abb90ae58)
