### PR TITLE
Fix typo in a11y main.rs logging

### DIFF
--- a/cosmic-applet-a11y/src/main.rs
+++ b/cosmic-applet-a11y/src/main.rs
@@ -7,7 +7,7 @@ fn main() -> cosmic::iced::Result {
     tracing_subscriber::fmt::init();
     let _ = tracing_log::LogTracer::init();
 
-    tracing::info!("Starting battery applet with version {VERSION}");
+    tracing::info!("Starting accessibility applet with version {VERSION}");
 
     cosmic_applet_a11y::run()
 }


### PR DESCRIPTION
changed reference of battery to accessibility