### PR TITLE
update rust toolchain from 1.85.1 to 1.87.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85.1
+          toolchain:1.87.0
           components: clippy
       - name: install dependencies
         run: sudo apt update && sudo apt install -y libxkbcommon-dev libwayland-dev libdbus-1-dev libpulse-dev libpipewire-0.3-dev libinput-dev
       - uses: actions-rs-plus/clippy-check@v2
         with:
-          toolchain: 1.85.1
+          toolchain:1.87.0
           args: --all --all-targets --all-features

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.87.0"


### PR DESCRIPTION
Not sure how you manage to build cosmic-applets right now but I get this error, which this pull requests resolves:

```
error: rustc 1.85.1 is not supported by the following package:
  fast_image_resize@5.3.0 requires rustc 1.87.0
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.85.1
```