### PR TITLE
App tray: add fallback logic for non-steam games opened in proton

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -1079,7 +1079,31 @@ impl cosmic::Application for CosmicAppList {
                                                     "could not find desktop entry for app"
                                                 );
 
-                                                fde::DesktopEntry::from_appid(info.app_id.clone())
+                                                let mut fallback_entry =
+                                                    fde::DesktopEntry::from_appid(
+                                                        info.app_id.clone()
+                                                    );
+
+                                                // proton opens games as steam_app_X, where X is either
+                                                // the steam appid or "default". games with a steam appid
+                                                // can have a desktop entry generated elsewhere; this
+                                                // specifically handles non-steam games opened
+                                                // under proton
+                                                if info.app_id == "steam_app_default" {
+                                                    for entry in &self.desktop_entries {
+                                                        let localised_name = entry
+                                                            .name(&self.locales)
+                                                            .map(|x| x.to_string())
+                                                            .unwrap_or_default();
+
+                                                        if localised_name == info.title {
+                                                            fallback_entry = entry.clone();
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+
+                                                fallback_entry
                                             }
                                         }
                                     }

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -1096,7 +1096,12 @@ impl cosmic::Application for CosmicAppList {
                                                             .map(|x| x.to_string())
                                                             .unwrap_or_default();
 
-                                                        if localised_name == info.title {
+                                                        if localised_name == info.title
+                                                            && entry
+                                                                .categories()
+                                                                .unwrap_or_default()
+                                                                .contains(&"Game")
+                                                        {
                                                             fallback_entry = entry.clone();
                                                             break;
                                                         }

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -1081,7 +1081,7 @@ impl cosmic::Application for CosmicAppList {
 
                                                 let mut fallback_entry =
                                                     fde::DesktopEntry::from_appid(
-                                                        info.app_id.clone()
+                                                        info.app_id.clone(),
                                                     );
 
                                                 // proton opens games as steam_app_X, where X is either

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -584,6 +584,10 @@ fn find_desktop_entries<'a>(
 impl CosmicAppList {
     // Cache all desktop entries to use when new apps are added to the dock.
     fn update_desktop_entries(&mut self) {
+        let paths = fde::default_paths();
+        for path in paths {
+            println!("{:?}", path);
+        }
         self.desktop_entries = fde::Iter::new(fde::default_paths())
             .filter_map(|p| fde::DesktopEntry::from_path(p, Some(&self.locales)).ok())
             .collect::<Vec<_>>();
@@ -1089,7 +1093,11 @@ impl cosmic::Application for CosmicAppList {
                                                 // can have a desktop entry generated elsewhere; this
                                                 // specifically handles non-steam games opened
                                                 // under proton
-                                                if info.app_id == "steam_app_default" {
+                                                // in addition, try to match WINE entries who have its
+                                                // appid = the full name of the executable (incl. .exe)
+                                                if info.app_id == "steam_app_default"
+                                                    || info.app_id.ends_with(".exe")
+                                                {
                                                     for entry in &self.desktop_entries {
                                                         let localised_name = entry
                                                             .name(&self.locales)

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -584,10 +584,6 @@ fn find_desktop_entries<'a>(
 impl CosmicAppList {
     // Cache all desktop entries to use when new apps are added to the dock.
     fn update_desktop_entries(&mut self) {
-        let paths = fde::default_paths();
-        for path in paths {
-            println!("{:?}", path);
-        }
         self.desktop_entries = fde::Iter::new(fde::default_paths())
             .filter_map(|p| fde::DesktopEntry::from_path(p, Some(&self.locales)).ok())
             .collect::<Vec<_>>();

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -1091,21 +1091,27 @@ impl cosmic::Application for CosmicAppList {
                                                 // under proton
                                                 // in addition, try to match WINE entries who have its
                                                 // appid = the full name of the executable (incl. .exe)
-                                                if info.app_id == "steam_app_default"
-                                                    || info.app_id.ends_with(".exe")
-                                                {
+                                                let is_proton_game =
+                                                    info.app_id == "steam_app_default";
+                                                if is_proton_game || info.app_id.ends_with(".exe") {
                                                     for entry in &self.desktop_entries {
                                                         let localised_name = entry
                                                             .name(&self.locales)
                                                             .map(|x| x.to_string())
                                                             .unwrap_or_default();
 
-                                                        if localised_name == info.title
-                                                            && entry
-                                                                .categories()
-                                                                .unwrap_or_default()
-                                                                .contains(&"Game")
-                                                        {
+                                                        if localised_name == info.title {
+                                                            // if this is a proton game, we only want
+                                                            // to look for game entries
+                                                            if is_proton_game
+                                                                && !entry
+                                                                    .categories()
+                                                                    .unwrap_or_default()
+                                                                    .contains(&"Game")
+                                                            {
+                                                                continue;
+                                                            }
+
                                                             fallback_entry = entry.clone();
                                                             break;
                                                         }


### PR DESCRIPTION
**changes tl;dr**
- proton opens games with an appid of `steam_app_X` where `X` is either the steam appid or `default`
- since `steam_app_default` is a generic/catch-all, this adds some logic to capture an entry based off of its localised name
- this is seemingly the only way to properly detect these games without some overhauls to proton/game launchers

with fix:
![image](https://github.com/user-attachments/assets/a47cdfac-4db5-4b2b-a96d-8005657f5aa0)

without:
![image](https://github.com/user-attachments/assets/a984f0cf-c657-4cb2-b344-173fd0efb72b)
