### PR TITLE
perf: refactor to reduce memory allocations

### DIFF
--- a/cosmic-app-list/src/wayland_subscription.rs
+++ b/cosmic-app-list/src/wayland_subscription.rs
@@ -57,11 +57,13 @@ pub struct WaylandImage {
 
 impl WaylandImage {
     pub fn new(img: image::RgbaImage) -> Self {
+        let width = img.width();
+        let height = img.height();
+
         Self {
-            // TODO avoid copy?
-            img: Bytes::copy_from_slice(img.as_bytes()),
-            width: img.width(),
-            height: img.height(),
+            img: Bytes::from_owner(img.into_vec()),
+            width,
+            height,
         }
     }
 }

--- a/cosmic-applet-a11y/src/app.rs
+++ b/cosmic-applet-a11y/src/app.rs
@@ -401,7 +401,7 @@ impl cosmic::Application for CosmicA11yApplet {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        Subscription::batch(vec![
+        Subscription::batch([
             accessibility::subscription().map(Message::DBusUpdate),
             backend::wayland::a11y_subscription().map(Message::WaylandUpdate),
             self.timeline

--- a/cosmic-applet-audio/src/mpris_subscription.rs
+++ b/cosmic-applet-audio/src/mpris_subscription.rs
@@ -171,7 +171,7 @@ impl State {
         filter_firefox_players(&mut players);
 
         // pre-sort by path so that the same player is always selected
-        players.sort_by(|a, b| a.name().cmp(b.name()));
+        players.sort_unstable_by(|a, b| a.name().cmp(b.name()));
 
         let mut state = Self {
             conn,

--- a/cosmic-applet-audio/src/mpris_subscription.rs
+++ b/cosmic-applet-audio/src/mpris_subscription.rs
@@ -179,7 +179,7 @@ impl State {
             players,
             active_player: None,
             active_player_metadata_stream: None,
-            any_player_state_stream: futures::stream::select_all(Vec::new()),
+            any_player_state_stream: futures::stream::select_all([]),
         };
         state.update_active_player().await;
         state.update_any_player_state_stream().await;
@@ -243,7 +243,7 @@ async fn run(output: &mut futures::channel::mpsc::Sender<MprisUpdate>) {
     let mut state = match State::new().await {
         Ok(state) => state,
         Err(err) => {
-            tracing::error!("Faile do monitor for mpris clients: {}", err);
+            tracing::error!("Failed to monitor for mpris clients: {}", err);
             return;
         }
     };

--- a/cosmic-applet-audio/src/pulse.rs
+++ b/cosmic-applet-audio/src/pulse.rs
@@ -777,8 +777,8 @@ pub struct DeviceInfo {
 impl<'a> From<&SinkInfo<'a>> for DeviceInfo {
     fn from(info: &SinkInfo<'a>) -> Self {
         Self {
-            name: info.name.clone().map(|x| x.into_owned()),
-            description: info.description.clone().map(|x| x.into_owned()),
+            name: info.name.as_deref().map(str::to_string),
+            description: info.description.as_deref().map(str::to_string),
             volume: info.volume,
             mute: info.mute,
             index: info.index,
@@ -789,8 +789,8 @@ impl<'a> From<&SinkInfo<'a>> for DeviceInfo {
 impl<'a> From<&SourceInfo<'a>> for DeviceInfo {
     fn from(info: &SourceInfo<'a>) -> Self {
         Self {
-            name: info.name.clone().map(|x| x.into_owned()),
-            description: info.description.clone().map(|x| x.into_owned()),
+            name: info.name.as_deref().map(str::to_string),
+            description: info.description.as_deref().map(str::to_string),
             volume: info.volume,
             mute: info.mute,
             index: info.index,
@@ -824,14 +824,15 @@ pub struct ServerInfo {
 
 impl<'a> From<&'a pulse::context::introspect::ServerInfo<'a>> for ServerInfo {
     fn from(info: &'a pulse::context::introspect::ServerInfo<'a>) -> Self {
+        use std::borrow::Cow;
         Self {
-            user_name: info.user_name.as_ref().map(|cow| cow.to_string()),
-            host_name: info.host_name.as_ref().map(|cow| cow.to_string()),
-            server_version: info.server_version.as_ref().map(|cow| cow.to_string()),
-            server_name: info.server_name.as_ref().map(|cow| cow.to_string()),
+            user_name: info.user_name.as_ref().map(Cow::to_string),
+            host_name: info.host_name.as_ref().map(Cow::to_string),
+            server_version: info.server_version.as_ref().map(Cow::to_string),
+            server_name: info.server_name.as_ref().map(Cow::to_string),
             //sample_spec: info.sample_spec,
-            default_sink_name: info.default_sink_name.as_ref().map(|cow| cow.to_string()),
-            default_source_name: info.default_source_name.as_ref().map(|cow| cow.to_string()),
+            default_sink_name: info.default_sink_name.as_ref().map(Cow::to_string),
+            default_source_name: info.default_source_name.as_ref().map(Cow::to_string),
             cookie: info.cookie,
             //channel_map: info.channel_map,
         }

--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -154,8 +154,7 @@ impl CosmicBatteryApplet {
             }
         } else {
             "off"
-        }
-        .to_string();
+        };
 
         self.display_icon_name =
             format!("cosmic-applet-battery-display-brightness-{screen_brightness}-symbolic",);
@@ -219,7 +218,7 @@ impl cosmic::Application for CosmicBatteryApplet {
 
                 ..Default::default()
             },
-            Task::batch(vec![zbus_session_cmd, init_charging_limit_cmd]),
+            Task::batch([zbus_session_cmd, init_charging_limit_cmd]),
         )
     }
 
@@ -508,10 +507,10 @@ impl cosmic::Application for CosmicBatteryApplet {
                 .into();
 
             match self.core.applet.anchor {
-                PanelAnchor::Left | PanelAnchor::Right => Column::with_children(vec![btn, dot])
+                PanelAnchor::Left | PanelAnchor::Right => Column::with_children([btn, dot])
                     .align_x(Alignment::Center)
                     .into(),
-                PanelAnchor::Top | PanelAnchor::Bottom => Row::with_children(vec![btn, dot])
+                PanelAnchor::Top | PanelAnchor::Bottom => Row::with_children([btn, dot])
                     .align_y(Alignment::Center)
                     .into(),
             }

--- a/cosmic-applet-battery/src/dgpu.rs
+++ b/cosmic-applet-battery/src/dgpu.rs
@@ -205,17 +205,17 @@ impl Gpu {
             // figure out bus path for calling nvidia-smi
             let mut sys_path = PathBuf::from("/sys/class/drm");
             sys_path.push(self.path.components().next_back()?.as_os_str());
-            let buslink = std::fs::read_link(sys_path)
-                .ok()?
-                .components()
-                .rev()
-                .nth(2)?
-                .as_os_str()
-                .to_string_lossy()
-                .into_owned();
+            let buslink = std::fs::read_link(sys_path).ok()?;
+            let buslink = buslink.components().nth_back(2)?.as_os_str();
 
             let smi_output = match tokio::process::Command::new("nvidia-smi")
-                .args(["pmon", "--id", &buslink, "--count", "1"])
+                .args([
+                    "pmon".as_ref(),
+                    "--id".as_ref(),
+                    buslink,
+                    "--count".as_ref(),
+                    "1".as_ref(),
+                ])
                 .output()
                 .await
             {

--- a/cosmic-applet-bluetooth/src/app.rs
+++ b/cosmic-applet-bluetooth/src/app.rs
@@ -112,7 +112,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
         match message {
             Message::TogglePopup => {
                 if let Some(p) = self.popup.take() {
-                    return Task::batch(vec![
+                    return Task::batch([
                         destroy_popup(p),
                         cosmic::task::future(
                             set_tick(Duration::from_secs(10))
@@ -134,7 +134,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
                     );
 
                     let tx = self.bluer_sender.clone();
-                    return Task::batch(vec![
+                    return Task::batch([
                         iced::Task::perform(
                             async {
                                 if let Some(tx) = tx {
@@ -361,7 +361,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
             space_xxs, space_s, ..
         } = theme::active().cosmic().spacing;
 
-        let mut known_bluetooth = vec![];
+        let mut known_bluetooth = Vec::new();
         // PERF: This should be pre-filtered in an update.
         for dev in self.bluer_state.devices.iter().filter(|d| {
             self.request_confirmation
@@ -370,7 +370,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
         }) {
             let mut row = row![
                 icon::from_name(dev.icon).size(16).symbolic(true),
-                text::body(dev.name.clone())
+                text::body(dev.name.as_str())
                     .align_x(Alignment::Start)
                     .align_y(Alignment::Center)
                     .width(Length::Fill)
@@ -493,7 +493,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
                 padded_control(
                     text::body(fl!(
                         "confirm-pin",
-                        HashMap::from_iter(vec![("deviceName", device.name.clone())])
+                        HashMap::from([("deviceName", device.name.clone())])
                     ))
                     .align_x(Alignment::Start)
                     .align_y(Alignment::Center)
@@ -571,7 +571,7 @@ impl cosmic::Application for CosmicBluetoothApplet {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        Subscription::batch(vec![
+        Subscription::batch([
             activation_token_subscription(0).map(Message::Token),
             bluetooth_subscription(0).map(Message::BluetoothEvent),
             self.timeline

--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -249,12 +249,7 @@ impl Ord for BluerDevice {
 impl PartialOrd for BluerDevice {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match self.status.cmp(&other.status) {
-            std::cmp::Ordering::Equal => {
-                Some(self.name.to_lowercase().cmp(&other.name.to_lowercase()))
-            }
-            o => Some(o),
-        }
+        Some(self.cmp(other))
     }
 }
 

--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -808,6 +808,6 @@ async fn build_device_list(mut devices: Vec<BluerDevice>, adapter: &Adapter) -> 
         devices.push(device);
     }
 
-    devices.sort();
+    devices.sort_unstable();
     devices
 }

--- a/cosmic-applet-input-sources/src/lib.rs
+++ b/cosmic-applet-input-sources/src/lib.rs
@@ -242,8 +242,8 @@ impl cosmic::Application for Window {
             widget::column::with_capacity(4 + self.active_layouts.len()).padding([8, 0]);
         for (id, layout) in self.active_layouts.iter().enumerate() {
             let group = widget::column::with_capacity(2)
-                .push(widget::text::body(layout.description.clone()))
-                .push(widget::text::caption(layout.layout.clone()));
+                .push(widget::text::body(layout.description.as_str()))
+                .push(widget::text::caption(layout.layout.as_str()));
             content_list = content_list
                 .push(applet::menu_button(group).on_press(Message::SetActiveLayout(id)));
         }

--- a/cosmic-applet-minimize/src/lib.rs
+++ b/cosmic-applet-minimize/src/lib.rs
@@ -173,7 +173,7 @@ impl cosmic::Application for Minimize {
                         // Temporarily take ownership to appease the borrow checker.
                         let mut apps = std::mem::take(&mut self.apps);
 
-                        if let Some(pos) = apps.iter_mut().position(|a| {
+                        if let Some(pos) = apps.iter().position(|a| {
                             a.toplevel_info.foreign_toplevel == toplevel_info.foreign_toplevel
                         }) {
                             if apps[pos].toplevel_info.app_id != toplevel_info.app_id {
@@ -194,7 +194,7 @@ impl cosmic::Application for Minimize {
                                 name: desktop_entry
                                     .full_name(&self.locales)
                                     .unwrap_or(Cow::Borrowed(&desktop_entry.appid))
-                                    .to_string(),
+                                    .into_owned(),
                                 icon_source: fde::IconSource::from_unknown(
                                     desktop_entry.icon().unwrap_or(&desktop_entry.appid),
                                 ),

--- a/cosmic-applet-minimize/src/wayland_handler.rs
+++ b/cosmic-applet-minimize/src/wayland_handler.rs
@@ -237,7 +237,7 @@ impl<T: AsFd> ShmImage<T> {
     pub fn image(&self) -> anyhow::Result<image::RgbaImage> {
         let mmap = unsafe { memmap2::Mmap::map(&self.fd.as_fd())? };
         image::RgbaImage::from_raw(self.width, self.height, mmap.to_vec())
-            .ok_or(anyhow::anyhow!("ShmImage had incorrect size"))
+            .ok_or_else(|| anyhow::anyhow!("ShmImage had incorrect size"))
     }
 }
 
@@ -475,12 +475,12 @@ pub(crate) fn wayland_handler(
         exit: false,
         tx,
         conn,
-        queue_handle: qh.clone(),
         shm_state,
         screencopy_state,
         seat_state: SeatState::new(&globals, &qh),
         toplevel_info_state: ToplevelInfoState::new(&registry_state, &qh),
         toplevel_manager_state: ToplevelManagerState::new(&registry_state, &qh),
+        queue_handle: qh,
         registry_state,
     };
 

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -370,7 +370,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     } = &req
                     {
                         if let Some(NewConnectionState::Waiting(access_point)) =
-                            self.new_connection.clone()
+                            self.new_connection.as_ref()
                         {
                             if !success
                                 && ssid == &access_point.ssid
@@ -384,7 +384,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                                     }
                                 } else if let Some(NewConnectionState::EnterPassword {
                                     access_point, ..
-                                }) = self.new_connection.clone()
+                                }) = self.new_connection.as_ref()
                                 {
                                     if success && ssid == &access_point.ssid && *hw_address == access_point.hw_address {
                                         self.new_connection = None;
@@ -863,7 +863,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                 let mut btn_content = vec![
                     column![
                         text::body(display_name),
-                        Column::with_children(vec![text("Adapter").size(10).into()])
+                        Column::with_children([text("Adapter").size(10).into()])
                     ]
                     .width(Length::Fill)
                     .into(),
@@ -1149,7 +1149,7 @@ impl cosmic::Application for CosmicNetworkApplet {
 
         if let Some(conn) = self.conn.as_ref() {
             let has_popup = self.popup.is_some();
-            Subscription::batch(vec![
+            Subscription::batch([
                 timeline,
                 network_sub,
                 token_sub,
@@ -1161,7 +1161,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     .map(Message::NetworkManagerEvent),
             ])
         } else {
-            Subscription::batch(vec![timeline, network_sub, token_sub])
+            Subscription::batch([timeline, network_sub, token_sub])
         }
     }
 

--- a/cosmic-applet-network/src/network_manager/available_wifi.rs
+++ b/cosmic-applet-network/src/network_manager/available_wifi.rs
@@ -9,7 +9,6 @@ use cosmic_dbus_networkmanager::{
 };
 
 use futures_util::StreamExt;
-use itertools::Itertools;
 use std::collections::HashMap;
 use zbus::zvariant::ObjectPath;
 
@@ -37,7 +36,7 @@ pub async fn handle_wireless_device(
     // Sort by strength and remove duplicates
     let mut aps = HashMap::<String, AccessPoint>::new();
     for ap in access_points {
-        let ssid = String::from_utf8_lossy(&ap.ssid().await?.clone()).into_owned();
+        let ssid = String::from_utf8_lossy(ap.ssid().await?.as_slice()).into_owned();
         let wps_push = ap.flags().await?.contains(ApFlags::WPS_PBC);
         let strength = ap.strength().await?;
         if let Some(access_point) = aps.get(&ssid) {
@@ -77,10 +76,8 @@ pub async fn handle_wireless_device(
             },
         );
     }
-    let aps = aps
-        .into_values()
-        .sorted_by(|a, b| b.strength.cmp(&a.strength))
-        .collect();
+    let mut aps = aps.into_values().collect::<Vec<_>>();
+    aps.sort_by_key(|ap| ap.strength);
     Ok(aps)
 }
 

--- a/cosmic-applet-network/src/network_manager/available_wifi.rs
+++ b/cosmic-applet-network/src/network_manager/available_wifi.rs
@@ -77,7 +77,7 @@ pub async fn handle_wireless_device(
         );
     }
     let mut aps = aps.into_values().collect::<Vec<_>>();
-    aps.sort_by_key(|ap| ap.strength);
+    aps.sort_unstable_by_key(|ap| ap.strength);
     Ok(aps)
 }
 

--- a/cosmic-applet-network/src/network_manager/current_networks.rs
+++ b/cosmic-applet-network/src/network_manager/current_networks.rs
@@ -71,7 +71,7 @@ pub async fn active_connections(
         }
     }
 
-    info.sort();
+    info.sort_unstable();
     Ok(info)
 }
 

--- a/cosmic-applet-network/src/network_manager/mod.rs
+++ b/cosmic-applet-network/src/network_manager/mod.rs
@@ -420,7 +420,7 @@ impl NetworkManagerState {
         let s = NetworkManagerSettings::new(conn).await?;
         _ = s.load_connections(&[]).await;
         let known_conns = s.list_connections().await.unwrap_or_default();
-        let mut active_conns = active_connections(
+        let active_conns = active_connections(
             network_manager
                 .active_connections()
                 .await
@@ -428,7 +428,7 @@ impl NetworkManagerState {
         )
         .await
         .unwrap_or_default();
-        active_conns.sort();
+        // active_conns.sort(); active_connections should have already sorted the vector
         let devices = network_manager.devices().await.ok().unwrap_or_default();
         let wireless_access_point_futures: Vec<_> = devices
             .into_iter()

--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -56,7 +56,7 @@ struct Notifications {
 
 impl Notifications {
     fn update_cards(&mut self, id: id::Cards) {
-        if let Some((id, _, card_value, ..)) = self.cards.iter_mut().find(|c| c.0 == id) {
+        if let Some((id, _, card_value, ..)) = self.cards.iter().find(|c| c.0 == id) {
             let chain = if *card_value {
                 chain::Cards::on(id.clone(), 1.)
             } else {
@@ -152,7 +152,7 @@ impl cosmic::Application for Notifications {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        Subscription::batch(vec![
+        Subscription::batch([
             self.core
                 .watch_config(cosmic_notifications_config::ID)
                 .map(|res| {
@@ -217,7 +217,7 @@ impl cosmic::Application for Notifications {
                             c.1.push(n);
                             c.3 = fl!(
                                 "show-more",
-                                HashMap::from_iter(vec![("more", c.1.len().saturating_sub(1))])
+                                HashMap::from([("more", c.1.len().saturating_sub(1))])
                             );
                         }
                     } else {
@@ -225,7 +225,7 @@ impl cosmic::Application for Notifications {
                             id::Cards::new(n.app_name.clone()),
                             vec![n],
                             false,
-                            fl!("show-more", HashMap::from_iter(vec![("more", "1")])),
+                            fl!("show-more", HashMap::from([("more", "1")])),
                             fl!("show-less"),
                             fl!("clear-group"),
                         ));
@@ -263,7 +263,7 @@ impl cosmic::Application for Notifications {
                         c.1.retain(|n| n.id != id);
                         c.3 = fl!(
                             "show-more",
-                            HashMap::from_iter(vec![("more", c.1.len().saturating_sub(1))])
+                            HashMap::from([("more", c.1.len().saturating_sub(1))])
                         );
                     }
                     self.cards.retain(|c| !c.1.is_empty());
@@ -581,9 +581,9 @@ fn duration_ago_msg(notification: &Notification) -> String {
         let min = d.as_secs() / 60;
         let hrs = min / 60;
         if hrs > 0 {
-            fl!("hours-ago", HashMap::from_iter(vec![("duration", hrs)]))
+            fl!("hours-ago", HashMap::from([("duration", hrs)]))
         } else {
-            fl!("minutes-ago", HashMap::from_iter(vec![("duration", min)]))
+            fl!("minutes-ago", HashMap::from([("duration", min)]))
         }
     } else {
         String::new()

--- a/cosmic-applet-notifications/src/subscriptions/notifications.rs
+++ b/cosmic-applet-notifications/src/subscriptions/notifications.rs
@@ -80,7 +80,7 @@ pub fn notifications(proxy: NotificationsAppletProxy<'static>) -> Subscription<O
                         cosmic::iced::futures::select! {
                             v = next_signal => {
                                 if let Some(msg) = v {
-                                    let Some(args) = msg.args().into_iter().next() else {
+                                    let Ok(args) = msg.args() else {
                                         break;
                                     };
                                     let notification = Notification::new(

--- a/cosmic-applet-status-area/src/components/app.rs
+++ b/cosmic-applet-status-area/src/components/app.rs
@@ -380,8 +380,7 @@ impl cosmic::Application for App {
                     }
 
                     self.overflow_popup = Some(popup_id);
-                    let cmds = vec![get_popup(popup_settings)];
-                    return Task::batch(cmds);
+                    return get_popup(popup_settings);
                 } else {
                     return Task::none();
                 }

--- a/cosmic-applet-tiling/src/window.rs
+++ b/cosmic-applet-tiling/src/window.rs
@@ -132,7 +132,7 @@ impl cosmic::Application for Window {
             .timeline
             .as_subscription()
             .map(|(_, now)| Message::Frame(now));
-        Subscription::batch(vec![
+        Subscription::batch([
             timeline,
             self.core
                 .watch_config::<CosmicCompConfig>("com.system76.CosmicComp")

--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -125,12 +125,11 @@ impl Window {
             first_day_of_week,
         );
 
-        let mut day_iter = first_day.iter_days();
+        let day_iter = first_day.iter_days();
         let prefs = DateTimeFormatterPreferences::from(self.locale.clone());
         let weekday = DateTimeFormatter::try_new(prefs, fieldsets::E::short()).unwrap();
 
-        for _ in 0..7 {
-            let date = day_iter.next().unwrap();
+        for date in day_iter.take(7) {
             let datetime = self.create_datetime(&date);
             calendar = calendar.push(
                 text::caption(weekday.format(&datetime).to_string())
@@ -447,7 +446,7 @@ impl cosmic::Application for Window {
         }
 
         let show_seconds_rx = self.show_seconds_tx.subscribe();
-        Subscription::batch(vec![
+        Subscription::batch([
             rectangle_tracker_subscription(0).map(|e| Message::Rectangle(e.1)),
             time_subscription(show_seconds_rx),
             activation_token_subscription(0).map(Message::Token),

--- a/cosmic-applet-workspaces/src/components/app.rs
+++ b/cosmic-applet-workspaces/src/components/app.rs
@@ -351,7 +351,7 @@ impl cosmic::Application for IcedWorkspacesApplet {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        Subscription::batch(vec![
+        Subscription::batch([
             workspaces().map(Message::WorkspaceUpdate),
             event::listen_with(|e, _, _| match e {
                 Mouse(mouse::Event::WheelScrolled { delta }) => Some(Message::WheelScrolled(delta)),


### PR DESCRIPTION
Some minor refactors like removing `clone()`s, replacing with references, avoiding allocating `Vec`s when they weren't necessary, etc.

There's also a new `std::cmp::Ord` impl for `ActiveConnectionInfo`, which should be heaps better than using `format!`. I had to also impl `std::cmp::PartialCmp` manually to do that, but the actual logic there shouldn't matter as long as it agrees with `std::cmp::Ord`.