### PR TITLE
fix text disappearing when moving sliders

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -770,8 +770,7 @@ impl cosmic::Application for Audio {
                         slider(0.0..=150.0, self.output_volume, Message::SetOutputVolume)
                             .width(Length::FillPortion(5))
                             .breakpoints(&[100.]),
-                        text(&self.output_volume_text)
-                            .size(16)
+                        container(text(&self.output_volume_text).size(16))
                             .width(Length::FillPortion(1))
                             .align_x(Alignment::End)
                     ]
@@ -792,8 +791,7 @@ impl cosmic::Application for Audio {
                         slider(0.0..=150.0, self.input_volume, Message::SetInputVolume)
                             .width(Length::FillPortion(5))
                             .breakpoints(&[100.]),
-                        text(&self.input_volume_text)
-                            .size(16)
+                        container(text(&self.input_volume_text).size(16))
                             .width(Length::FillPortion(1))
                             .align_x(Alignment::End)
                     ]

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -43,6 +43,7 @@ use cosmic_settings_subscriptions::{
 use cosmic_time::{anim, chain, id, once_cell::sync::Lazy, Instant, Timeline};
 
 use std::{collections::HashMap, path::PathBuf, time::Duration};
+use cosmic::widget::text_input;
 use tokio::sync::mpsc::UnboundedSender;
 
 // XXX improve
@@ -632,11 +633,13 @@ impl cosmic::Application for CosmicBatteryApplet {
                                 Message::SetScreenBrightness
                             )
                             .on_release(Message::ReleaseScreenBrightness),
-                            text(format!(
-                                "{:.0}%",
-                                self.screen_brightness_percent().unwrap_or(0.) * 100.
-                            ))
-                            .size(16)
+                            container(
+                                text(format!(
+                                    "{:.0}%",
+                                    self.screen_brightness_percent().unwrap_or(0.) * 100.
+                                ))
+                                .size(16)
+                            )
                             .width(Length::Fixed(40.0))
                             .align_x(Alignment::End)
                         ]
@@ -661,11 +664,13 @@ impl cosmic::Application for CosmicBatteryApplet {
                                 Message::SetKbdBrightness
                             )
                             .on_release(Message::ReleaseKbdBrightness),
-                            text(format!(
-                                "{:.0}%",
-                                100. * kbd_brightness as f64 / max_kbd_brightness as f64
-                            ))
-                            .size(16)
+                            container(
+                                text(format!(
+                                    "{:.0}%",
+                                    100. * kbd_brightness as f64 / max_kbd_brightness as f64
+                                ))
+                                .size(16)
+                            )
                             .width(Length::Fixed(40.0))
                             .align_x(Alignment::End)
                         ]


### PR DESCRIPTION
I don't know why it happens but wrapping the text widget inside a container fixes it.
Fixes #817 and #936 