### PR TITLE
fix(battery): start and end threshold check

### DIFF
--- a/cosmic-applet-battery/src/backend/mod.rs
+++ b/cosmic-applet-battery/src/backend/mod.rs
@@ -220,7 +220,7 @@ pub async fn get_charging_limit() -> anyhow::Result<bool> {
             match backend {
                 Backend::S76PowerDaemon(proxy) => {
                     if let Ok((start, end)) = proxy.get_charge_thresholds().await {
-                        return Ok(start > 0 || end > 0);
+                        return Ok(end > start && end < 100);
                     }
                 }
                 Backend::PowerProfilesDaemon(_) => {


### PR DESCRIPTION
end limits should be greater than start and end should be < 100 for it to be considered enabled. fixes #1019