### PR TITLE
Use icon form for buttons on small panels

### DIFF
--- a/cosmic-panel-button/src/lib.rs
+++ b/cosmic-panel-button/src/lib.rs
@@ -119,7 +119,7 @@ impl cosmic::Application for Button {
                 || matches!(
                     (&self.core.applet.size, &self.config.force_presentation),
                     (
-                        Size::PanelSize(PanelSize::M | PanelSize::L | PanelSize::XL),
+                        Size::PanelSize(PanelSize::S | PanelSize::M | PanelSize::L | PanelSize::XL),
                         None
                     )
                 )


### PR DESCRIPTION
After this change, only the XS panel should use the text form. Draft until this is confirmed if we want to do it.