### PR TITLE
Show secure icons in network applet

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -111,7 +111,26 @@ struct CosmicNetworkApplet {
     hw_device_to_show: Option<HwAddress>,
 }
 
-fn wifi_icon(strength: u8) -> &'static str {
+fn wifi_icon(strength: u8, network_type: NetworkType) -> &'static str {
+    match network_type {
+        NetworkType::Open => wifi_icon_open(strength),
+        _ => wifi_icon_secure(strength),
+    }
+}
+
+fn wifi_icon_secure(strength: u8) -> &'static str {
+    if strength < 25 {
+        "network-wireless-secure-signal-weak-symbolic"
+    } else if strength < 50 {
+        "network-wireless-secure-signal-ok-symbolic"
+    } else if strength < 75 {
+        "network-wireless-secure-signal-good-symbolic"
+    } else {
+        "network-wireless-secure-signal-excellent-symbolic"
+    }
+}
+
+fn wifi_icon_open(strength: u8) -> &'static str {
     if strength < 25 {
         "network-wireless-signal-weak-symbolic"
     } else if strength < 50 {
@@ -171,7 +190,7 @@ impl CosmicNetworkApplet {
                     (
                         "network-wired-disconnected-symbolic",
                         ActiveConnectionInfo::WiFi { strength, .. },
-                    ) => wifi_icon(*strength),
+                    ) => wifi_icon(*strength, NetworkType::Open),
                     (_, ActiveConnectionInfo::Wired { .. })
                         if icon_name != "network-vpn-symbolic" =>
                     {
@@ -721,7 +740,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                         ipv4.push(text(format!("{}: {}", fl!("ipv4"), addr)).size(12).into());
                     }
                     let mut btn_content = vec![
-                        icon::from_name(wifi_icon(*strength))
+                        icon::from_name(wifi_icon(*strength, NetworkType::Open))
                             .size(24)
                             .symbolic(true)
                             .into(),
@@ -935,7 +954,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                 btn_content.push(ssid.into());
             } else {
                 btn_content.push(
-                    icon::from_name(wifi_icon(known.strength))
+                    icon::from_name(wifi_icon(known.strength, known.network_type))
                         .size(24)
                         .symbolic(true)
                         .into(),
@@ -1129,7 +1148,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                 }
                 let button = menu_button(
                     row![
-                        icon::from_name(wifi_icon(ap.strength))
+                        icon::from_name(wifi_icon(ap.strength, ap.network_type))
                             .size(16)
                             .symbolic(true),
                         text::body(&ap.ssid).align_y(Alignment::Center)

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -190,7 +190,7 @@ impl CosmicNetworkApplet {
                     (
                         "network-wired-disconnected-symbolic",
                         ActiveConnectionInfo::WiFi { strength, .. },
-                    ) => wifi_icon(*strength, NetworkType::Open),
+                    ) => wifi_icon(*strength, NetworkType::Open), // Use Open icon for clarity
                     (_, ActiveConnectionInfo::Wired { .. })
                         if icon_name != "network-vpn-symbolic" =>
                     {
@@ -729,6 +729,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     state,
                     strength,
                     hw_address,
+                    network_type,
                 } => {
                     if self.hw_device_to_show.is_some()
                         && hw_address != self.hw_device_to_show.as_ref().unwrap()
@@ -740,10 +741,13 @@ impl cosmic::Application for CosmicNetworkApplet {
                         ipv4.push(text(format!("{}: {}", fl!("ipv4"), addr)).size(12).into());
                     }
                     let mut btn_content = vec![
-                        icon::from_name(wifi_icon(*strength, NetworkType::Open))
-                            .size(24)
-                            .symbolic(true)
-                            .into(),
+                        icon::from_name(wifi_icon(
+                            *strength,
+                            network_type.unwrap_or(NetworkType::Open),
+                        ))
+                        .size(24)
+                        .symbolic(true)
+                        .into(),
                         column![text::body(name), Column::with_children(ipv4)]
                             .width(Length::Fill)
                             .into(),

--- a/cosmic-applet-network/src/network_manager/current_networks.rs
+++ b/cosmic-applet-network/src/network_manager/current_networks.rs
@@ -6,6 +6,7 @@ use cosmic_dbus_networkmanager::{
 };
 use std::net::Ipv4Addr;
 
+use super::available_wifi::{get_network_type, NetworkType};
 use super::hw_address::HwAddress;
 
 pub async fn active_connections(
@@ -59,6 +60,7 @@ pub async fn active_connections(
                             .unwrap_or_default(),
                             state,
                             strength: access_point.strength().await.unwrap_or_default(),
+                            network_type: get_network_type(&access_point).await,
                         });
                     }
                 }
@@ -99,6 +101,7 @@ pub enum ActiveConnectionInfo {
         hw_address: HwAddress,
         state: ActiveConnectionState,
         strength: u8,
+        network_type: Option<NetworkType>,
     },
     Vpn {
         name: String,


### PR DESCRIPTION
This PR adds the secure icons to Wifi.
It does it for the wifi list, commit 1. 
And it does it for the active connections, commit 2. 

It does not change the icon in the panel if the wifi is secure, as I think that it shouldn't convey that information there for clarity.