### PR TITLE
status-area: Fix handling of `NameOwnerChanged` with non-`None` new name

### DIFF
--- a/cosmic-applet-status-area/src/subscriptions/status_notifier_watcher/server.rs
+++ b/cosmic-applet-status-area/src/subscriptions/status_notifier_watcher/server.rs
@@ -118,17 +118,19 @@ pub async fn create_service(connection: &zbus::Connection) -> zbus::Result<()> {
                     have_bus_name = false;
                 }
             } else if let BusName::Unique(name) = &args.name {
-                let mut interface = interface.get_mut().await;
-                if let Some(idx) = interface
-                    .items
-                    .iter()
-                    .position(|(unique_name, _)| unique_name == name)
-                {
-                    let ctxt = SignalEmitter::new(&connection, OBJECT_PATH).unwrap();
-                    let service = interface.items.remove(idx).1;
-                    StatusNotifierWatcher::status_notifier_item_unregistered(&ctxt, &service)
-                        .await
-                        .unwrap();
+                if args.new_owner.is_none() {
+                    let mut interface = interface.get_mut().await;
+                    if let Some(idx) = interface
+                        .items
+                        .iter()
+                        .position(|(unique_name, _)| unique_name == name)
+                    {
+                        let ctxt = SignalEmitter::new(&connection, OBJECT_PATH).unwrap();
+                        let service = interface.items.remove(idx).1;
+                        StatusNotifierWatcher::status_notifier_item_unregistered(&ctxt, &service)
+                            .await
+                            .unwrap();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes issue where `fcitx5` app icon persists after it is no longer running. It seems it was getting a `NameOwnerChanged` event with the acquired name after `register_status_notifier_item()`.