### PR TITLE
fix(audio-applet): Replace hardcoded string with existing fluent key

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -633,7 +633,7 @@ impl cosmic::Application for Audio {
                     fl!("output"),
                     match sink {
                         Some(sink) => sink.to_owned(),
-                        None => String::from("No device selected"),
+                        None => fl!("no-device"),
                     },
                     self.model.sinks(),
                     Message::OutputToggle,


### PR DESCRIPTION
- When no input device is selected, the 'no-device' fluent key is used. In English, this key translates to "No device selected".
- The exact same situation should apply for output devices, but the string there is hardcoded and therefore untranslatable.
- This utilizes the same 'no-device' key for output device, making it translatable.

### Before
<img width="348" height="386" alt="before2" src="https://github.com/user-attachments/assets/3f15ee1c-5200-4e56-9963-f6db60886227" />

### After
<img width="348" height="386" alt="after2" src="https://github.com/user-attachments/assets/f798fb99-5c11-4548-823d-2393ebd3b56e" />