### PR TITLE
fix: Remove duplicate portuguese entries from desktop entries

### DIFF
--- a/cosmic-panel-app-button/data/com.system76.CosmicPanelAppButton.desktop
+++ b/cosmic-panel-app-button/data/com.system76.CosmicPanelAppButton.desktop
@@ -4,7 +4,6 @@ Name[es]=Botón de biblioteca de aplicaciones del panel Cosmic
 Name[ja]=Cosmicパネルのアップライブラリーボタン
 Name[ko]=코스믹 패널 앱 라이브러리 단추
 Name[pl]=Przycisk biblioteki aplikacji
-Name[pt]=Botão da biblioteca de aplicações do painel Cosmic
 Name[ru]=Кнопка библиотеки приложений на панели Cosmic
 Name[hu]=Alkalmazáskönyvtár gomb
 Name[pt_BR]=Biblioteca de aplicativos

--- a/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
+++ b/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
@@ -1,7 +1,6 @@
 [Desktop Entry]
 Name=Workspaces Button
 Name[pl]=Przycisk przestrzeni roboczych
-Name[pt]=Botão de áreas de trabalho do painel Cosmic
 Name[hu]=Munkaterületek gomb
 Name[pt]=Botão de áreas de trabalho
 Type=Application


### PR DESCRIPTION
There were a few other duplicate [pt] translations that I found from https://github.com/pop-os/cosmic-applets/pull/894

Maybe it's worth having desktop-file-validate as part of a CI action, I dunno
