### PR TITLE
add option to display battery as percentage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "libcosmic",
  "rust-embed",
  "rustc-hash 2.1.1",
+ "serde",
  "tokio",
  "tracing",
  "tracing-log",

--- a/cosmic-applet-battery/Cargo.toml
+++ b/cosmic-applet-battery/Cargo.toml
@@ -24,3 +24,4 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 udev = "0.9"
 zbus.workspace = true
+serde.workspace = true

--- a/cosmic-applet-battery/src/config.rs
+++ b/cosmic-applet-battery/src/config.rs
@@ -1,4 +1,12 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
+use cosmic::cosmic_config::{self, CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry};
+use serde::{Deserialize, Serialize};
 
 pub const APP_ID: &str = "com.system76.CosmicAppletButton";
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, CosmicConfigEntry, PartialEq, Eq)]
+#[version = 1]
+pub struct PowerAppletConfig {
+    pub display_as_percentage: bool,
+}


### PR DESCRIPTION
I like to see my battery as a percentage instead of an icon, and it seemed like an easy enough thing to try doing myself.
I did a good bit of copy/pasting from other applets.
The option to enable it is  ~/.config/cosmic/com.system76.CosmicAppletButton/v1/display_as_percentage
It uses `core.watch_config` that I copied from the time applet to update its own config.
I also added a config type for this applet, `display_as_percentage` is currently the only field (with all the derives and macros copied from another applet).
I noticed this didn't create the config file on my system, not sure if that's something the applet should check for, but it does react to changes to the config file.
Also idk how to get the applet to live on the bar/panel, so I haven't been able to test if the width is acceptable.