### PR TITLE
fix(status-area): draw the context menu at the relevant icon

### DIFF
--- a/cosmic-applet-status-area/src/components/app.rs
+++ b/cosmic-applet-status-area/src/components/app.rs
@@ -230,7 +230,7 @@ impl cosmic::Application for App {
                                 Some((i, self.core.main_window_id().unwrap()))
                             }
                         })
-                        .unwrap_or((0, self.core.main_window_id().unwrap()));
+                        .unwrap_or((i, self.core.main_window_id().unwrap()));
 
                     let mut popup_settings = self
                         .core
@@ -312,7 +312,7 @@ impl cosmic::Application for App {
                             Some((i, self.core.main_window_id().unwrap()))
                         }
                     })
-                    .unwrap_or((0, self.core.main_window_id().unwrap()));
+                    .unwrap_or((i, self.core.main_window_id().unwrap()));
 
                 let mut popup_settings = self
                     .core


### PR DESCRIPTION
fixes #1216 

While testing this fix, I noticed a bunch of other issues:
- Hovering on other status area icons closes the current popup but doesn't open their pop up
- The icon for the overflow gets clipped
- If you change the panel size such that the it doesn't fit all the status area icons anymore, some of the icons just disappear and won't show up even if you open cosmic-applet-status-area outside the panel. I had to close those programs and open them again for the icons to show up again. 

I'll try to see if I can fix them and open separate PRs for them.