### PR TITLE
battery: Only consider connected built-in ports for primary-gpu logic

### DIFF
--- a/cosmic-applet-battery/src/dgpu.rs
+++ b/cosmic-applet-battery/src/dgpu.rs
@@ -393,13 +393,15 @@ fn all_gpus<S: AsRef<str>>(seat: S) -> io::Result<Vec<Gpu>> {
     if let Some(primary_idx) = gpus
         .iter()
         .position(|gpu| {
-            connectors(&gpu.path).is_some_and(|mut conns| {
-                conns.any(|info| {
-                    let i = info.interface();
-                    i == Interface::EmbeddedDisplayPort
-                        || i == Interface::LVDS
-                        || i == Interface::DSI
-                })
+            connectors(&gpu.path).is_some_and(|conns| {
+                conns
+                    .filter(|info| info.state() == drm::control::connector::State::Connected)
+                    .any(|info| {
+                        let i = info.interface();
+                        i == Interface::EmbeddedDisplayPort
+                            || i == Interface::LVDS
+                            || i == Interface::DSI
+                    })
             })
         })
         .or_else(|| gpus.iter().position(|gpu| gpu.boot_vga))


### PR DESCRIPTION
Should fix https://github.com/pop-os/cosmic-applets/issues/1034, missed that when porting cosmic-comps code over.

Some modern laptops have mux-switches and thus both gpus have an internal connected the panel can be connected to. (But it defaults to the iGPU and there is no infrastructure in linux to switch. Once this becomes dynamic we have to start querying the compositor instead.)