### PR TITLE
fix(app-list): watch icon directories for file changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "image",
  "libcosmic",
  "memmap2 0.9.9",
+ "notify",
  "rust-embed",
  "rustc-hash 2.1.1",
  "rustix 1.1.3",

--- a/cosmic-app-list/Cargo.toml
+++ b/cosmic-app-list/Cargo.toml
@@ -15,6 +15,7 @@ i18n-embed-fl.workspace = true
 image = { version = "0.25.9", default-features = false }
 libcosmic.workspace = true
 memmap2 = "0.9.9"
+notify = "8.2"
 fastrand = "2.3.0"
 rust-embed.workspace = true
 rustix.workspace = true

--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -29,7 +29,7 @@ use cosmic::{
     cosmic_config::{Config, CosmicConfigEntry},
     desktop::IconSourceExt,
     iced::{
-        self, Alignment, Background, Border, Length, Limits, Padding, Subscription,
+        self, Alignment, Background, Border, Length, Limits, Padding, Subscription, stream,
         clipboard::mime::{AllowedMimeTypes, AsMimeTypes},
         event::listen_with,
         platform_specific::shell::commands::popup::{destroy_popup, get_popup},
@@ -182,6 +182,7 @@ impl DockItem {
         is_focused: bool,
         dot_border_radius: [f32; 4],
         window_id: window::Id,
+        icon_generation: u64,
     ) -> Element<'_, Message> {
         let Self {
             toplevels,
@@ -265,8 +266,16 @@ impl DockItem {
             .into(),
         };
 
+        // Sub-pixel padding tweak forces iced to detect a layout change when
+        // icon_generation bumps, triggering a redraw of SVG widgets. With
+        // pop-os/iced#264, draw() then re-stats the file and reloads on
+        // mtime change.
+        let mut btn_padding = app_icon.padding;
+        if icon_generation % 2 == 1 {
+            btn_padding.top += 0.001;
+        }
         let icon_button = button::custom(icon_wrapper)
-            .padding(app_icon.padding)
+            .padding(btn_padding)
             .selected(is_focused)
             .class(app_list_icon_style(is_focused));
 
@@ -361,6 +370,8 @@ struct CosmicAppList {
     hovered_toplevel: Option<ExtForeignToplevelHandleV1>,
     overflow_favorites_popup: Option<window::Id>,
     overflow_active_popup: Option<window::Id>,
+    /// Bumped on each icon file change to force iced to detect a view diff.
+    icon_generation: u64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -403,6 +414,7 @@ enum Message {
     OpenFavorites,
     OpenActive,
     Surface(surface::Action),
+    IconsChanged,
 }
 
 fn index_in_list(
@@ -1527,6 +1539,17 @@ impl cosmic::Application for CosmicAppList {
                         })
                         .collect();
             }
+            Message::IconsChanged => {
+                self.icon_generation = self.icon_generation.wrapping_add(1);
+                // The icon_generation bump forces iced to detect a view diff
+                // via a sub-pixel padding change, triggering a redraw that
+                // lets the renderer re-stat the SVG file. With pop-os/iced#264,
+                // the draw() call checks mtime and reloads changed files.
+                //
+                // We don't call update_desktop_entries() or update_pinned_list()
+                // here — the icon file path hasn't changed, just its content,
+                // and update_pinned_list() would reset toplevel associations.
+            }
             Message::CloseRequested(id) => {
                 if Some(id) == self.popup.as_ref().map(|p| p.id) {
                     self.popup = None;
@@ -1731,6 +1754,7 @@ impl cosmic::Application for CosmicAppList {
                                 .any(|y| focused_item.contains(&y.0.foreign_toplevel)),
                             dot_radius,
                             self.core.main_window_id().unwrap(),
+                            self.icon_generation,
                         ),
                         dock_item
                             .desktop_info
@@ -1786,6 +1810,7 @@ impl cosmic::Application for CosmicAppList {
                         .any(|y| focused_item.contains(&y.0.foreign_toplevel)),
                     dot_radius,
                     self.core.main_window_id().unwrap(),
+                    self.icon_generation,
                 ),
             );
         } else if self.is_listening_for_dnd && self.pinned_list.is_empty() {
@@ -1825,6 +1850,7 @@ impl cosmic::Application for CosmicAppList {
                                     .any(|y| focused_item.contains(&y.0.foreign_toplevel)),
                                 dot_radius,
                                 self.core.main_window_id().unwrap(),
+                                self.icon_generation,
                             ),
                             dock_item
                                 .desktop_info
@@ -2234,6 +2260,7 @@ impl cosmic::Application for CosmicAppList {
                                     .any(|y| focused_item.contains(&y.0.foreign_toplevel)),
                                 dot_radius,
                                 id,
+                                self.icon_generation,
                             ),
                             dock_item
                                 .desktop_info
@@ -2337,6 +2364,7 @@ impl cosmic::Application for CosmicAppList {
                                     .any(|y| focused_item.contains(&y.0.foreign_toplevel)),
                                 dot_radius,
                                 id,
+                                self.icon_generation,
                             ),
                             dock_item
                                 .desktop_info
@@ -2416,6 +2444,7 @@ impl cosmic::Application for CosmicAppList {
                 }
                 Message::ConfigUpdated(u.config)
             }),
+            icon_watcher_subscription().map(|_| Message::IconsChanged),
         ])
     }
 
