### PR TITLE
fix(bluetooth): display Alias instead of raw Name

### DIFF
--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -286,8 +286,9 @@ impl BluerDevice {
                 .map(|res| device_type_to_icon(&res.ok().flatten().unwrap_or_default()))
         );
 
-        if name.is_empty() {
-            name = device.address().to_string();
+        let addr_str = device.address().to_string();
+        if name.is_empty() || name.replace('-', ":") == addr_str {
+            name = addr_str;
         }
 
         let status = if is_connected {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
## Summary

Display Bluetooth device `Alias` instead of raw `Name`, and normalize hyphenated-MAC aliases for unnamed devices.

The `bluer` crate documents that `Name` is "only present for completeness" and recommends always using `Alias`, which returns the user-friendly name when set and falls back to `Name` when no alias exists.

For unnamed devices, BlueZ's `Alias` falls back to the device address using hyphens (e.g., `AA-BB-CC-DD-EE-FF`). The `has_name()` method compared this against `address.to_string()` (colon-separated), so the string inequality caused hyphenated MACs to be treated as real device names, passing the visibility filter. The second commit normalizes the alias by comparing its hyphen-to-colon form against the address — if they match, the name is set to the colon-formatted address so `has_name()` correctly returns false.

Closes #1330.

Companion PR for settings: pop-os/cosmic-settings#1893.

## Test plan

- [x] Devices without aliases display the same name as before (Alias falls back to Name)
- [x] Devices with custom aliases display the alias instead of raw name
- [x] Unnamed BLE devices (BlueZ Alias = hyphenated MAC) show colon-formatted address, not hyphenated MAC
- [x] `cargo check -p cosmic-applet-bluetooth` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
