### PR TITLE
[WIP] status-area: Handle menuless items properly

### DIFF
--- a/cosmic-applet-status-area/src/components/app.rs
+++ b/cosmic-applet-status-area/src/components/app.rs
@@ -26,6 +26,7 @@ pub enum Msg {
     TogglePopup(usize),
     Hovered(usize),
     Surface(surface::Action),
+    RightPressed(usize),
 }
 
 #[derive(Default)]
@@ -188,6 +189,10 @@ impl cosmic::Application for App {
                 }
                 Task::none()
             }
+            Msg::RightPressed(id) => {
+                self.menus[&id].ctx_menu_activate();
+                Task::none()
+            }
             Msg::Hovered(id) => {
                 let mut cmds = Vec::new();
                 if let Some(old_id) = self.open_menu.take() {
@@ -261,6 +266,7 @@ impl cosmic::Application for App {
                 .on_press_down(Msg::TogglePopup(*id)),
             )
             .on_enter(Msg::Hovered(*id))
+            .on_right_press(Msg::RightPressed(*id))
             .into()
         });
         self.core


### PR DESCRIPTION
SNI protocol does not mandate the presence of a DBus menu. The `ItemIsMenu` method returns whether the item is a menu or not. But we should also handle items that don't provide a menu, even if they don't advertise this fact through `ItemIsMenu`.

If the item isn't a menu (or doesn't have one), then:
- Left click should call the `Activate` method on the item.
- Right click should call the `ContextMenu` method on the item.

This is a work-in-progress implementation to make the applet respect the above.

This is my first pull request to COSMIC, I would appreciate any mentoring!