### PR TITLE
Check if connection is of wireguard type

### DIFF
--- a/cosmic-applet-network/src/network_manager/mod.rs
+++ b/cosmic-applet-network/src/network_manager/mod.rs
@@ -396,7 +396,10 @@ async fn start_listening(
                             if let Ok(conn_id) = active_conn.id().await {
                                 if conn_id == name
                                     && (active_conn.vpn().await.unwrap_or(false)
-                                        || active_conn.type_().await.unwrap_or("unknown")
+                                        || active_conn
+                                            .type_()
+                                            .await
+                                            .unwrap_or("unknown".to_string())
                                             == "wireguard")
                                 {
                                     match network_manager.deactivate_connection(&active_conn).await


### PR DESCRIPTION
For some reason `active_conn.vpn()` returns false for my wireguard connection, because that it fails to deactivate vpn. This fixes that issue, but maybe this should be fixed in dbus-settings-bindings