### PR TITLE
perf(bluetooth): reduce CPU usage and improve async performance

### DIFF
--- a/cosmic-applet-bluetooth/src/lib.rs
+++ b/cosmic-applet-bluetooth/src/lib.rs
@@ -8,6 +8,7 @@ mod localize;
 
 use crate::localize::localize;
 
+#[inline]
 pub fn run() -> cosmic::iced::Result {
     localize();
     app::run()

--- a/cosmic-applet-bluetooth/src/localize.rs
+++ b/cosmic-applet-bluetooth/src/localize.rs
@@ -34,6 +34,7 @@ macro_rules! fl {
 }
 
 // Get the `Localizer` to be used for localizing this library.
+#[inline]
 pub fn localizer() -> Box<dyn Localizer> {
     Box::from(DefaultLocalizer::new(&*LANGUAGE_LOADER, &Localizations))
 }


### PR DESCRIPTION
Further improvement for #896

- Moves interval tick within `listen_bluetooth_power_changes` loop to throttle device change events
- Prevent double build of `build_device_list` in `listen_bluetooth_power_changes`
- Reuse Vec in `build_device_list`
- `BluerDevice` now directly stores only the properties it needs
- `BluerDevice` properties are fetched concurrently in a `join!()`
- `BluerDevice`s are also fetched concurrently from their addresses with `FuturesUnordered`
- Deduplicate bluer_state method with bluer_state function.
- Mark functions as inline/never