@@ -2426,6 +2455,166 @@ impl cosmic::Application for CosmicAppList {
     fn on_close_requested(&self, id: window::Id) -> Option<Message> {
         Some(Message::CloseRequested(id))
     }
+}
+
+/// Subscription that watches icon theme directories for file changes via inotify.
+/// Emits a unit value when any icon file is created or modified, debounced to 500ms.
+fn icon_watcher_subscription() -> Subscription<()> {
+    Subscription::run_with_id(
+        std::any::TypeId::of::<IconWatcherMarker>(),
+        stream::channel(4, |mut output| async move {
+            use futures::SinkExt;
+            use notify::{EventKind, RecursiveMode, Watcher};
+
+            let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+
+            let mut watcher = match notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
+                if let Ok(event) = event {
+                    match event.kind {
+                        EventKind::Create(_) | EventKind::Modify(_) => {
+                            let _ = tx.blocking_send(());
+                        }
+                        _ => {}
+                    }
+                }
+            }) {
+                Ok(w) => w,
+                Err(e) => {
+                    tracing::warn!("Failed to create icon file watcher: {e}");
+                    pending::<()>().await;
+                    return;
+                }
+            };
+
+            for dir in icon_watch_dirs() {
+                if dir.is_dir() {
+                    if let Err(e) = watcher.watch(&dir, RecursiveMode::Recursive) {
+                        tracing::debug!("Failed to watch icon dir {}: {e}", dir.display());
+                    }
+                }
+            }
+
+            // Re-enumerate icon dirs every 5 minutes to pick up newly installed themes
+            let mut reenumerate = tokio::time::interval(Duration::from_secs(300));
+            reenumerate.tick().await; // consume immediate first tick
+
+            loop {
+                tokio::select! {
+                    event = rx.recv() => {
+                        if event.is_none() { break; }
+                        // Debounce: wait 500ms, drain any queued events
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        while rx.try_recv().is_ok() {}
+                        let _ = output.send(()).await;
+                    }
+                    _ = reenumerate.tick() => {
+                        for dir in icon_watch_dirs() {
+                            if dir.is_dir() {
+                                let _ = watcher.watch(&dir, RecursiveMode::Recursive);
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+    )
+}
+
+struct IconWatcherMarker;
+
+/// Returns icon directories to watch for changes.
+///
+/// Discovers `apps/` subdirectories under all icon themes found in
+/// XDG_DATA_HOME, XDG_DATA_DIRS, and ~/.icons, plus /usr/share/pixmaps.
+fn icon_watch_dirs() -> Vec<std::path::PathBuf> {
+    let mut bases = Vec::new();
+
+    // XDG_DATA_HOME (default: ~/.local/share)
+    if let Some(data_home) = std::env::var_os("XDG_DATA_HOME") {
+        bases.push(std::path::PathBuf::from(data_home));
+    } else if let Some(home) = std::env::var_os("HOME") {
+        bases.push(std::path::PathBuf::from(home).join(".local/share"));
+    }
+
+    // XDG_DATA_DIRS (default: /usr/local/share:/usr/share)
+    if let Some(data_dirs) = std::env::var_os("XDG_DATA_DIRS") {
+        for dir in std::env::split_paths(&data_dirs) {
+            bases.push(dir);
+        }
+    } else {
+        bases.push(std::path::PathBuf::from("/usr/local/share"));
+        bases.push(std::path::PathBuf::from("/usr/share"));
+    }
+
+    let mut dirs = Vec::new();
+
+    // For each base, scan icons/<theme>/<size>/apps/
+    for base in &bases {
+        let icons_dir = base.join("icons");
+        if let Ok(themes) = std::fs::read_dir(&icons_dir) {
+            for theme in themes.filter_map(|e| e.ok()) {
+                if !theme.path().is_dir() {
+                    continue;
+                }
+                if let Ok(sizes) = std::fs::read_dir(theme.path()) {
+                    for size in sizes.filter_map(|e| e.ok()) {
+                        let apps = size.path().join("apps");
+                        if apps.is_dir() {
+                            dirs.push(apps);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ~/.icons/<theme>/<size>/apps/
+    if let Some(home) = std::env::var_os("HOME") {
+        let home_icons = std::path::PathBuf::from(home).join(".icons");
+        if let Ok(themes) = std::fs::read_dir(&home_icons) {
+            for theme in themes.filter_map(|e| e.ok()) {
+                if !theme.path().is_dir() {
+                    continue;
+                }
+                if let Ok(sizes) = std::fs::read_dir(theme.path()) {
+                    for size in sizes.filter_map(|e| e.ok()) {
+                        let apps = size.path().join("apps");
+                        if apps.is_dir() {
+                            dirs.push(apps);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // /usr/share/pixmaps (legacy fallback, not under icon themes)
+    let pixmaps = std::path::PathBuf::from("/usr/share/pixmaps");
+    if pixmaps.is_dir() {
+        dirs.push(pixmaps);
+    }
+
+    // Resolve symlinks: if icons in watched dirs are symlinks pointing outside
+    // the hierarchy (e.g., /opt/myapp/icon.svg), also watch the target directories.
+    let mut symlink_target_dirs = Vec::new();
+    for dir in &dirs {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.filter_map(|e| e.ok()) {
+                if entry.path().symlink_metadata().map_or(false, |m| m.is_symlink()) {
+                    if let Ok(target) = std::fs::canonicalize(entry.path()) {
+                        if let Some(parent) = target.parent() {
+                            symlink_target_dirs.push(parent.to_path_buf());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    dirs.extend(symlink_target_dirs);
+
+    dirs.sort();
+    dirs.dedup();
+    dirs
 }
 
 fn launch_on_preferred_gpu(desktop_info: &DesktopEntry, gpus: Option<&[Gpu]>) -> Option<Message> {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

- Add a file system watcher (via the `notify` crate) that monitors system and user icon directories for changes
- When icon files are created or modified, trigger a view update that causes iced to re-render SVG widgets, allowing the renderer's mtime-based cache invalidation to detect and load the new icon content
- Discover icon directories dynamically: enumerate all `<theme>/<size>/apps/` subdirectories under `XDG_DATA_HOME`, `XDG_DATA_DIRS`, `~/.icons`, plus `/usr/share/pixmaps` as legacy fallback
- Resolve symlinks in watched directories to also watch target directories outside the XDG hierarchy (e.g., icons symlinked to `/opt/...`)
- Re-enumerate icon directories every 5 minutes to pick up newly installed icon themes without requiring a restart
- Debounce file events to 500ms to batch rapid changes

## Motivation

When an app's SVG icon file changes on disk (e.g., updated via package install), the COSMIC dock shows the stale icon for pinned items until the applet process restarts. This PR detects icon file changes via inotify and forces an immediate re-render.

Since iced has no public API for externally invalidating the SVG render cache or forcing a widget repaint from `update()`, the view refresh is triggered by a sub-pixel padding change (0.001px) keyed to a generation counter. This is sufficient to cause iced's layout diff to detect a change and repaint the affected SVG widgets.

## Dependencies

Requires pop-os/iced#264 (mtime-based SVG cache invalidation in the tiny_skia renderer) — without it, the triggered redraws have no mtime-checking logic to activate.

## Test plan

- [x] Pin an app with an SVG icon to the dock
- [x] Replace the SVG file on disk with a visually different one
- [x] Icon should update within ~1 second without any user interaction
- [x] Verify rename-based update works (write to `.tmp`, `mv` over original — simulates dpkg atomic replacement)
- [x] Verify running apps still show window indicators after icon refresh (toplevel associations preserved)
- [x] Check `/proc/<pid>/fd` count for inotify fd leaks after extended use

Signed-off-by: ModelMiser <hello@modelmiser.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
