### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,12 +175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "parking",
  "polling 3.10.0",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "slab",
  "windows-sys 0.60.2",
 ]
@@ -442,7 +436,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite 2.6.1",
- "rustix 1.0.8",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -468,7 +462,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.60.2",
@@ -811,7 +805,7 @@ checksum = "cb9f6e1368bd4621d2c86baa7e37de77a938adf5221e5dd3d6133340101b309e"
 dependencies = [
  "bitflags 2.9.4",
  "polling 3.10.0",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "slab",
  "tracing",
 ]
@@ -830,21 +824,21 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a7a1dbbe026a55ef47a500b123af5a9a0914520f061d467914cf21be95daf"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
  "calloop 0.14.3",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-client",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -897,17 +891,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1149,8 +1142,7 @@ dependencies = [
  "memmap2 0.9.8",
  "rand 0.9.2",
  "rust-embed",
- "rustix 1.0.8",
- "serde",
+ "rustix 1.1.2",
  "switcheroo-control",
  "tokio",
  "tracing",
@@ -1185,7 +1177,6 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1258,9 +1249,7 @@ dependencies = [
  "i18n-embed",
  "i18n-embed-fl",
  "libcosmic",
- "libpulse-binding",
  "rust-embed",
- "serde",
  "tokio",
  "tracing",
  "tracing-log",
@@ -1279,7 +1268,7 @@ dependencies = [
  "libcosmic",
  "memmap2 0.9.8",
  "rust-embed",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "tokio",
  "tracing",
  "tracing-log",
@@ -1337,7 +1326,7 @@ dependencies = [
  "libcosmic",
  "logind-zbus",
  "rust-embed",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "tokio",
  "tracing",
  "tracing-log",
@@ -1376,7 +1365,6 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "xkb-data",
 ]
 
 [[package]]
@@ -1386,14 +1374,12 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "cosmic-applets-config",
- "cosmic-config",
  "i18n-embed",
  "i18n-embed-fl",
  "icu",
  "libcosmic",
  "logind-zbus",
  "rust-embed",
- "serde",
  "timedate-zbus",
  "tokio",
  "tracing",
@@ -1408,7 +1394,6 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "cosmic-client-toolkit",
- "cosmic-protocols",
  "futures",
  "i18n-embed",
  "i18n-embed-fl",
@@ -1642,7 +1627,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "pipewire",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "smithay-client-toolkit 0.20.0",
  "thiserror 2.0.16",
  "tokio",
@@ -1998,7 +1983,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2191,12 +2176,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2315,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fixed_decimal"
@@ -2651,7 +2636,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -2675,7 +2660,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3253,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d8f41e97997bf55d0533f45d67453355cfa9a8990b0b058bedc28df1a5cec2"
+checksum = "1f6c40ba6481ed7ddd358437af0f000eb9f661345845977d9d1b38e606374e1f"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
@@ -3685,9 +3670,9 @@ checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "immutable-chunkmap"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2194c61e2a29841937e84ec2264a905985c397ccccfbd4783191d3285fa92ef"
+checksum = "9a3e98b1520e49e252237edc238a39869da9f3241f2ec19dc788c1d24694d1e4"
 dependencies = [
  "arrayvec",
 ]
@@ -3705,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -3885,9 +3870,9 @@ checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4025,7 +4010,7 @@ dependencies = [
  "rfd",
  "ron 0.11.0",
  "rust-embed",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "serde",
  "shlex",
  "slotmap",
@@ -4159,9 +4144,9 @@ checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -4200,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "logind-zbus"
@@ -4436,7 +4421,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
@@ -5298,7 +5283,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 
@@ -5432,9 +5417,9 @@ checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "pxfm"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e790881194f6f6e86945f0a42a6981977323669aeb6c40e9c7ec253133b96f8"
+checksum = "f55f4fedc84ed39cb7a489322318976425e42a147e2be79d8f878e2884f94e84"
 dependencies = [
  "num-traits",
 ]
@@ -5818,15 +5803,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5959,7 +5944,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itoa",
  "memchr",
  "ryu",
@@ -5996,7 +5981,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -6160,13 +6145,13 @@ dependencies = [
  "bitflags 2.9.4",
  "bytemuck",
  "calloop 0.14.3",
- "calloop-wayland-source 0.4.0",
+ "calloop-wayland-source 0.4.1",
  "cursor-icon",
  "libc",
  "log",
  "memmap2 0.9.8",
  "pkg-config",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "thiserror 2.0.16",
  "wayland-backend",
  "wayland-client",
@@ -6424,15 +6409,15 @@ checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6674,7 +6659,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -6685,7 +6670,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6852,9 +6837,9 @@ checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-linebreak"
@@ -7018,30 +7003,40 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -7053,9 +7048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7066,9 +7061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7076,9 +7071,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7089,9 +7084,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
@@ -7119,7 +7114,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -7132,7 +7127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.4",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7154,7 +7149,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-client",
  "xcursor",
 ]
@@ -7244,7 +7239,7 @@ checksum = "fcbd4f3aba6c9fba70445ad2a484c0ef0356c1a9459b1e8e435bedc1971a6222"
 dependencies = [
  "bitflags 2.9.4",
  "downcast-rs",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7263,9 +7258,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7323,7 +7318,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "log",
  "naga",
  "once_cell",
@@ -7417,11 +7412,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -7494,7 +7489,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings",
 ]
@@ -7550,6 +7545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7564,7 +7565,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7573,7 +7574,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7619,6 +7620,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -7673,7 +7683,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -7935,9 +7945,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "write16"
@@ -7976,7 +7986,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "x11rb-protocol",
  "xcursor",
 ]
@@ -8266,18 +8276,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8346,9 +8356,9 @@ checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,27 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus 5.10.0",
+ "zbus 5.11.0",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0986d5b4f0802160191ad75f8d33ada000558757db3defb70299ca95d9fcbd"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1137,7 +1157,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "url",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1165,7 +1185,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1187,7 +1207,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1208,7 +1228,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "udev",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1284,7 +1304,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1292,7 +1312,6 @@ name = "cosmic-applet-notifications"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytemuck",
  "cosmic-notifications-config",
  "cosmic-notifications-util",
  "cosmic-time",
@@ -1301,14 +1320,12 @@ dependencies = [
  "i18n-embed-fl",
  "libcosmic",
  "rust-embed",
- "rust-embed-utils",
- "sendfd",
  "tokio",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
  "url",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1325,7 +1342,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1339,7 +1356,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1382,7 +1399,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1462,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1472,19 +1489,18 @@ dependencies = [
  "iced_futures",
  "known-folders",
  "notify",
- "once_cell",
- "ron",
+ "ron 0.11.0",
  "serde",
  "tokio",
  "tracing",
- "xdg",
- "zbus 5.10.0",
+ "xdg 3.0.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -1495,7 +1511,7 @@ name = "cosmic-dbus-a11y"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
 dependencies = [
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1508,7 +1524,7 @@ dependencies = [
  "procfs",
  "thiserror 1.0.69",
  "time",
- "zbus 5.10.0",
+ "zbus 5.11.0",
  "zvariant 5.7.0",
 ]
 
@@ -1522,13 +1538,13 @@ dependencies = [
  "memmap2 0.9.8",
  "thiserror 2.0.16",
  "tracing",
- "xdg",
+ "xdg 2.5.2",
 ]
 
 [[package]]
 name = "cosmic-notifications-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-notifications#744439a6e79f7bcb74ba861d525318f9b774c7f5"
+source = "git+https://github.com/pop-os/cosmic-notifications#3c2a10a2a5da99af8a9cbb689d87cdea8c170cad"
 dependencies = [
  "cosmic-config",
  "serde",
@@ -1537,13 +1553,14 @@ dependencies = [
 [[package]]
 name = "cosmic-notifications-util"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-notifications#744439a6e79f7bcb74ba861d525318f9b774c7f5"
+source = "git+https://github.com/pop-os/cosmic-notifications#3c2a10a2a5da99af8a9cbb689d87cdea8c170cad"
 dependencies = [
  "fast_image_resize",
+ "libcosmic",
  "serde",
  "tracing",
  "url",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1561,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#f0e2d217c6cbfb656ffbcfc03be28191ccf42468"
+source = "git+https://github.com/pop-os/cosmic-panel#2bd1a6f8e42b3857853a23b097daf2ab45eb0e18"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1589,10 +1606,10 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#6d45dbeaade7689ad2241f818fb1c6336ebe2bc2"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon#ff15f3240f6cf36ea74eacbf55ad805377e88a41"
 dependencies = [
  "cosmic-config",
- "ron",
+ "ron 0.9.0",
  "serde",
  "serde_with",
  "thiserror 2.0.16",
@@ -1605,7 +1622,7 @@ name = "cosmic-settings-daemon"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
 dependencies = [
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1632,25 +1649,25 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "upower_dbus",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
 name = "cosmic-text"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#f7033bb0433f6a9ba109007027781ba46ea9ba27"
+source = "git+https://github.com/pop-os/cosmic-text.git#355b7febb17ecb0522346fcc5aff6ea78e33e78a"
 dependencies = [
  "bitflags 2.9.4",
  "fontdb 0.23.0",
+ "harfrust",
  "log",
  "rangemap",
  "rustc-hash 1.1.0",
- "rustybuzz",
  "self_cell",
+ "skrifa 0.36.0",
  "smol_str",
  "swash",
  "sys-locale",
- "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -1660,15 +1677,14 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "almost",
  "cosmic-config",
  "csscolorparser",
  "dirs 6.0.0",
- "lazy_static",
  "palette",
- "ron",
+ "ron 0.11.0",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -2053,7 +2069,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "dpi"
 version = "0.1.1"
-source = "git+https://github.com/pop-os/winit.git?tag=iced-xdg-surface-0.13#1cc02bdab141072eaabad639d74b032fd0fcc62e"
+source = "git+https://github.com/pop-os/winit.git?tag=iced-xdg-surface-0.13#dbe91fcc363c101f1d6ed5301d49911b01a26f61"
 
 [[package]]
 name = "drm"
@@ -2489,7 +2505,7 @@ dependencies = [
  "memchr",
  "thiserror 2.0.16",
  "unicase",
- "xdg",
+ "xdg 2.5.2",
 ]
 
 [[package]]
@@ -2821,6 +2837,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406a98b615ed380f2195fa8fb2ed3083e64b2a6329d710e06f95a42466f0f0c4"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.34.0",
+ "smallvec",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2998,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3007,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "bitflags 2.9.4",
  "bytes",
@@ -3031,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "futures",
  "iced_core",
@@ -3057,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "bitflags 2.9.4",
  "bytemuck",
@@ -3079,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3091,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -3106,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3122,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.9.4",
@@ -3153,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3172,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3961,10 +3990,10 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2dd6dce0533118104052594cce250314975453bc"
+source = "git+https://github.com/pop-os/libcosmic#e83e43bf1e38476e79383b299668afa525bad3e9"
 dependencies = [
  "apply",
- "ashpd",
+ "ashpd 0.12.0",
  "auto_enums",
  "chrono",
  "cosmic-client-toolkit",
@@ -3978,6 +4007,8 @@ dependencies = [
  "derive_setters",
  "freedesktop-desktop-entry",
  "futures",
+ "i18n-embed",
+ "i18n-embed-fl",
  "iced",
  "iced_core",
  "iced_futures",
@@ -3987,13 +4018,13 @@ dependencies = [
  "iced_widget",
  "iced_winit",
  "image",
- "lazy_static",
  "libc",
  "mime 0.3.17",
  "palette",
  "raw-window-handle",
  "rfd",
- "ron",
+ "ron 0.11.0",
+ "rust-embed",
  "rustix 1.0.8",
  "serde",
  "shlex",
@@ -4004,7 +4035,7 @@ dependencies = [
  "tracing",
  "unicode-segmentation",
  "url",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -4180,7 +4211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469c962578b549a82f3d0cc72d0f77d1123780fa7121e2b03d78b0780f6ccac6"
 dependencies = [
  "serde",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -4383,7 +4414,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "time",
- "zbus 5.10.0",
+ "zbus 5.11.0",
  "zvariant 5.7.0",
 ]
 
@@ -5520,19 +5551,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "read-fonts"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "8941f8e9d5f8ad3aebea330d01ac68c0167600eb31a86ecd86e97be4d13b51f5"
 dependencies = [
- "bitflags 1.3.2",
+ "bytemuck",
+ "core_maths",
+ "font-types",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -5645,7 +5678,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
 dependencies = [
- "ashpd",
+ "ashpd 0.11.0",
  "block2 0.6.1",
  "dispatch2",
  "js-sys",
@@ -5677,6 +5710,19 @@ name = "ron"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
+dependencies = [
+ "base64",
+ "bitflags 2.9.4",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ron"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
 dependencies = [
  "base64",
  "bitflags 2.9.4",
@@ -5797,7 +5843,6 @@ checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
  "bitflags 2.9.4",
  "bytemuck",
- "libm",
  "smallvec",
  "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
@@ -5875,16 +5920,6 @@ name = "self_cell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
-
-[[package]]
-name = "sendfd"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b183bfd5b1bc64ab0c1ef3ee06b008a9ef1b68a7d3a99ba566fbfe7a7c6d745b"
-dependencies = [
- "libc",
- "tokio",
-]
 
 [[package]]
 name = "serde"
@@ -6057,7 +6092,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.29.3",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37004372610e83ee2a4c69c7d896b41f33da6a3dc1a4fe07dd9b2629a549b1dc"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.34.0",
 ]
 
 [[package]]
@@ -6179,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "softbuffer"
 version = "0.4.1"
-source = "git+https://github.com/pop-os/softbuffer?tag=cosmic-4.0#6e75b1ad7e98397d37cb187886d05969bc480995"
+source = "git+https://github.com/pop-os/softbuffer?tag=cosmic-4.0#a3f77e251e7422803f693df6e3fc313c010c4dcb"
 dependencies = [
  "as-raw-xcb-connection",
  "bytemuck",
@@ -6194,7 +6239,7 @@ dependencies = [
  "memmap2 0.9.8",
  "objc",
  "raw-window-handle",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.17",
  "rustix 0.38.44",
  "tiny-xlib",
  "wasm-bindgen",
@@ -6286,7 +6331,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
 dependencies = [
- "skrifa",
+ "skrifa 0.31.3",
  "yazi",
  "zeno",
 ]
@@ -6296,7 +6341,7 @@ name = "switcheroo-control"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
 dependencies = [
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -6483,7 +6528,7 @@ name = "timedate-zbus"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
 dependencies = [
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -6860,7 +6905,7 @@ source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930
 dependencies = [
  "serde",
  "serde_repr",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -7822,7 +7867,7 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 [[package]]
 name = "winit"
 version = "0.30.5"
-source = "git+https://github.com/pop-os/winit.git?tag=iced-xdg-surface-0.13#1cc02bdab141072eaabad639d74b032fd0fcc62e"
+source = "git+https://github.com/pop-os/winit.git?tag=iced-xdg-surface-0.13#dbe91fcc363c101f1d6ed5301d49911b01a26f61"
 dependencies = [
  "ahash",
  "android-activity",
@@ -7849,7 +7894,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "raw-window-handle",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.17",
  "rustix 0.38.44",
  "sctk-adwaita",
  "smithay-client-toolkit 0.19.2",
@@ -7955,6 +8000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7967,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#f0e2d217c6cbfb656ffbcfc03be28191ccf42468"
+source = "git+https://github.com/pop-os/cosmic-panel#2bd1a6f8e42b3857853a23b097daf2ab45eb0e18"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",
@@ -8122,9 +8173,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a073be99ace1adc48af593701c8015cd9817df372e14a1a6b0ee8f8bf043be"
+checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
 dependencies = [
  "async-broadcast 0.7.2",
  "async-executor",
@@ -8150,7 +8201,7 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.60.2",
  "winnow 0.7.13",
- "zbus_macros 5.10.0",
+ "zbus_macros 5.11.0",
  "zbus_names 4.2.0",
  "zvariant 5.7.0",
 ]
@@ -8171,9 +8222,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e80cd713a45a49859dcb648053f63265f4f2851b6420d47a958e5697c68b131"
+checksum = "57e797a9c847ed3ccc5b6254e8bcce056494b375b511b3d6edcec0aeb4defaca"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",

--- a/cosmic-app-list/Cargo.toml
+++ b/cosmic-app-list/Cargo.toml
@@ -12,14 +12,13 @@ cosmic-protocols.workspace = true
 futures.workspace = true
 i18n-embed.workspace = true
 i18n-embed-fl.workspace = true
-image = { version = "0.25.6", default-features = false }
+image = { version = "0.25.8", default-features = false }
 itertools = "0.14.0"
 libcosmic.workspace = true
 memmap2 = "0.9.8"
 rand = "0.9.2"
 rust-embed.workspace = true
 rustix.workspace = true
-serde = { workspace = true, features = ["derive"] }
 switcheroo-control = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 tokio.workspace = true
 tracing-log.workspace = true

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -173,7 +173,10 @@ impl DockItem {
 
         let cosmic_icon = fde::IconSource::from_unknown(desktop_info.icon().unwrap_or_default())
             .as_cosmic_icon()
-            .size(app_icon.icon_size);
+            // sets the preferred icon size variant
+            .size(128)
+            .width(app_icon.icon_size.into())
+            .height(app_icon.icon_size.into());
 
         let dots = if toplevels.is_empty() {
             (0..1)

--- a/cosmic-applet-a11y/Cargo.toml
+++ b/cosmic-applet-a11y/Cargo.toml
@@ -21,4 +21,3 @@ tokio.workspace = true
 tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-zbus.workspace = true

--- a/cosmic-applet-input-sources/Cargo.toml
+++ b/cosmic-applet-input-sources/Cargo.toml
@@ -10,11 +10,9 @@ cosmic-comp-config = { git = "https://github.com/pop-os/cosmic-comp.git", rev = 
 i18n-embed-fl.workspace = true
 i18n-embed.workspace = true
 libcosmic.workspace = true
-libpulse-binding = "2.30.1"
 rust-embed.workspace = true
 tokio.workspace = true
 tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-serde = { workspace = true, features = ["derive"] }
 xkb-data = "0.2"

--- a/cosmic-applet-minimize/Cargo.toml
+++ b/cosmic-applet-minimize/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-only"
 anyhow.workspace = true
 i18n-embed-fl.workspace = true
 i18n-embed.workspace = true
-image = { version = "0.25.6", default-features = false }
+image = { version = "0.25.8", default-features = false }
 libcosmic.workspace = true
 memmap2 = "0.9.8"
 rust-embed.workspace = true

--- a/cosmic-applet-notifications/Cargo.toml
+++ b/cosmic-applet-notifications/Cargo.toml
@@ -13,8 +13,6 @@ cosmic-notifications-util = { git = "https://github.com/pop-os/cosmic-notificati
 cosmic-notifications-config = { git = "https://github.com/pop-os/cosmic-notifications" }
 # cosmic-notifications-util = { path = "../../cosmic-notifications-daemon/cosmic-notifications-util" }
 # cosmic-notifications-config = { path = "../../cosmic-notifications-daemon/cosmic-notifications-config" }
-sendfd = { version = "0.4", features = ["tokio"] }
-bytemuck = "1"
 futures-util = { workspace = true, features = ["sink"] }
 tracing-subscriber.workspace = true
 tracing-log.workspace = true
@@ -26,6 +24,5 @@ i18n-embed = { workspace = true, features = [
 ] }
 i18n-embed-fl.workspace = true
 rust-embed.workspace = true
-rust-embed-utils.workspace = true
 zbus = { workspace = true, features = ["tokio", "p2p"] }
 url = "2.5.7"

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -457,7 +457,7 @@ impl cosmic::Application for Notifications {
                     .iter()
                     .rev()
                     .map(|n| {
-                        let app_name = text(if n.app_name.len() > 24 {
+                        let app_name = text::caption(if n.app_name.len() > 24 {
                             Cow::from(format!(
                                 "{:.26}...",
                                 n.app_name.lines().next().unwrap_or_default()
@@ -465,7 +465,6 @@ impl cosmic::Application for Notifications {
                         } else {
                             Cow::from(&n.app_name)
                         })
-                        .size(12)
                         .width(Length::Fill);
 
                         let duration_since = text::caption(duration_ago_msg(n));
@@ -481,59 +480,20 @@ impl cosmic::Application for Notifications {
                             n.id,
                             Element::from(
                                 column!(
-                                    match n.image() {
-                                        Some(cosmic_notifications_util::Image::File(path)) => {
-                                            row![
-                                                icon::from_path(PathBuf::from(path))
-                                                    .icon()
-                                                    .size(16),
-                                                app_name,
-                                                duration_since,
-                                                close_notif
-                                            ]
+                                    if let Some(icon) = n.notification_icon() {
+                                        row![icon.size(16), app_name, duration_since, close_notif]
                                             .spacing(8)
                                             .align_y(Alignment::Center)
-                                        }
-                                        Some(cosmic_notifications_util::Image::Name(name)) => {
-                                            row![
-                                                icon::from_name(name.as_str()).size(16),
-                                                app_name,
-                                                duration_since,
-                                                close_notif
-                                            ]
+                                    } else {
+                                        row![app_name, duration_since, close_notif]
                                             .spacing(8)
                                             .align_y(Alignment::Center)
-                                        }
-                                        Some(cosmic_notifications_util::Image::Data {
-                                            width,
-                                            height,
-                                            data,
-                                        }) => {
-                                            row![
-                                                icon::from_raster_pixels(
-                                                    *width,
-                                                    *height,
-                                                    data.clone()
-                                                )
-                                                .icon()
-                                                .size(16),
-                                                app_name,
-                                                duration_since,
-                                                close_notif
-                                            ]
-                                            .spacing(8)
-                                            .align_y(Alignment::Center)
-                                        }
-                                        None => row![app_name, duration_since, close_notif]
-                                            .spacing(8)
-                                            .align_y(Alignment::Center),
                                     },
                                     column![
                                         text::body(n.summary.lines().next().unwrap_or_default())
                                             .width(Length::Fill),
-                                        text(n.body.lines().next().unwrap_or_default())
+                                        text::caption(n.body.lines().next().unwrap_or_default())
                                             .width(Length::Fill)
-                                            .size(12)
                                     ]
                                 )
                                 .width(Length::Fill),
@@ -564,7 +524,7 @@ impl cosmic::Application for Notifications {
                     {
                         Some(cosmic::widget::icon::from_path(path))
                     } else {
-                        Some(cosmic::widget::icon::from_name(n.app_icon.clone()).handle())
+                        Some(cosmic::widget::icon::from_name(n.app_icon.as_str()).handle())
                     }
                 });
                 let card_list = anim!(

--- a/cosmic-applet-tiling/Cargo.toml
+++ b/cosmic-applet-tiling/Cargo.toml
@@ -18,4 +18,3 @@ tokio.workspace = true
 tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-xkb-data = "0.2"

--- a/cosmic-applet-time/Cargo.toml
+++ b/cosmic-applet-time/Cargo.toml
@@ -6,8 +6,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 cosmic-applets-config.workspace = true
-cosmic-config.workspace = true
-chrono = { version = "0.4.41", features = ["clock"] }
+chrono = { version = "0.4.42", features = ["clock"] }
 chrono-tz = "0.10"
 i18n-embed-fl.workspace = true
 i18n-embed.workspace = true
@@ -18,7 +17,6 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 icu = { version = "2.0.0", features = ["compiled_data"] }
-serde.workspace = true
 zbus.workspace = true
 timedate-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 logind-zbus = "5.3.2"

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -5,7 +5,7 @@ use chrono::{Datelike, Timelike};
 use cosmic::iced_futures::stream;
 use cosmic::widget::Id;
 use cosmic::{
-    Element, Task, app,
+    Apply, Element, Task, app,
     applet::{cosmic_panel_config::PanelAnchor, menu_button, padded_control},
     cctk::sctk::reexports::calloop,
     cosmic_theme::Spacing,
@@ -133,10 +133,9 @@ impl Window {
             let date = day_iter.next().unwrap();
             let datetime = self.create_datetime(&date);
             calendar = calendar.push(
-                text(weekday.format(&datetime).to_string())
-                    .size(12)
-                    .width(Length::Fixed(44.0))
-                    .align_x(Alignment::Center),
+                text::caption(weekday.format(&datetime).to_string())
+                    .apply(container)
+                    .center_x(Length::Fixed(44.0)),
             );
             first_day_of_week = first_day_of_week.succ();
         }
@@ -716,10 +715,14 @@ fn date_button(day: u32, is_month: bool, is_day: bool, is_today: bool) -> Button
         button::ButtonClass::Text
     };
 
-    let button = button::custom(text::body(format!("{day}")).center())
-        .class(style)
-        .height(Length::Fixed(44.0))
-        .width(Length::Fixed(44.0));
+    let button = button::custom(
+        text::body(format!("{day}"))
+            .apply(container)
+            .center(Length::Fill),
+    )
+    .class(style)
+    .height(Length::Fixed(44.0))
+    .width(Length::Fixed(44.0));
 
     if is_month {
         button.on_press(Message::SelectDay(day))

--- a/cosmic-applet-workspaces/Cargo.toml
+++ b/cosmic-applet-workspaces/Cargo.toml
@@ -8,7 +8,6 @@ license = "GPL-3.0-only"
 [dependencies]
 libcosmic.workspace = true
 cctk.workspace = true
-cosmic-protocols.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-log.workspace = true


### PR DESCRIPTION
Makes the notifications applet use the method from `cosmic-notifications`, and updates dependencies.

The text alignment issue that the App Library had also appeared in the time applet. Maybe some change in `cosmic-text` broke alignment? Since I don't see any changes around that in libcosmic.

Sets the App Tray target icon variant to 128 (I think those variants are matching previous behavior), since it otherwise changes icons depending on size (because of recent libcosmic improvements), and the smaller icon variants might not look the best here.