### PR TITLE
i18n: translate desktop entries with xdgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "xdgen",
 ]
 
 [[package]]
@@ -2658,6 +2659,16 @@ dependencies = [
  "thiserror 2.0.18",
  "unicase",
  "xdg",
+]
+
+[[package]]
+name = "freedesktop_entry_parser"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6d3a3635983a889f065aa9ce760384713f23a9b4a04f696f86c39a5d7a6a5a"
+dependencies = [
+ "indexmap 2.13.0",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -8313,6 +8324,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdgen"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25af88f104f06d5aeb80c77e5eb85e6f6f355f86f6e34307a14befd716efe4bf"
+dependencies = [
+ "fluent",
+ "freedesktop_entry_parser",
+ "unic-langid",
+ "xmltree",
+]
+
+[[package]]
 name = "xkb-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8378,10 +8401,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc04313cab124e498ab1724e739720807b6dc405b9ed0edc5860164d2e4ff70"
+dependencies = [
+ "xml",
+]
 
 [[package]]
 name = "xmlwriter"

--- a/cosmic-app-list/data/com.system76.CosmicAppList.desktop
+++ b/cosmic-app-list/data/com.system76.CosmicAppList.desktop
@@ -1,31 +1,16 @@
 [Desktop Entry]
 Name=App Tray
-Name[ar]=درج التطبيقات
-Name[bg]=Меню за програми
-Name[cs]=Panel aplikací
-Name[zh_CN]=应用托盘
-Name[hu]=Alkalmazástálca
-Name[pl]=Zasobnik aplikacji
-Name[pt]=Bandeja de Aplicativos
-Name[de]=App-Tray
-Name[nl]=App-Tray
-Name[sk]=Panel aplikácií
-Name[sv]=Programfält
-Name[es]=Bandeja de aplicaciones
-Name[it]=Area applicazioni
-Name[uk]=Панель застосунків
+Comment=Launch pinned apps and manage open windows
 Type=Application
 Exec=cosmic-app-list
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;App;Tray;List;Task;Bar;
 Icon=com.system76.CosmicAppList
 StartupNotify=true
 NoDisplay=true
 X-CosmicApplet=true
 X-MinimizeApplet=5
-# Indicate that the applet should be shrunk if the panel is too small to fit it
 X-OverflowPriority=100
 X-OverflowMinSize=4
 X-HostWaylandDisplay=true

--- a/cosmic-applet-a11y/data/com.system76.CosmicAppletA11y.desktop
+++ b/cosmic-applet-a11y/data/com.system76.CosmicAppletA11y.desktop
@@ -1,30 +1,15 @@
 [Desktop Entry]
 Name=Accessibility
-Name[ar]=الإتاحة
-Name[bg]=Достъпност
-Name[cs]=Přístupnost
-Name[zh_CN]=无障碍
-Name[hu]=Akadálymentesség
-Name[pl]=Dostępność
-Name[pt]=Acessibilidade
-Name[nl]=Toegankelijkheid
-Name[de]= Zugänglichkeit
-Name[sk]=Zjednodušenie ovládania
-Name[sv]=Tillgänglighet
-Name[es]=Accesibilidad
-Name[it]=Accessibilità
-Name[uk]=Доступність
+Comment=Configure accessibility settings from the panel
 Type=Application
 Exec=cosmic-applet-a11y
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Accessibility;A11y;Screen;Reader;Magnifier;Contrast;Color;
 Icon=preferences-desktop-accessibility-symbolic
 StartupNotify=true
 NoDisplay=true
 X-CosmicApplet=true
 X-CosmicShrinkable=true
-# Indicates that the auto-hover click should go to the "end" of the hover popup
 X-CosmicHoverPopup=Auto
 X-OverflowPriority=10

--- a/cosmic-applet-audio/data/com.system76.CosmicAppletAudio.desktop
+++ b/cosmic-applet-audio/data/com.system76.CosmicAppletAudio.desktop
@@ -1,31 +1,15 @@
 [Desktop Entry]
 Name=Sound
-Name[ar]=الصوت
-Name[bg]=Звук
-Name[cs]=Zvuk
-Name[zh_CN]=音频
-Name[ko]=코스믹 오디오 애플릿
-Name[hu]=Hang
-Name[pl]=Dźwięk
-Name[pt]=Som
-Name[nl]=Geluid
-Name[de]=Klang
-Name[sk]=Zvuk
-Name[sv]=Ljud
-Name[es]=Sonido
-Name[it]=Audio
-Name[uk]=Звук
+Comment=Audio device selection, volume control, and MPRIS media controls
 Type=Application
 Exec=cosmic-applet-audio
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Sound;Audio;MPRIS;
 Icon=com.system76.CosmicAppletAudio-symbolic
 StartupNotify=true
 NoDisplay=true
 X-CosmicApplet=true
 X-CosmicShrinkable=true
-# Indicates that the auto-hover click should go to the "end" of the hover popup
 X-CosmicHoverPopup=End
 X-OverflowPriority=10

--- a/cosmic-applet-battery/data/com.system76.CosmicAppletBattery.desktop
+++ b/cosmic-applet-battery/data/com.system76.CosmicAppletBattery.desktop
@@ -1,25 +1,11 @@
 [Desktop Entry]
 Name=Power & Battery
-Name[ar]=الطاقة والبطارية
-Name[bg]=Захранване и батерия
-Name[cs]=Napájení a baterie
-Name[zh_CN]=电源与电池
-Name[ko]=코스믹 배터리 애플릿
-Name[hu]=Energia és Akkumulátor
-Name[pl]=Zasilanie i bateria
-Name[pt]=Energia e Bateria
-Name[nl]=Energie en batterij
-Name[de]=Energie und Akku
-Name[sk]=Napájanie a batéria
-Name[sv]=Ström & batteri
-Name[it]=Alimentazione e batteria
-Name[uk]=Живлення та акумулятор
+Comment=Power modes and power saving options
 Type=Application
 Exec=cosmic-applet-battery
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Power;Battery;
 Icon=com.system76.CosmicAppletBattery-symbolic
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-bluetooth/data/com.system76.CosmicAppletBluetooth.desktop
+++ b/cosmic-applet-bluetooth/data/com.system76.CosmicAppletBluetooth.desktop
@@ -1,13 +1,11 @@
 [Desktop Entry]
 Name=Bluetooth
-Name[ar]=بلوتوث
-Name[zh_CN]=蓝牙
+Comment=Manage Bluetooth devices
 Type=Application
 Exec=cosmic-applet-bluetooth
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Bluetooth;
 Icon=com.system76.CosmicAppletBluetooth-symbolic
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-input-sources/data/com.system76.CosmicAppletInputSources.desktop
+++ b/cosmic-applet-input-sources/data/com.system76.CosmicAppletInputSources.desktop
@@ -1,25 +1,11 @@
 [Desktop Entry]
 Name=Input Sources
-Name[ar]=مصادر الإدخال
-Name[bg]=Входни устройства
-Name[cs]=Vstupní zdroje
-Name[zh_CN]=输入源
-Name[hu]=Beviteli Források
-Name[pl]=Źródła wprowadzdania danych
-Name[pt]=Métodos de Entrada de Teclado
-Name[nl]=Invoerbronnen
-Name[de]=Eigangsquellen
-Name[sk]=Vstupné zdroje
-Name[es]=Fuentes de entrada de teclado
-Name[sv]=Inmatningskällor
-Name[it]=Sorgenti di immissione
-Name[uk]=Джерела введення
+Comment=Switch between input sources
 Type=Application
 Exec=cosmic-applet-input-sources
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Input;Source;
 Icon=com.system76.CosmicAppletInputSources-symbolic
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-minimize/data/com.system76.CosmicAppletMinimize.desktop
+++ b/cosmic-applet-minimize/data/com.system76.CosmicAppletMinimize.desktop
@@ -1,25 +1,11 @@
 [Desktop Entry]
 Name=Minimized Windows
-Name[ar]=النوافذ المصغّرة
-Name[bg]=Минимизирани прозорци
-Name[cs]=Minimalizovaná okna
-Name[zh_CN]=最小化窗口
-Name[hu]=Kis méretű ablakok
-Name[pl]=Zminimalizowane okna
-Name[pt]=Janelas Minimizadas
-Name[nl]=Geminimaliseerde vensters
-Name[de]=Minimierte Fenster
-Name[sk]=Minimalizované okná
-Name[es]=Ventanas minimizadas
-Name[sv]=Minimera fönster
-Name[it]=Finestre minimizzate
-Name[uk]=Згорнуті вікна
+Comment=Manage minimized windows
 Type=Application
 Exec=cosmic-applet-minimize
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Minimize;
 Icon=com.system76.CosmicAppletMinimize
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-network/data/com.system76.CosmicAppletNetwork.desktop
+++ b/cosmic-applet-network/data/com.system76.CosmicAppletNetwork.desktop
@@ -1,25 +1,11 @@
 [Desktop Entry]
 Name=Network
-Name[ar]=الشبكة
-Name[bg]=Мрежа
-Name[cs]=Síť
-Name[zh_CN]=网络
-Name[hu]=Hálózat
-Name[pl]=Sieć
-Name[pt]=Rede
-Name[nl]=Netwerk
-Name[de]=Netzwerk
-Name[sk]=Sieť
-Name[sv]=Nätverk
-Name[es]=Red
-Name[it]=Rete
-Name[uk]=Мережа
+Comment=Manage network connections
 Type=Application
 Exec=cosmic-applet-network
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Network;
 Icon=com.system76.CosmicAppletNetwork-symbolic
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-notifications/data/com.system76.CosmicAppletNotifications.desktop
+++ b/cosmic-applet-notifications/data/com.system76.CosmicAppletNotifications.desktop
@@ -1,25 +1,11 @@
 [Desktop Entry]
 Name=Notifications Center
-Name[ar]=مركز الإشعارات
-Name[bg]=Център за известия
-Name[cs]=Centrum oznámení
-Name[zh_CN]=通知中心
-Name[hu]=Értesítési központ
-Name[pl]=Centrum powiadomień
-Name[pt]=Central de Notificações
-Name[nl]=Meldingscentrum
-Name[de]=Notifizierungszentrum
-Name[sk]=Centrum oznámení
-Name[sv]=Aviseringscenter
-Name[es]=Centro de notificaciones
-Name[it]=Centro notifiche
-Name[uk]=Центр сповіщень
+Comment=Manage notifications and Do Not Disturb
 Type=Application
 Exec=cosmic-applet-notifications
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Notification;
 Icon=com.system76.CosmicAppletNotifications-symbolic
 NoDisplay=true
 X-CosmicApplet=true

--- a/cosmic-applet-power/data/com.system76.CosmicAppletPower.desktop
+++ b/cosmic-applet-power/data/com.system76.CosmicAppletPower.desktop
@@ -1,24 +1,11 @@
 [Desktop Entry]
 Name=User Session
-Name[ar]=جلسة المستخدم
-Name[bg]=Потребителска сесия
-Name[cs]=Uživatelská relace
-Name[zh_CN]=用户会话
-Name[hu]=Felhasználói Munkamenet
-Name[pl]=Sesja użytkownika
-Name[pt]=Sessão de Usuário
-Name[nl]=Gebruikerssessie
-Name[sk]=Používateľská relácia
-Name[sv]=Användarsession
-Name[es]=Sesión de usuario
-Name[it]=Sessione utente
-Name[uk]=Сеанс користувача
+Comment=Lock screen, log out, suspend, reboot, and shutdown
 Type=Application
 Exec=cosmic-applet-power
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;User;Session;Lock;Log;Reboot;Shutdown;Suspend;
 Icon=com.system76.CosmicAppletPower-symbolic
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-status-area/data/com.system76.CosmicAppletStatusArea.desktop
+++ b/cosmic-applet-status-area/data/com.system76.CosmicAppletStatusArea.desktop
@@ -1,24 +1,11 @@
 [Desktop Entry]
 Name=Notifications Tray
-Name[ar]=درج الإشعارات
-Name[bg]=Тава за известия
-Name[cs]=Panel oznámení
-Name[zh_CN]=通知托盘
-Name[hu]=Értesítési terület
-Name[nl]=Meldingsvlak
-Name[pl]=Zasobnik powiadomień
-Name[pt]=Área de Notificações
-Name[sk]=Panel oznámení
-Name[sv]=Fält för programikoner
-Name[es]=Bandeja de notificaciones
-Name[it]=Area notifiche
-Name[uk]=Область сповіщень
+Comment=Application indicators which may export menus to the panel
 Type=Application
 Exec=cosmic-applet-status-area
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;App;Indicator;Notification;Tray;Status;
 Icon=com.system76.CosmicAppletStatusArea
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-tiling/data/com.system76.CosmicAppletTiling.desktop
+++ b/cosmic-applet-tiling/data/com.system76.CosmicAppletTiling.desktop
@@ -1,25 +1,11 @@
 [Desktop Entry]
 Name=Tiling
-Name[ar]=تبليط
-Name[bg]=Прилепване на прозорци
-Name[cs]=Dlaždicový režim oken
-Name[zh_CN]=平铺
-Name[hu]=Csempézés
-Name[pl]=Kafelkowanie
-Name[pt_BR]=Janelas Lado a Lado
-Name[pt]=Janelas Lado a Lado
-Name[nl]=Vensters tegelen
-Name[sk]=Dláždenie okien
-Name[sv]=Kakling
-Name[es]=Ventanas mosaico
-Name[it]=Tiling
-Name[uk]=Укладання
+Comment=Manage the active hint, current & per-workspace auto-tiling
 Type=Application
 Exec=cosmic-applet-tiling
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Tiling;Hint;Workspace;
 Icon=com.system76.CosmicAppletTiling-symbolic
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applet-time/data/com.system76.CosmicAppletTime.desktop
+++ b/cosmic-applet-time/data/com.system76.CosmicAppletTime.desktop
@@ -1,24 +1,11 @@
 [Desktop Entry]
 Name=Date, Time & Calendar
-Name[ar]=التاريخ والوقت والتقويم
-Name[bg]=Дата, час и календар
-Name[cs]=Datum, čas a kalendář
-Name[zh_CN]=日期、时间和日历
-Name[hu]=Dátum, Idő és Naptár
-Name[pl]=Data, godzina i kalendarz
-Name[pt]=Data, Hora e Calendário
-Name[nl]=Datum, tijd en agenda
-Name[sk]=Dátum, čas a kalendár
-Name[es]=Fecha, hora y calendario
-Name[sv]=Datum, Tid & Kalender
-Name[it]=Data, ora e calendario
-Name[uk]=Дата, час і календар
+Comment=Display the current time in the panel with a calendar popup
 Type=Application
 Exec=cosmic-applet-time
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Date;Time;Calendar;
 Icon=com.system76.CosmicAppletTime-symbolic
 NoDisplay=true
 X-CosmicApplet=true

--- a/cosmic-applet-workspaces/data/com.system76.CosmicAppletWorkspaces.desktop
+++ b/cosmic-applet-workspaces/data/com.system76.CosmicAppletWorkspaces.desktop
@@ -1,23 +1,11 @@
 [Desktop Entry]
 Name=Numbered Workspaces
-Name[ar]=مساحات عمل مرقمة
-Name[bg]=Номерирани работни пространства
-Name[cs]=Číslované pracovní plochy
-Name[zh_CN]=工作区编号
-Name[hu]=Számozott Munkaterületek
-Name[pl]=Obszary robocze według numeru
-Name[pt]=Áreas de Trabalho Numeradas
-Name[nl]=Genummerde werkbladen
-Name[sk]=Číslované pracovné plochy
-Name[sv]=Numrerade arbetsytor
-Name[es]=Espacios de trabajo numerados
-Name[it]=Spazi di lavoro numerati
-Name[uk]=Нумеровані робочі простори
+Comment=Switch between numbered workspaces in the panel
 Type=Application
 Exec=cosmic-applet-workspaces
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
+Keywords=COSMIC;Applet;Workspace;
 Icon=com.system76.CosmicAppletWorkspaces
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-applets/Cargo.toml
+++ b/cosmic-applets/Cargo.toml
@@ -4,6 +4,9 @@ version = "1.0.2"
 edition = "2024"
 license = "GPL-3.0-only"
 
+[build-dependencies]
+xdgen = "0.1"
+
 [dependencies]
 cosmic-app-list = { path = "../cosmic-app-list" }
 cosmic-applet-audio = { path = "../cosmic-applet-audio" }

--- a/cosmic-applets/build.rs
+++ b/cosmic-applets/build.rs
@@ -1,0 +1,126 @@
+use std::fs;
+use xdgen::{App, Context, FluentString};
+
+fn main() {
+    let ctx = Context::new("../i18n/", "desktop_entries").unwrap();
+
+    [
+        (
+            "com.system76.CosmicAppList",
+            "cosmic-app-list",
+            "cosmic-app-list-comment",
+            "cosmic-app-list-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletA11y",
+            "cosmic-applet-a11y",
+            "cosmic-applet-a11y-comment",
+            "cosmic-applet-a11y-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletAudio",
+            "cosmic-applet-audio",
+            "cosmic-applet-audio-comment",
+            "cosmic-applet-audio-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletBattery",
+            "cosmic-applet-battery",
+            "cosmic-applet-battery-comment",
+            "cosmic-applet-battery-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletBluetooth",
+            "cosmic-applet-bluetooth",
+            "cosmic-applet-bluetooth-comment",
+            "cosmic-applet-bluetooth-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletInputSources",
+            "cosmic-applet-input-sources",
+            "cosmic-applet-input-sources-comment",
+            "cosmic-applet-input-sources-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletMinimize",
+            "cosmic-applet-minimize",
+            "cosmic-applet-minimize-comment",
+            "cosmic-applet-minimize-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletNetwork",
+            "cosmic-applet-network",
+            "cosmic-applet-network-comment",
+            "cosmic-applet-network-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletNotifications",
+            "cosmic-applet-notifications",
+            "cosmic-applet-notifications-comment",
+            "cosmic-applet-notifications-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletPower",
+            "cosmic-applet-power",
+            "cosmic-applet-power-comment",
+            "cosmic-applet-power-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletStatusArea",
+            "cosmic-applet-status-area",
+            "cosmic-applet-status-area-comment",
+            "cosmic-applet-status-area-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletTiling",
+            "cosmic-applet-tiling",
+            "cosmic-applet-tiling-comment",
+            "cosmic-applet-tiling-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletTime",
+            "cosmic-applet-time",
+            "cosmic-applet-time-comment",
+            "cosmic-applet-time-keywords",
+        ),
+        (
+            "com.system76.CosmicAppletWorkspaces",
+            "cosmic-applet-workspaces",
+            "cosmic-applet-workspaces-comment",
+            "cosmic-applet-workspaces-keywords",
+        ),
+        (
+            "com.system76.CosmicPanelAppButton",
+            "cosmic-panel-app-button",
+            "cosmic-panel-app-button-comment",
+            "cosmic-panel-app-button-keywords",
+        ),
+        (
+            "com.system76.CosmicPanelLauncherButton",
+            "cosmic-panel-launcher-button",
+            "cosmic-panel-launcher-button-comment",
+            "cosmic-panel-launcher-button-keywords",
+        ),
+        (
+            "com.system76.CosmicPanelWorkspacesButton",
+            "cosmic-panel-workspaces-button",
+            "cosmic-panel-workspaces-button-comment",
+            "cosmic-panel-workspaces-button-keywords",
+        ),
+    ]
+    .into_iter()
+    .map(|(id, name, comment, keywords)| {
+        let template_path = ["../", name, "/data/", id, ".desktop"].concat();
+
+        let app = App::new(FluentString(name))
+            .comment(FluentString(comment))
+            .keywords(FluentString(keywords));
+
+        (id, app.expand_desktop(&template_path, &ctx).unwrap())
+    })
+    .for_each(|(id, contents)| {
+        let parent = "../target/xdgen/";
+        fs::create_dir_all(parent).unwrap();
+        fs::write([parent, id, ".desktop"].concat().as_str(), contents).unwrap();
+    });
+}

--- a/cosmic-panel-app-button/data/com.system76.CosmicPanelAppButton.desktop
+++ b/cosmic-panel-app-button/data/com.system76.CosmicPanelAppButton.desktop
@@ -1,27 +1,11 @@
 [Desktop Entry]
 Name=App Library Button
-Name[ar]=زر مكتبة التطبيقات
-Name[bg]=Бутон за библиотеката с програми
-Name[cs]=Tlačítko knihovny aplikací
-Name[zh_CN]=应用程序库按钮
-Name[es]=Botón de biblioteca de aplicaciones
-Name[ja]=Cosmicパネルのアップライブラリーボタン
-Name[ko]=코스믹 패널 앱 라이브러리 단추
-Name[pl]=Przycisk biblioteki aplikacji
-Name[ru]=Кнопка библиотеки приложений на панели Cosmic
-Name[hu]=Alkalmazáskönyvtár gomb
-Name[pt_BR]=Botão da Biblioteca de Aplicativos
-Name[pt]=Botão da Biblioteca de Aplicativos
-Name[nl]=Knop appbibliotheek
-Name[sk]=Tlačidlo knižnice aplikácií
-Name[sv]=Knapp för programbibliotek
-Name[uk]=Бібліотека застосунків
+Comment=Open the application library for launching installed applications
 Type=Application
 Exec=cosmic-panel-button com.system76.CosmicAppLibrary
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;App;Library;Tray;
 Icon=com.system76.CosmicPanelAppButton
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-panel-launcher-button/data/com.system76.CosmicPanelLauncherButton.desktop
+++ b/cosmic-panel-launcher-button/data/com.system76.CosmicPanelLauncherButton.desktop
@@ -1,24 +1,11 @@
 [Desktop Entry]
 Name=Launcher Button
-Name[ar]=زر المشغل
-Name[bg]=Бутон за стартера
-Name[cs]=Tlačítko spouštěče
-Name[zh_CN]=启动器按钮
-Name[hu]=Indító gomb
-Name[pl]=Przycisk programu uruchamiającego
-Name[pt]=Botão Lançador de Aplicativos
-Name[nl]=Knop snelstarter
-Name[sk]=Tlačidlo spúšťača
-Name[es]=Botón del lanzador
-Name[sv]=Knapp för programstartare
-Name[it]=Tasto Launcher
-Name[uk]=Запускач
+Comment=Open the launcher to search applications and run commands
 Type=Application
 Exec=cosmic-panel-button com.system76.CosmicLauncher
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Launcher;Runner;
 Icon=com.system76.CosmicPanelLauncherButton
 StartupNotify=true
 NoDisplay=true

--- a/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
+++ b/cosmic-panel-workspaces-button/data/com.system76.CosmicPanelWorkspacesButton.desktop
@@ -1,24 +1,11 @@
 [Desktop Entry]
 Name=Workspaces Button
-Name[ar]=زر مساحات العمل
-Name[bg]=Бутон за работните пространства
-Name[cs]=Tlačítko pracovních ploch
-Name[zh_CN]=工作区按钮
-Name[pl]=Przycisk przestrzeni roboczych
-Name[hu]=Munkaterületek gomb
-Name[pt]=Botão de Áreas de Trabalho
-Name[nl]=Knop werkbladenoverzicht
-Name[sk]=Tlačidlo pracovných plôch
-Name[es]=Botón de espacios de trabajo
-Name[sv]=Knapp för arbetsytor
-Name[it]=Tasto Spazi di lavoro
-Name[uk]=Робочі простори
+Comment=Open the workspaces overview to manage and switch workspaces
 Type=Application
 Exec=cosmic-panel-button com.system76.CosmicWorkspaces
 Terminal=false
 Categories=COSMIC;
-Keywords=COSMIC;Iced;
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Keywords=COSMIC;Applet;Workspace;Overview;
 Icon=com.system76.CosmicPanelWorkspacesButton
 StartupNotify=true
 NoDisplay=true

--- a/i18n/ar/desktop_entries.ftl
+++ b/i18n/ar/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = درج التطبيقات
+cosmic-applet-a11y = الإتاحة
+cosmic-applet-audio = الصوت
+cosmic-applet-battery = الطاقة والبطارية
+cosmic-applet-bluetooth = بلوتوث
+cosmic-applet-input-sources = مصادر الإدخال
+cosmic-applet-minimize = النوافذ المصغّرة
+cosmic-applet-network = الشبكة
+cosmic-applet-notifications = مركز الإشعارات
+cosmic-applet-power = جلسة المستخدم
+cosmic-applet-status-area = درج الإشعارا
+cosmic-applet-tiling = تبليط
+cosmic-applet-time = التاريخ والوقت والتقويم
+cosmic-applet-workspaces = مساحات عمل مرقمة
+cosmic-panel-app-button = زر مكتبة التطبيقات
+cosmic-panel-launcher-button = زر المشغل
+cosmic-panel-workspaces-button = زر مساحات العمل

--- a/i18n/bg/desktop_entries.ftl
+++ b/i18n/bg/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Меню за програми
+cosmic-applet-a11y = Достъпност
+cosmic-applet-audio = Звук
+cosmic-applet-battery = Захранване и батерия
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Входни устройства
+cosmic-applet-minimize = Минимизирани прозорци
+cosmic-applet-network = Мрежа
+cosmic-applet-notifications = Център за известия
+cosmic-applet-power = Потребителска сесия
+cosmic-applet-status-area = Тава за известия
+cosmic-applet-tiling = Прилепване на прозорци
+cosmic-applet-time = Дата, час и календар
+cosmic-applet-workspaces = Номерирани работни пространства
+cosmic-panel-app-button = Бутон за библиотеката с програми
+cosmic-panel-launcher-button = Бутон за стартера
+cosmic-panel-workspaces-button = Бутон за работните пространства

--- a/i18n/cs/desktop_entries.ftl
+++ b/i18n/cs/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Panel aplikací
+cosmic-applet-a11y = Přístupnost
+cosmic-applet-audio = Zvuk
+cosmic-applet-battery = Napájení a baterie
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Vstupní zdroje
+cosmic-applet-minimize = Minimalizovaná okna
+cosmic-applet-network = Síť
+cosmic-applet-notifications = Centrum oznámení
+cosmic-applet-power = Uživatelská relace
+cosmic-applet-status-area = Panel oznámení
+cosmic-applet-tiling = Dlaždicový režim oken
+cosmic-applet-time = Datum, čas a kalendář
+cosmic-applet-workspaces = Číslované pracovní plochy
+cosmic-panel-app-button = Tlačítko knihovny aplikací
+cosmic-panel-launcher-button = Tlačítko spouštěče
+cosmic-panel-workspaces-button = Tlačítko pracovních ploch

--- a/i18n/de/desktop_entries.ftl
+++ b/i18n/de/desktop_entries.ftl
@@ -1,0 +1,9 @@
+cosmic-app-list = Taskleiste
+cosmic-applet-a11y = Zugänglichkeit
+cosmic-applet-audio = Klang
+cosmic-applet-battery = Energie und Akku
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Eigangsquellen
+cosmic-applet-minimize = Minimierte Fenster
+cosmic-applet-network = Netzwerk
+cosmic-applet-notifications = Notifizierungszentrum

--- a/i18n/en/desktop_entries.ftl
+++ b/i18n/en/desktop_entries.ftl
@@ -1,0 +1,67 @@
+cosmic-app-list = App Tray
+cosmic-app-list-comment = Launch pinned apps and manage open windows
+cosmic-app-list-keywords = COSMIC;Applet;App;Tray;List;Task;Bar;
+
+cosmic-applet-a11y = Accessibility
+cosmic-applet-a11y-comment = Configure accessibility settings from the panel
+cosmic-applet-a11y-keywords = COSMIC;Applet;Accessibility;A11y;Screen;Reader;Magnifier;Contrast;Color;
+
+cosmic-applet-audio = Sound
+cosmic-applet-audio-comment = Audio device selection, volume control, and MPRIS media controls
+cosmic-applet-audio-keywords = COSMIC;Applet;Sound;Audio;MPRIS;
+
+cosmic-applet-battery = Power & Battery
+cosmic-applet-battery-comment = Power modes and power saving options
+cosmic-applet-battery-keywords = COSMIC;Applet;Power;Battery;
+
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-bluetooth-comment = Manage Bluetooth devices
+cosmic-applet-bluetooth-keywords = COSMIC;Applet;Bluetooth;
+
+cosmic-applet-input-sources = Input Sources
+cosmic-applet-input-sources-comment = Switch between input sources
+cosmic-applet-input-sources-keywords = COSMIC;Applet;Input;Source;
+
+cosmic-applet-minimize = Minimized Windows
+cosmic-applet-minimize-comment = Manage minimized windows
+cosmic-applet-minimize-keywords = COSMIC;Applet;Minimize;
+
+cosmic-applet-network = Network
+cosmic-applet-network-comment = Manage network connections
+cosmic-applet-network-keywords = COSMIC;Applet;Network;
+
+cosmic-applet-notifications = Notifications Center
+cosmic-applet-notifications-comment = Manage notifications and Do Not Disturb
+cosmic-applet-notifications-keywords = COSMIC;Applet;Notification;
+
+cosmic-applet-power = User Session
+cosmic-applet-power-comment = Lock screen, log out, suspend, reboot, and shutdown
+cosmic-applet-power-keywords = COSMIC;Applet;User;Session;Lock;Log;Reboot;Shutdown;Suspend;
+
+cosmic-applet-status-area = Notifications Tray
+cosmic-applet-status-area-comment = Application indicators which may export menus to the panel
+cosmic-applet-status-area-keywords = COSMIC;Applet;App;Indicator;Notification;Tray;Status;
+
+cosmic-applet-tiling = Tiling
+cosmic-applet-tiling-comment = Manage the active hint, current & per-workspace auto-tiling
+cosmic-applet-tiling-keywords = COSMIC;Applet;Tiling;Hint;Workspace;
+
+cosmic-applet-time = Date, Time & Calendar
+cosmic-applet-time-comment = Display the current time in the panel with a calendar popup
+cosmic-applet-time-keywords = COSMIC;Applet;Date;Time;Calendar;
+
+cosmic-applet-workspaces = Numbered Workspaces
+cosmic-applet-workspaces-comment = Switch between numbered workspaces in the panel
+cosmic-applet-workspaces-keywords = COSMIC;Applet;Workspace;
+
+cosmic-panel-app-button = App Library Button
+cosmic-panel-app-button-comment = Open the application library for launching installed applications
+cosmic-panel-app-button-keywords = COSMIC;Applet;App;Library;Tray;
+
+cosmic-panel-launcher-button = Launcher Button
+cosmic-panel-launcher-button-comment = Open the launcher to search applications and run commands
+cosmic-panel-launcher-button-keywords = COSMIC;Applet;Launcher;Runner;
+
+cosmic-panel-workspaces-button = Workspaces Button
+cosmic-panel-workspaces-button-comment = Open the workspaces overview to manage and switch workspaces
+cosmic-panel-workspaces-button-keywords = COSMIC;Applet;Workspace;Overview;

--- a/i18n/es/desktop_entries.ftl
+++ b/i18n/es/desktop_entries.ftl
@@ -1,0 +1,16 @@
+cosmic-app-list = Bandeja de aplicaciones
+cosmic-applet-a11y = Accesibilidad
+cosmic-applet-audio = Sonido
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Fuentes de entrada de teclado
+cosmic-applet-minimize = Ventanas minimizadas
+cosmic-applet-network = Red
+cosmic-applet-notifications = Centro de notificaciones
+cosmic-applet-power = Sesión de usuario
+cosmic-applet-status-area = Bandeja de notificaciones
+cosmic-applet-tiling = Ventanas mosaico
+cosmic-applet-time = Fecha, hora y calendario
+cosmic-applet-workspaces = Espacios de trabajo numerados
+cosmic-panel-app-button = =Botón de biblioteca de aplicaciones
+cosmic-panel-launcher-button = Botón del lanzador
+cosmic-panel-workspaces-button = Botón de espacios de trabajo

--- a/i18n/hu/desktop_entries.ftl
+++ b/i18n/hu/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Alkalmazástálca
+cosmic-applet-a11y = Akadálymentesség
+cosmic-applet-audio = Hang
+cosmic-applet-battery = Energia és Akkumulátor
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Beviteli Források
+cosmic-applet-minimize = Kis méretű ablakok
+cosmic-applet-network = Hálózat
+cosmic-applet-notifications = Értesítési központ
+cosmic-applet-power = Felhasználói Munkamenet
+cosmic-applet-status-area = Értesítési terület
+cosmic-applet-tiling = Csempézés
+cosmic-applet-time = Dátum, Idő és Naptár
+cosmic-applet-workspaces = Számozott Munkaterületek
+cosmic-panel-app-button = Alkalmazáskönyvtár gomb
+cosmic-panel-launcher-button = Indító gomb
+cosmic-panel-workspaces-button = Munkaterületek gomb

--- a/i18n/it/desktop_entries.ftl
+++ b/i18n/it/desktop_entries.ftl
@@ -1,0 +1,16 @@
+cosmic-app-list = Area applicazioni
+cosmic-applet-a11y = Accessibilità
+cosmic-applet-audio = Audio
+cosmic-applet-battery = Alimentazione e batteria
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Sorgenti di immissione
+cosmic-applet-minimize = Finestre minimizzate
+cosmic-applet-network = Rete
+cosmic-applet-notifications = Centro notifiche
+cosmic-applet-power = Sessione utente
+cosmic-applet-status-area = Area notifiche
+cosmic-applet-tiling = Tiling
+cosmic-applet-time = Data, ora e calendario
+cosmic-applet-workspaces = Spazi di lavoro numerati
+cosmic-panel-launcher-button = Tasto Launcher
+cosmic-panel-workspaces-button = Tasto Spazi di lavoro

--- a/i18n/ko/desktop_entries.ftl
+++ b/i18n/ko/desktop_entries.ftl
@@ -1,0 +1,3 @@
+cosmic-applet-audio = 코스믹 오디오 애플릿
+cosmic-applet-battery = 코스믹 배터리 애플릿
+cosmic-panel-app-button = 코스믹 패널 앱 라이브러리 단추

--- a/i18n/nl/desktop_entries.ftl
+++ b/i18n/nl/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Taakbalk
+cosmic-applet-a11y = Toegankelijkheid
+cosmic-applet-audio = Geluid
+cosmic-applet-battery = Energie en batterij
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Invoerbronnen
+cosmic-applet-minimize = Geminimaliseerde vensters
+cosmic-applet-network = Netwerk
+cosmic-applet-notifications = Meldingscentrum
+cosmic-applet-power = Gebruikerssessie
+cosmic-applet-status-area = Meldingsvlak
+cosmic-applet-tiling = Vensters tegelen
+cosmic-applet-time = Datum, tijd en agenda
+cosmic-applet-workspaces = Genummerde werkbladen
+cosmic-panel-app-button = Knop appbibliotheek
+cosmic-panel-launcher-button = Knop snelstarter
+cosmic-panel-workspaces-button = Knop werkbladenoverzicht

--- a/i18n/pl/desktop_entries.ftl
+++ b/i18n/pl/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Zasobnik aplikacji
+cosmic-applet-a11y = Dostępność
+cosmic-applet-audio = Dźwięk
+cosmic-applet-battery = Zasilanie i bateria
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Źródła wprowadzdania danych
+cosmic-applet-minimize = Zminimalizowane okna
+cosmic-applet-network = Sieć
+cosmic-applet-notifications = Centrum powiadomień
+cosmic-applet-power = Sesja użytkownika
+cosmic-applet-status-area = Zasobnik powiadomień
+cosmic-applet-tiling = Kafelkowanie
+cosmic-applet-time = Data, godzina i kalendarz
+cosmic-applet-workspaces = Obszary robocze według numeru
+cosmic-panel-app-button = Przycisk biblioteki aplikacji
+cosmic-panel-launcher-button = Przycisk programu uruchamiającego
+cosmic-panel-workspaces-button = Przycisk przestrzeni roboczych

--- a/i18n/pt/desktop_entries.ftl
+++ b/i18n/pt/desktop_entries.ftl
@@ -1,0 +1,16 @@
+cosmic-app-list = Bandeja de Aplicativos
+cosmic-applet-a11y = Acessibilidade
+cosmic-applet-audio = Som
+cosmic-applet-bluetooth = Energia e Bateria
+cosmic-applet-input-sources = Métodos de Entrada de Teclado
+cosmic-applet-minimize = Janelas Minimizadas
+cosmic-applet-network = Rede
+cosmic-applet-notifications = Central de Notificações
+cosmic-applet-power = Sessão de Usuário
+cosmic-applet-status-area = Área de Notificações
+cosmic-applet-tiling = Janelas Lado a Lado
+cosmic-applet-time = Data, Hora e Calendário
+cosmic-applet-workspaces = Áreas de Trabalho Numeradas
+cosmic-panel-app-button = Botão da Biblioteca de Aplicativos
+cosmic-panel-launcher-button = Botão Lançador de Aplicativos
+cosmic-panel-workspaces-button = Botão de Áreas de Trabalho

--- a/i18n/sk/desktop_entries.ftl
+++ b/i18n/sk/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Panel aplikácií
+cosmic-applet-a11y = Zjednodušenie ovládania
+cosmic-applet-audio = Zvuk
+cosmic-applet-battery = Napájanie a batéria
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Vstupné zdroje
+cosmic-applet-minimize = Minimalizované okná
+cosmic-applet-network = Sieť
+cosmic-applet-notifications = Centrum oznámení
+cosmic-applet-power = Používateľská relácia
+cosmic-applet-status-area = Panel oznámení
+cosmic-applet-tiling = Dláždenie okien
+cosmic-applet-time = Dátum, čas a kalendár
+cosmic-applet-workspaces = Číslované pracovné plochy
+cosmic-panel-app-button = Tlačidlo knižnice aplikácií
+cosmic-panel-launcher-button = Tlačidlo spúšťača
+cosmic-panel-workspaces-button = Tlačidlo pracovných plôch

--- a/i18n/sv/desktop_entries.ftl
+++ b/i18n/sv/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Programfält
+cosmic-applet-a11y = Tillgänglighet
+cosmic-applet-audio = Ljud
+cosmic-applet-battery = Ström & batteri
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Input Sources
+cosmic-applet-minimize = Minimized Windows
+cosmic-applet-network = Network
+cosmic-applet-notifications = Notifications Center
+cosmic-applet-power = Power & Battery
+cosmic-applet-status-area = Notifications Tray
+cosmic-applet-tiling = Tiling
+cosmic-applet-time = Date, Time & Calendar
+cosmic-applet-workspaces = Numbered Workspaces
+cosmic-panel-app-button = App Library Button
+cosmic-panel-launcher-button = Launcher Button
+cosmic-panel-workspaces-button = Workspaces Button

--- a/i18n/uk/desktop_entries.ftl
+++ b/i18n/uk/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = Панель застосунків
+cosmic-applet-a11y = Доступність
+cosmic-applet-audio = Звук
+cosmic-applet-battery = Живлення та акумулятор
+cosmic-applet-bluetooth = Bluetooth
+cosmic-applet-input-sources = Джерела введення
+cosmic-applet-minimize = Згорнуті вікна
+cosmic-applet-network = Мережа
+cosmic-applet-notifications = Центр сповіщень
+cosmic-applet-power = Сеанс користувача
+cosmic-applet-status-area = Область сповіщень
+cosmic-applet-tiling = Укладання
+cosmic-applet-time = Дата, час і календар
+cosmic-applet-workspaces = Нумеровані робочі простори
+cosmic-panel-app-button = Бібліотека застосунків
+cosmic-panel-launcher-button = Запускач
+cosmic-panel-workspaces-button = Робочі простори

--- a/i18n/zh-CN/desktop_entries.ftl
+++ b/i18n/zh-CN/desktop_entries.ftl
@@ -1,0 +1,17 @@
+cosmic-app-list = 应用托盘
+cosmic-applet-a11y = 无障碍
+cosmic-applet-audio = 音频
+cosmic-applet-battery = 电源与电池
+cosmic-applet-bluetooth = 蓝牙
+cosmic-applet-input-sources = 输入源
+cosmic-applet-minimize = 最小化窗口
+cosmic-applet-network = 网络
+cosmic-applet-notifications = 通知中心
+cosmic-applet-power = 用户会话
+cosmic-applet-status-area = 通知托盘
+cosmic-applet-tiling = 平铺
+cosmic-applet-time = 日期、时间和日历
+cosmic-applet-workspaces = 工作区编号
+cosmic-panel-app-button = 应用程序库按钮
+cosmic-panel-launcher-button = 启动器按钮
+cosmic-panel-workspaces-button = 工作区按钮

--- a/justfile
+++ b/justfile
@@ -7,7 +7,6 @@ target := if debug == '1' { 'debug' } else { 'release' }
 vendor_args := if vendor == '1' { '--frozen --offline' } else { '' }
 debug_args := if debug == '1' { '' } else { '--release' }
 cargo_args := vendor_args + ' ' + debug_args
-
 targetdir := env('CARGO_TARGET_DIR', 'target')
 sharedir := rootdir + prefix + '/share'
 iconsdir := sharedir + '/icons/hicolor'
@@ -15,9 +14,7 @@ prefixdir := prefix + '/bin'
 bindir := rootdir + prefixdir
 libdir := rootdir + prefix + '/lib'
 default-schema-target := sharedir / 'cosmic'
-
 cosmic-applets-bin := prefixdir / 'cosmic-applets'
-
 metainfo := 'com.system76.CosmicApplets.metainfo.xml'
 metainfo-src := 'data' / metainfo
 metainfo-dst := clean(rootdir / prefix) / 'share' / 'metainfo' / metainfo
@@ -26,7 +23,7 @@ default: build-release
 
 # Compiles with debug profile
 build-debug *args:
-    cargo build {{args}}
+    cargo build {{ args }}
 
 # Compiles with release profile
 build-release *args: (build-debug '--release' args)
@@ -35,37 +32,35 @@ build-release *args: (build-debug '--release' args)
 build-vendored *args: vendor-extract (build-release '--frozen --offline' args)
 
 _link_applet name:
-    ln -sf {{cosmic-applets-bin}} {{bindir}}/{{name}}
+    ln -sf {{ cosmic-applets-bin }} {{ bindir }}/{{ name }}
 
 _install_icons name:
-    find {{name}}/'data'/'icons' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -d '\n' -I {} install -Dm0644 {{name}}/'data'/'icons'/{} {{iconsdir}}/{}
+    find {{ name }}/'data'/'icons' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -d '\n' -I {} install -Dm0644 {{ name }}/'data'/'icons'/{} {{ iconsdir }}/{}
 
 _install_default_schema name:
-    find {{name}}/'data'/'default_schema' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -d '\n' -I {} install -Dm0644 {{name}}/'data'/'default_schema'/{} {{default-schema-target}}/{}
+    find {{ name }}/'data'/'default_schema' -type f -exec echo {} \; | rev | cut -d'/' -f-3 | rev | xargs -d '\n' -I {} install -Dm0644 {{ name }}/'data'/'default_schema'/{} {{ default-schema-target }}/{}
 
 _install_desktop path:
-    install -Dm0644 {{path}} {{sharedir}}/applications/{{file_name(path)}}
+    install -Dm0644 {{ path }} {{ sharedir }}/applications/{{ file_name(path) }}
 
 _install_bin name:
-    install -Dm0755 {{targetdir}}/{{target}}/{{name}} {{bindir}}/{{name}}
+    install -Dm0755 {{ targetdir }}/{{ target }}/{{ name }} {{ bindir }}/{{ name }}
 
-_install_applet id name: (_install_icons name) \
-    (_install_desktop name + '/data/' + id + '.desktop') \
-    (_link_applet name)
+_install_applet id name: (_install_icons name) (_install_desktop name + '/data/' + id + '.desktop') (_link_applet name)
 
-_install_button id name: (_install_icons name) (_install_desktop name + '/data/' + id + '.desktop')
+_install_button id name: (_install_icons name) (_install_desktop 'target/xdgen/' + id + '.desktop')
 
 _install_metainfo:
-    install -Dm0644 {{metainfo-src}} {{metainfo-dst}}
+    install -Dm0644 {{ metainfo-src }} {{ metainfo-dst }}
 
 _install_status_notifier_watcher:
-    sed "s|@bindir@|{{prefixdir}}|" cosmic-applet-status-area/data/dbus-1/com.system76.CosmicStatusNotifierWatcher.service.in > cosmic-applet-status-area/data/dbus-1/com.system76.CosmicStatusNotifierWatcher.service
-    install -Dm0644 cosmic-applet-status-area/data/dbus-1/com.system76.CosmicStatusNotifierWatcher.service {{sharedir}}/dbus-1/services/com.system76.CosmicStatusNotifierWatcher.service
-    sed "s|@bindir@|{{prefixdir}}|" cosmic-applet-status-area/data/com.system76.CosmicStatusNotifierWatcher.service.in > cosmic-applet-status-area/data/com.system76.CosmicStatusNotifierWatcher.service
-    install -Dm0644 cosmic-applet-status-area/data/com.system76.CosmicStatusNotifierWatcher.service {{libdir}}/systemd/user/com.system76.CosmicStatusNotifierWatcher.service
+    sed "s|@bindir@|{{ prefixdir }}|" cosmic-applet-status-area/data/dbus-1/com.system76.CosmicStatusNotifierWatcher.service.in > cosmic-applet-status-area/data/dbus-1/com.system76.CosmicStatusNotifierWatcher.service
+    install -Dm0644 cosmic-applet-status-area/data/dbus-1/com.system76.CosmicStatusNotifierWatcher.service {{ sharedir }}/dbus-1/services/com.system76.CosmicStatusNotifierWatcher.service
+    sed "s|@bindir@|{{ prefixdir }}|" cosmic-applet-status-area/data/com.system76.CosmicStatusNotifierWatcher.service.in > cosmic-applet-status-area/data/com.system76.CosmicStatusNotifierWatcher.service
+    install -Dm0644 cosmic-applet-status-area/data/com.system76.CosmicStatusNotifierWatcher.service {{ libdir }}/systemd/user/com.system76.CosmicStatusNotifierWatcher.service
 
 # Installs files into the system
-install: (_install_bin 'cosmic-applets') (_link_applet 'cosmic-panel-button') (_install_applet 'com.system76.CosmicAppList' 'cosmic-app-list') (_install_default_schema 'cosmic-app-list') (_install_applet 'com.system76.CosmicAppletA11y' 'cosmic-applet-a11y') (_install_applet 'com.system76.CosmicAppletAudio' 'cosmic-applet-audio') (_install_applet 'com.system76.CosmicAppletInputSources' 'cosmic-applet-input-sources') (_install_applet 'com.system76.CosmicAppletBattery' 'cosmic-applet-battery') (_install_applet 'com.system76.CosmicAppletBluetooth' 'cosmic-applet-bluetooth') (_install_applet 'com.system76.CosmicAppletMinimize' 'cosmic-applet-minimize') (_install_applet 'com.system76.CosmicAppletNetwork' 'cosmic-applet-network') (_install_applet 'com.system76.CosmicAppletNotifications' 'cosmic-applet-notifications') (_install_applet 'com.system76.CosmicAppletPower' 'cosmic-applet-power') (_install_applet 'com.system76.CosmicAppletStatusArea' 'cosmic-applet-status-area') (_install_applet 'com.system76.CosmicAppletTiling' 'cosmic-applet-tiling') (_install_applet 'com.system76.CosmicAppletTime' 'cosmic-applet-time') (_install_applet 'com.system76.CosmicAppletWorkspaces' 'cosmic-applet-workspaces') (_install_button 'com.system76.CosmicPanelAppButton' 'cosmic-panel-app-button') (_install_button 'com.system76.CosmicPanelLauncherButton' 'cosmic-panel-launcher-button') (_install_button 'com.system76.CosmicPanelWorkspacesButton' 'cosmic-panel-workspaces-button') (_install_metainfo) (_install_status_notifier_watcher)
+install: (_install_bin 'cosmic-applets') (_link_applet 'cosmic-panel-button') (_install_applet 'com.system76.CosmicAppList' 'cosmic-app-list') (_install_default_schema 'cosmic-app-list') (_install_applet 'com.system76.CosmicAppletA11y' 'cosmic-applet-a11y') (_install_applet 'com.system76.CosmicAppletAudio' 'cosmic-applet-audio') (_install_applet 'com.system76.CosmicAppletInputSources' 'cosmic-applet-input-sources') (_install_applet 'com.system76.CosmicAppletBattery' 'cosmic-applet-battery') (_install_applet 'com.system76.CosmicAppletBluetooth' 'cosmic-applet-bluetooth') (_install_applet 'com.system76.CosmicAppletMinimize' 'cosmic-applet-minimize') (_install_applet 'com.system76.CosmicAppletNetwork' 'cosmic-applet-network') (_install_applet 'com.system76.CosmicAppletNotifications' 'cosmic-applet-notifications') (_install_applet 'com.system76.CosmicAppletPower' 'cosmic-applet-power') (_install_applet 'com.system76.CosmicAppletStatusArea' 'cosmic-applet-status-area') (_install_applet 'com.system76.CosmicAppletTiling' 'cosmic-applet-tiling') (_install_applet 'com.system76.CosmicAppletTime' 'cosmic-applet-time') (_install_applet 'com.system76.CosmicAppletWorkspaces' 'cosmic-applet-workspaces') (_install_button 'com.system76.CosmicPanelAppButton' 'cosmic-panel-app-button') (_install_button 'com.system76.CosmicPanelLauncherButton' 'cosmic-panel-launcher-button') (_install_button 'com.system76.CosmicPanelWorkspacesButton' 'cosmic-panel-workspaces-button') _install_metainfo _install_status_notifier_watcher
 
 # Vendor Cargo dependencies locally
 vendor:
@@ -83,8 +78,8 @@ vendor-extract:
 
 # Bump cargo version, create git commit, and create tag
 tag version:
-    find -type f -name Cargo.toml -exec sed -i '0,/^version/s/^version.*/version = "{{version}}"/' '{}' \; -exec git add '{}' \;
+    find -type f -name Cargo.toml -exec sed -i '0,/^version/s/^version.*/version = "{{ version }}"/' '{}' \; -exec git add '{}' \;
     cargo check
     cargo clean
-    dch -D noble -v {{version}}
+    dch -D noble -v {{ version }}
     git add Cargo.lock debian/changelog


### PR DESCRIPTION
This will require adding a new project to Weblate for the desktop_entries domain in the new root i18n directory.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

