### PR TITLE
Fix: Duplicate translation for cosmic-applet-status-area

### DIFF
--- a/cosmic-applet-status-area/data/com.system76.CosmicAppletStatusArea.desktop
+++ b/cosmic-applet-status-area/data/com.system76.CosmicAppletStatusArea.desktop
@@ -3,7 +3,6 @@ Name=Notifications Tray
 Name[hu]=Értesítési terület
 Name[nl]=Meldingsbeheerder
 Name[pl]=Zasobnik powiadomień
-Name[pt]=Área de estado do applet Cosmic
 Name[pt]=Área de Notificações
 Type=Application
 Exec=cosmic-applet-status-area


### PR DESCRIPTION
When running desktop-file-validate:

```
/builddir/build/BUILD/cosmic-applets-1.0.0_alpha.6_git20250408.2573eb7-build/BUILDROOT/usr/share/applications/com.system76.CosmicAppletStatusArea.desktop: error: file contains multiple keys named "Name[pt]" in group "Desktop Entry"
```

Fixes building for Fedora, as we use desktop-file-validate for checking desktop files.

Ref: https://github.com/pop-os/cosmic-applets/commit/2573eb7545e1619a9007c691df3dde0caa8edea9

I figured since this is the translation that was recently added, that the intent is to keep the newer one.