### PR TITLE
fix: Align brightness reporting with cosmic-osd

### DIFF
--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -139,12 +139,9 @@ impl CosmicBatteryApplet {
         let raw = self.screen_brightness? as i64;
         let max = self.max_screen_brightness?.max(1) as i64;
         if max <= 20 {
-            // Matching brightness calculation logic from cosmic-osd and cosmic-settings-daemon
-            let mut k = (raw * 20 + max / 2) / max;
-            if k < 0 { k = 0; }
-            if k > 20 { k = 20; }
-            let p = if k == 0 { 1 } else { 5 * k };
-            Some((p as f64) / 100.0)
+            // Coarse panels (<=20 brightness levels)
+            let rung = (raw.saturating_add(1)).min(20);
+            Some((5 * rung) as f64 / 100.0)
         } else {
             let p = ((raw * 100 + max / 2) / max).clamp(1, 100) as f64;
             Some(p / 100.0)


### PR DESCRIPTION
This is a follow-up PR to https://github.com/pop-os/cosmic-osd/pull/148 and https://github.com/pop-os/cosmic-settings-daemon/pull/113 to align brightness reporting calculation between cosmic-osd and cosmic-applet-battery slider.

This mismatch occurs in rare cases where the raw brightness scale for hardware is less than 20 units (as seen in System76 Darter Pro 8)