### PR TITLE
fix(battery): handle unknown power profile without panicking

### DIFF
--- a/cosmic-applet-battery/src/backend/mod.rs
+++ b/cosmic-applet-battery/src/backend/mod.rs
@@ -66,7 +66,10 @@ pub async fn get_power_profile(daemon: Backend<'_>) -> Result<Power> {
                 "Battery" => Ok(Power::Battery),
                 "Balanced" => Ok(Power::Balanced),
                 "Performance" => Ok(Power::Performance),
-                _ => panic!("Unknown power profile: {power}"),
+                _ => {
+                    tracing::warn!("Unknown power profile: {power}");
+                    Ok(Power::Balanced)
+                }
             }
         }
         Backend::PowerProfilesDaemon(ppd) => {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

`get_power_profile()` panics if the S76 PowerDaemon returns an unrecognized profile string. This can crash or disrupt the battery applet. The PowerProfiles Daemon path in the same function already handles unknown strings gracefully by defaulting to Balanced.

This patch replaces the `panic!` with `tracing::warn!` and defaults to `Power::Balanced`, matching the existing PPD behavior and how cosmic-settings handles the same case via `PowerProfile::from_string()`.

## Test plan

- [ ] Verify battery applet starts and displays correct profile with S76 PowerDaemon
- [ ] Verify profile switching (Battery/Balanced/Performance) still works
- [ ] Confirm `tracing::warn!` is logged (not a panic) when an unrecognized profile string is received