### PR TITLE
i18n(ar): Added & updated Arabic translation

### DIFF
--- a/cosmic-applet-tiling/i18n/ar/cosmic_applet_tiling.ftl
+++ b/cosmic-applet-tiling/i18n/ar/cosmic_applet_tiling.ftl
@@ -1,5 +1,5 @@
-tile-windows = تجزئة النوافذ تلقائيًا
-tile-current = تجزئة مساحة العمل الحالية
+tile-windows = تبليط النوافذ تلقائيًا
+tile-current = تبليط مساحة العمل الحالية
 shortcuts = اختصارات
 navigate-windows = التنقل بين النوافذ
 move-window = نقل النافذة
@@ -16,5 +16,5 @@ shift = Shift
 arrow-keys = مفاتيح الأسهم
 tiled = مجزأة
 floating = عائمة
-autotile-behavior = تجزئة النوافذ في مساحات العمل
+autotile-behavior = تبليط النوافذ في مساحات العمل
 new-workspace = سلوك مساحة العمل الجديدة

--- a/cosmic-applet-workspaces/i18n/ar/cosmic_applet_workspaces.ftl
+++ b/cosmic-applet-workspaces/i18n/ar/cosmic_applet_workspaces.ftl
@@ -1,1 +1,1 @@
-cosmic-applet-workspaces = مساحات عمل كوزميك
+cosmic-applet-workspaces = مساحات عمل COSMIC

--- a/cosmic-panel-launcher-button/data/com.system76.CosmicPanelLauncherButton.desktop
+++ b/cosmic-panel-launcher-button/data/com.system76.CosmicPanelLauncherButton.desktop
@@ -6,6 +6,7 @@ Name[pl]=Przycisk programu uruchamiającego
 Name[pt]=Botão Lançador de Aplicativos
 Name[nl]=Knop snelstarter
 Name[sk]=Tlačidlo spúšťača
+Name[ar]=زر المشغل
 Type=Application
 Exec=cosmic-panel-button com.system76.CosmicLauncher
 Terminal=false

--- a/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
+++ b/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
@@ -6,6 +6,7 @@ Name[hu]=Munkaterületek gomb
 Name[pt]=Botão de Áreas de Trabalho
 Name[nl]=Knop werkbladenoverzicht
 Name[sk]=Tlačidlo pracovných plôch
+Name[ar]=زر مساحات العمل
 Type=Application
 Exec=cosmic-panel-button com.system76.CosmicWorkspaces
 Terminal=false


### PR DESCRIPTION
Added & updated Arabic translations:
- Instead of transliterating "COSMIC," I just put it as it is in English. 👉 [COSMIC workspaces applet](https://github.com/pop-os/cosmic-applets/compare/master...defaultUser822:cosmic-applets:master#diff-53da006988f954019db2ce4503e5767521ffa80057a425e7d00b0893791a4385)
- Instead of translating tiling as in distributing equally, translated it as in tiles 👉 [COSMIC tiling applet](https://github.com/pop-os/cosmic-applets/compare/master...defaultUser822:cosmic-applets:master#diff-9b750d8671503f1d402d0e792356df3396d1507ce91c37bbca5673f91e66202a)
- Added Arabic translations to .desktop files.

👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
1. [CosmicPanelWorkspacesButton.desktop](https://github.com/pop-os/cosmic-applets/compare/master...defaultUser822:cosmic-applets:master#diff-dfa3efa5983091804439f285fcf28535855e411b85a21428054be9c942fb3ffe)
2. [CosmicPanelLauncherButton.desktop](https://github.com/pop-os/cosmic-applets/compare/master...defaultUser822:cosmic-applets:master#diff-32c811ae2004b319c971c7a715428f3b55f787e86dd30a731caedecfb0633b02)
