### PR TITLE
Fix stuck applet unresponsiveness by lazy-loading menu layouts

### DIFF
--- a/cosmic-applet-status-area/src/components/app.rs
+++ b/cosmic-applet-status-area/src/components/app.rs
@@ -478,7 +478,8 @@ impl cosmic::Application for App {
         subscriptions.push(status_notifier_watcher::subscription().map(Msg::StatusNotifier));
 
         for (id, menu) in &self.menus {
-            subscriptions.push(menu.subscription().with(*id).map(Msg::StatusMenu));
+            let is_open = self.open_menu == Some(*id);
+            subscriptions.push(menu.subscription(is_open).with(*id).map(Msg::StatusMenu));
         }
         subscriptions.push(activation_token_subscription(0).map(Msg::Token));
 

--- a/cosmic-applet-status-area/src/components/status_menu.rs
+++ b/cosmic-applet-status-area/src/components/status_menu.rs
@@ -154,11 +154,14 @@ impl State {
         }
     }
 
-    pub fn subscription(&self) -> iced::Subscription<Msg> {
-        iced::Subscription::batch([
-            self.item.layout_subscription().map(Msg::Layout),
-            self.item.icon_subscription().map(Msg::Icon),
-        ])
+    pub fn subscription(&self, is_open: bool) -> iced::Subscription<Msg> {
+        let mut subscriptions = vec![self.item.icon_subscription().map(Msg::Icon)];
+
+        if is_open {
+            subscriptions.push(self.item.layout_subscription().map(Msg::Layout));
+        }
+
+        iced::Subscription::batch(subscriptions)
     }
 
     pub fn opened(&self) {


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-applets/issues/1245 and 
https://github.com/pop-os/cosmic-applets/issues/1263

This PR fixes the "stuck VLC" bug where the status area applet would become unresponsive or leave "ghost" icons behind when interacting with VLC (specifically when launching videos).

The applet was previously "eager-loading" menu layouts. As soon as an icon was registered, we opened a subscription to `com.canonical.dbusmenu.GetLayout`.
However, VLC (and likely other applications) has a race condition or resource contention issue where it stops responding to `GetLayout` DBus calls while initializing video playback. Because the applet kept asking for the layout in the background, these requests would pile up and time out. These timeouts clogged the DBus connection, preventing the `StatusNotifierItemUnregistered` signal from being processed when VLC eventually closed, not only leaving the zombie icon of VLC but also breaking interaction with other icons.

**The Fix**
I have implemented **lazy-loading** for the menu layouts.

- Modified `State::subscription` to accept an `is_open` boolean.
- The `layout_subscription` (and the resulting `GetLayout` calls) is now only active when the user has actually clicked the icon to open the menu.
- The `Icon` subscription remains active at all times so the tray icon updates correctly.

**Verification**

- VLC: Launching a video no longer freezes the applet.
- Cleanup: Closing VLC removes the icon immediately (signals are no longer blocked by timeouts).
- Performance: Significantly reduced background DBus traffic for all tray items.

This also, in a way, complements #1251: it reduces background DBusMenu layout traffic, which otherwise could amplify the “frequent `GetLayout` under load” problem.