### PR TITLE
feat(cosmic-applet-time): use bold font for datetime text

### DIFF
--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -192,7 +192,13 @@ impl Window {
         let elements: Vec<Element<'_, Message>> = if let Some(strftime) = self.maybe_strftime() {
             strftime
                 .split_whitespace()
-                .map(|piece| self.core.applet.text(piece.to_owned()).into())
+                .map(|piece| {
+                    self.core
+                        .applet
+                        .text(piece.to_owned())
+                        .font(cosmic::font::bold())
+                        .into()
+                })
                 .collect()
         } else {
             let mut elements = Vec::new();
@@ -212,7 +218,13 @@ impl Window {
                     .to_string();
 
                 for p in formatted_date.split_whitespace() {
-                    elements.push(self.core.applet.text(p.to_owned()).into());
+                    elements.push(
+                        self.core
+                            .applet
+                            .text(p.to_owned())
+                            .font(cosmic::font::bold())
+                            .into(),
+                    );
                 }
                 elements.push(
                     horizontal_rule(2)
@@ -232,7 +244,13 @@ impl Window {
             // todo: split using formatToParts when it is implemented
             // https://github.com/unicode-org/icu4x/issues/4936#issuecomment-2128812667
             for p in formatted_time.split_whitespace().flat_map(|s| s.split(':')) {
-                elements.push(self.core.applet.text(p.to_owned()).into());
+                elements.push(
+                    self.core
+                        .applet
+                        .text(p.to_owned())
+                        .font(cosmic::font::bold())
+                        .into(),
+                );
             }
 
             elements
@@ -301,7 +319,10 @@ impl Window {
 
         Element::from(
             row!(
-                self.core.applet.text(formatted_date),
+                self.core
+                    .applet
+                    .text(formatted_date)
+                    .font(cosmic::font::bold()),
                 container(vertical_space().height(Length::Fixed(
                     (self.core.applet.suggested_size(true).1
                         + 2 * self.core.applet.suggested_padding(true).1)


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Imho the date time should should be highlighted a little more in the panel. Especially given that e.g. workspace names are already bold using bold text here seems to be a good choice.

<img width="674" height="44" alt="Screenshot_2026-03-04_22-45-37" src="https://github.com/user-attachments/assets/123d07af-c207-45f0-af98-feb507e78afe" />
<img width="674" height="44" alt="Screenshot_2026-03-04_22-37-03" src="https://github.com/user-attachments/assets/49fdb998-67d1-4a58-a432-123860580abb" />

<img width="2559" height="45" alt="Screenshot_2026-03-04_22-46-04" src="https://github.com/user-attachments/assets/ed5fde6c-03fc-4dc4-9e21-3e3dab869443" />
<img width="2559" height="41" alt="Screenshot_2026-03-04_22-36-16" src="https://github.com/user-attachments/assets/ba972cc1-c171-4ae5-90fa-dec1333feeb5" />
