### PR TITLE
fix(status-area): prevent crash on invalid icon data

### DIFF
--- a/cosmic-applet-status-area/src/components/status_menu.rs
+++ b/cosmic-applet-status-area/src/components/status_menu.rs
@@ -60,6 +60,12 @@ impl State {
                             .into_iter()
                             .max_by_key(|i| (i.width, i.height))
                             .map(|mut i| {
+                                if i.width <= 0 || i.height <= 0 || i.bytes.is_empty() {
+                                    // App sent invalid icon data during initialization - show placeholder until NewIcon signal
+                                    eprintln!("Skipping invalid icon: {}x{} with {} bytes, app may still be initializing", 
+                                            i.width, i.height, i.bytes.len());
+                                    return icon::from_name("dialog-question").symbolic(true).handle();
+                                }
                                 // Convert ARGB to RGBA
                                 for pixel in i.bytes.chunks_exact_mut(4) {
                                     pixel.rotate_left(1);


### PR DESCRIPTION
Some applications don't register an icon immediately and will register an icon with NewIcon later. This crashes the status-area when trying to create a pixmap from invalid data.

This PR solves this by setting dialog-question as a temporary icon, until hopefully getting a NewIcon update.

Possibly solves #951 