### PR TITLE
fix(battery): guard against negative time_to_empty

### DIFF
--- a/cosmic-applet-battery/src/app.rs
+++ b/cosmic-applet-battery/src/app.rs
@@ -392,7 +392,7 @@ impl cosmic::Application for CosmicBatteryApplet {
                     time_to_empty,
                 } => {
                     self.update_battery(percent, on_battery);
-                    self.time_remaining = Duration::from_secs(time_to_empty as u64);
+                    self.time_remaining = Duration::from_secs(time_to_empty.max(0) as u64);
                 }
                 DeviceDbusEvent::NoBattery => {
                     std::process::exit(0);


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

The battery applet casts UPower's `time_to_empty` (i64) directly to u64 for `Duration::from_secs()`. If UPower reports a negative value during state transitions (spec says 0 when unknown, but edge cases exist with some kernel drivers), the cast wraps to ~2^64 seconds, producing a nonsensical time remaining display.

This adds `.max(0)` before the cast, cosmic-settings guards against this differently (jiff's `Span` type with display-time `is_positive()` filtering); this applies clamping at ingestion instead.

## Test plan

- [ ] Verify time remaining displays correctly while discharging
- [ ] Verify time display clears appropriately when charging or no battery