### PR TITLE
change: cosmic_applet_power shutdown message

### DIFF
--- a/cosmic-applet-power/i18n/en/cosmic_applet_power.ftl
+++ b/cosmic-applet-power/i18n/en/cosmic_applet_power.ftl
@@ -21,7 +21,7 @@ confirm-title =
     { $action -> 
         [restart] { restart }
         [suspend] { suspend }
-        [shutdown] { shutdown }
+        [shutdown] { shut down }
         [log-out] Quit all applications and log out
         *[other] Apply the selected action
     } now?


### PR DESCRIPTION
Add a space to the power applet shutdown message. Used to read "shutdown now" whereas "shut down now" is more correct. It should be a verb (shut down) instead of a noun (shutdown) as it is associated with the action of shutting down. This was first discussed in a [Reddit thread](https://www.reddit.com/r/pop_os/comments/1rkxjoo/changing_ui_elements_specifically_the_shutdown/), of which I am the OP. More context may be found there.

AI: not applicable.
Testing: unable to test, but change is (probably) trivial.

- [ ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

