### PR TITLE
fix (network): reversed order of WAPs

### DIFF
--- a/cosmic-applet-network/src/network_manager/mod.rs
+++ b/cosmic-applet-network/src/network_manager/mod.rs
@@ -631,7 +631,7 @@ impl NetworkManagerState {
             })
             .cloned()
             .collect();
-        wireless_access_points.sort_by_key(|ap| ap.strength);
+        wireless_access_points.sort_by(|a, b| b.strength.cmp(&a.strength));
         self_.wireless_access_points = wireless_access_points;
         for ap in &self_.wireless_access_points {
             tracing::info!(


### PR DESCRIPTION
Don't blindly use `sort_by_key` when wanting a descending order search... my bad :cry:

fixes: dd0158d8f0ac83eaae4097474c8960616b751815
closes: #1110 