### PR TITLE
i18n(notifications): 'Just now' instead of '0 minutes ago'

### DIFF
--- a/cosmic-applet-notifications/i18n/en/cosmic_applet_notifications.ftl
+++ b/cosmic-applet-notifications/i18n/en/cosmic_applet_notifications.ftl
@@ -1,11 +1,13 @@
-hours-ago = { $duration } { $duration ->
-    [one] hour
-    *[other] hours
-} ago
-minutes-ago = { $duration } { $duration ->
-    [one] minute
-    *[other] minutes
-} ago
+hours-ago = { $duration ->
+    [0] Just now
+    [one] 1 hour ago
+    *[other] { $duration } hours ago
+}
+minutes-ago = { $duration ->
+    [0] Just now
+    [one] 1 minute ago
+    *[other] { $duration } minutes ago
+}
 show-less = Show less
 show-more = Show {$more} more
 clear-group = Clear group


### PR DESCRIPTION
When the notification is new (< 1 minute), the time of arrival now shows up as 'Just now' instead of '0 minutes ago'.

<img width="496" height="592" alt="notifications" src="https://github.com/user-attachments/assets/18c4873b-15db-460d-81a5-6a22cbf6b961" />