### PR TITLE
fixup! perf: refactor to reduce memory allocations and cpu work

### DIFF
--- a/cosmic-applet-network/src/network_manager/current_networks.rs
+++ b/cosmic-applet-network/src/network_manager/current_networks.rs
@@ -116,10 +116,10 @@ impl std::cmp::Ord for ActiveConnectionInfo {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (self, other) {
             (Self::Vpn { .. }, Self::Wired { .. } | Self::WiFi { .. })
-            | (Self::Wired { .. }, Self::WiFi { .. }) => std::cmp::Ordering::Greater,
+            | (Self::Wired { .. }, Self::WiFi { .. }) => std::cmp::Ordering::Less,
 
             (Self::WiFi { .. }, Self::Wired { .. } | Self::Vpn { .. })
-            | (Self::Wired { .. }, Self::Vpn { .. }) => std::cmp::Ordering::Less,
+            | (Self::Wired { .. }, Self::Vpn { .. }) => std::cmp::Ordering::Greater,
 
             (Self::Vpn { name: n1, .. }, Self::Vpn { name: n2, .. })
             | (Self::Wired { name: n1, .. }, Self::Wired { name: n2, .. })


### PR DESCRIPTION
I mixed up `Ordering::Greater` and `Ordering::Less` :smiling_face_with_tear: (sorts are in ascending order)

fixes dd0158d8f0ac83eaae4097474c8960616b751815