### PR TITLE
fix(audio): disable auto-profile set on init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "cosmic-pipewire"
 version = "1.0.0-beta6"
-source = "git+https://github.com/pop-os/cosmic-settings?branch=sound#07ae9647e6ae57ad572c978e0ecfa15f78c45f11"
+source = "git+https://github.com/pop-os/cosmic-settings#107f19b03e0107f96e7199b466e01f3d6a670a4b"
 dependencies = [
  "intmap",
  "libspa",
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-sound-subscription"
 version = "1.0.0-beta6"
-source = "git+https://github.com/pop-os/cosmic-settings?branch=sound#07ae9647e6ae57ad572c978e0ecfa15f78c45f11"
+source = "git+https://github.com/pop-os/cosmic-settings#107f19b03e0107f96e7199b466e01f3d6a670a4b"
 dependencies = [
  "cosmic-pipewire",
  "crossbeam-queue",

--- a/cosmic-applet-audio/Cargo.toml
+++ b/cosmic-applet-audio/Cargo.toml
@@ -24,4 +24,3 @@ zbus.workspace = true
 
 [dependencies.cosmic-settings-sound-subscription]
 git = "https://github.com/pop-os/cosmic-settings"
-branch = "sound"


### PR DESCRIPTION
Requires https://github.com/pop-os/cosmic-settings/pull/1607

Disables setting device profiles on applet init. May fix reports of having all sound devices set to `Off` on login (or resume from suspend?)
