### PR TITLE
refactor(network): Use nmrs for WiFi connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "indexmap 2.13.0",
  "libcosmic",
  "nm-secret-agent-manager",
+ "nmrs",
  "rust-embed",
  "rustc-hash 2.1.1",
  "secure-string",
@@ -2757,6 +2758,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -4644,6 +4651,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nmrs"
+version = "1.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7b61a6ea9fa68a6bf6303834ed7457254f825632642c62c18931951ae6ad59"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "log",
+ "serde",
+ "thiserror 2.0.17",
+ "uuid",
+ "zbus 5.13.1",
+ "zvariant 5.9.1",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6237,6 +6260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7218,6 +7247,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/cosmic-applet-network/Cargo.toml
+++ b/cosmic-applet-network/Cargo.toml
@@ -31,6 +31,7 @@ nm-secret-agent-manager = { git = "https://github.com/pop-os/dbus-settings-bindi
 indexmap = "2.13.0"
 secure-string = "0.3.0"
 uuid = { version = "1.19.0", features = ["v4"] }
+nmrs = "1.3.5"
 
 
 [dependencies.cosmic-settings-network-manager-subscription]


### PR DESCRIPTION
More than anything, this is a [feeler of sorts](https://www.reddit.com/r/rust/comments/1q5nawa/comment/ny47t1i/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) to see if I could bring in some value to this initiative. [My project, nmrs](https://github.com/cachebag/nmrs) provides (what I think to be) a pretty nice API for NetworkManager over D-Bus.

Happy to revise, re-approach, etc. where needed or if you guys in fact don't need this and prefer dealing with D-Bus directly, then of course feel free to close this. 

In either case, love what you guys are doing!

--

Replace D-Bus channel flow with direct nmrs API calls for WiFi connections. Provides typed error handling and simplifies code.

- Add nmrs 1.3.5 dependency
- Use `nmrs.connect()` for open and secured networks
- Add `ConnectionError` variants for better error messages
- Remove request/sender channel boilerplate\

Also replace channel-based D-Bus requests with direct nmrs API calls for
WiFi enable/disable and network forgetting. This provides some better error
feedback and waits for operations to complete.