### PR TITLE
feat(battery): add option to show charge percentage next to the icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,7 @@ dependencies = [
 name = "cosmic-applet-battery"
 version = "0.1.0"
 dependencies = [
+ "cosmic-config",
  "cosmic-settings-subscriptions",
  "cosmic-time",
  "drm 0.14.1",
@@ -1120,6 +1121,7 @@ dependencies = [
  "libcosmic",
  "once_cell",
  "rust-embed",
+ "serde",
  "tokio",
  "tracing",
  "tracing-log",

--- a/cosmic-applet-battery/Cargo.toml
+++ b/cosmic-applet-battery/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-only"
 [dependencies]
 cosmic-settings-subscriptions.workspace = true
 cosmic-time.workspace = true
+cosmic-config.workspace = true
 drm = "0.14.1"
 futures.workspace = true
 i18n-embed-fl.workspace = true
@@ -20,3 +21,4 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 udev = "0.9"
 zbus.workspace = true
+serde.workspace = true

--- a/cosmic-applet-battery/i18n/en/cosmic_applet_battery.ftl
+++ b/cosmic-applet-battery/i18n/en/cosmic_applet_battery.ftl
@@ -5,6 +5,7 @@ balanced-desc = Standard performance and battery usage.
 performance = High Performance
 performance-desc = High performance and power usage.
 max-charge = Increase the lifespan of your battery by setting a maximum charge value of 80%
+show-percentage = Show battery percentage on panel
 seconds = s
 minutes = m
 hours = h

--- a/cosmic-applet-battery/src/config.rs
+++ b/cosmic-applet-battery/src/config.rs
@@ -1,4 +1,13 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use cosmic_config::{cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry};
+use serde::{Deserialize, Serialize};
+
 pub const APP_ID: &str = "com.system76.CosmicAppletButton";
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, CosmicConfigEntry, Default)]
+#[version = 1]
+pub struct BatteryConfig {
+    pub show_percentage: bool,
+}


### PR DESCRIPTION
Closes #735 

<img width="368" height="579" alt="image" src="https://github.com/user-attachments/assets/a190628e-631c-4f2a-b4a2-62e64e5e52c3" />

I haven't tested how the applet looks when the GPU selector is visible, as I don't currently have a hybrid graphics system, but it should be fine.