### PR TITLE
[Time] Use medium fieldsets in horizontal

### DIFF
--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -262,7 +262,7 @@ impl Window {
 
             if self.config.show_date_in_top_panel {
                 if self.config.show_weekday {
-                    let mut fs = fieldsets::MDET::long();
+                    let mut fs = fieldsets::MDET::medium();
                     if !self.config.show_seconds {
                         fs = fs.with_time_precision(TimePrecision::Minute);
                     }
@@ -271,7 +271,7 @@ impl Window {
                         .format(&datetime)
                         .to_string()
                 } else {
-                    let mut fs = fieldsets::MDT::long();
+                    let mut fs = fieldsets::MDT::medium();
                     if !self.config.show_seconds {
                         fs = fs.with_time_precision(TimePrecision::Minute);
                     }


### PR DESCRIPTION
It seems ICU changed the behavior of `long()`, so it displayed in the panel as e.g. `December 11 at 13:00` instead of `December 11, 13:00`.
It now displays as `Dec 11, 13:00`, making it more compact and matching GNOME.

Potentially needs UX review.