### PR TITLE
Support FreeBSD coreutils

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,10 +37,10 @@ _link_applet name:
     ln -sf {{cosmic-applets-bin}} {{bindir}}/{{name}}
 
 _install_icons name:
-    find {{name}}/'data'/'icons' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -d '\n' -I {} install -Dm0644 {{name}}/'data'/'icons'/{} {{iconsdir}}/{}
+    find {{name}}/'data'/'icons' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -L1 -I {} install -Dm0644 {{name}}/'data'/'icons'/{} {{iconsdir}}/{}
 
 _install_default_schema name:
-    find {{name}}/'data'/'default_schema' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -d '\n' -I {} install -Dm0644 {{name}}/'data'/'default_schema'/{} {{default-schema-target}}/{}
+    find {{name}}/'data'/'default_schema' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -L1 -I {} install -Dm0644 {{name}}/'data'/'default_schema'/{} {{default-schema-target}}/{}
 
 _install_desktop path:
     install -Dm0644 {{path}} {{sharedir}}/applications/{{file_name(path)}}


### PR DESCRIPTION
Chimera Linux uses the FreeBSD coreutils

I had two issues when building cosmic on chimera:
1. `xargs -d` is [not supported](https://man.freebsd.org/cgi/man.cgi?xargs)
2. `sed 's|...|..'` (using pipes as delimiters) is not supported