### PR TITLE
feat(audio): use cosmic-settings-daemon varlink interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,22 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "annotate-snippets"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
-dependencies = [
- "anstyle",
- "unicode-width",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -529,25 +513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "annotate-snippets",
- "bitflags 2.11.1",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.2",
- "shlex",
- "syn",
 ]
 
 [[package]]
@@ -652,7 +617,7 @@ dependencies = [
  "libc",
  "log",
  "macaddr",
- "nix 0.29.0",
+ "nix",
  "num-derive",
  "num-traits",
  "pin-project",
@@ -705,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "by_address"
@@ -804,25 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
-dependencies = [
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,17 +800,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -976,21 +911,6 @@ name = "configparser"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
-
-[[package]]
-name = "convert_case"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie-factory"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "core-foundation"
@@ -1120,9 +1040,11 @@ dependencies = [
 name = "cosmic-applet-audio"
 version = "1.0.15"
 dependencies = [
- "cosmic-settings-sound-subscription",
+ "cosmic-settings-audio-client",
+ "futures",
  "i18n-embed",
  "i18n-embed-fl",
+ "intmap",
  "libcosmic",
  "mpris2-zbus",
  "rust-embed",
@@ -1134,6 +1056,7 @@ dependencies = [
  "url",
  "urlencoding",
  "zbus",
+ "zlink",
 ]
 
 [[package]]
@@ -1408,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1429,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "quote",
  "syn",
@@ -1521,20 +1444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-pipewire"
-version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
-dependencies = [
- "intmap",
- "libspa",
- "libspa-sys",
- "pipewire",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
 source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#c253ec1d6804afbcdf250f5cc37ae1194bba7bd2"
@@ -1551,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-a11y-manager-subscription"
 version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
+source = "git+https://github.com/pop-os/cosmic-settings#1f225d19ce582423fe8713fc6669c51d162f256f"
 dependencies = [
  "cosmic-protocols",
  "iced_futures",
@@ -1565,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-accessibility-subscription"
 version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
+source = "git+https://github.com/pop-os/cosmic-settings#1f225d19ce582423fe8713fc6669c51d162f256f"
 dependencies = [
  "cosmic-dbus-a11y",
  "futures",
@@ -1573,6 +1482,33 @@ dependencies = [
  "tokio",
  "tracing",
  "zbus",
+]
+
+[[package]]
+name = "cosmic-settings-audio-client"
+version = "1.0.0"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon?branch=varlink#70513d8e3ac904bd87e6fc7a0d60328cdc0e6ad7"
+dependencies = [
+ "cosmic-settings-audio-core",
+ "dirs",
+ "futures-util",
+ "ron 0.12.1",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zlink",
+]
+
+[[package]]
+name = "cosmic-settings-audio-core"
+version = "1.0.0"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon?branch=varlink#70513d8e3ac904bd87e6fc7a0d60328cdc0e6ad7"
+dependencies = [
+ "dirs",
+ "ron 0.12.1",
+ "serde",
+ "zlink",
 ]
 
 [[package]]
@@ -1599,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon-subscription"
 version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
+source = "git+https://github.com/pop-os/cosmic-settings#1f225d19ce582423fe8713fc6669c51d162f256f"
 dependencies = [
  "futures",
  "iced_futures",
@@ -1612,13 +1548,13 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-network-manager-subscription"
 version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
+source = "git+https://github.com/pop-os/cosmic-settings#1f225d19ce582423fe8713fc6669c51d162f256f"
 dependencies = [
  "bitflags 2.11.1",
  "cosmic-dbus-networkmanager",
  "futures",
  "iced_futures",
- "itertools 0.14.0",
+ "itertools",
  "nm-secret-agent-manager",
  "secret-service",
  "secure-string",
@@ -1629,24 +1565,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-settings-sound-subscription"
-version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
-dependencies = [
- "cosmic-pipewire",
- "futures",
- "intmap",
- "libcosmic",
- "numtoa",
- "rustix 1.1.4",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "cosmic-settings-upower-subscription"
 version = "1.0.7"
-source = "git+https://github.com/pop-os/cosmic-settings#81912bed6cdebe2719e29e6bd1453e7b977acb0e"
+source = "git+https://github.com/pop-os/cosmic-settings#1f225d19ce582423fe8713fc6669c51d162f256f"
 dependencies = [
  "futures",
  "iced_futures",
@@ -1684,7 +1605,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "almost",
  "configparser",
@@ -2058,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2195,9 +2116,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "endi"
@@ -2327,7 +2248,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -2531,7 +2452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6d3a3635983a889f065aa9ce760384713f23a9b4a04f696f86c39a5d7a6a5a"
 dependencies = [
  "indexmap 2.14.0",
- "nom 8.0.0",
+ "nom",
 ]
 
 [[package]]
@@ -2629,9 +2550,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2752,12 +2673,6 @@ name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -3035,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3056,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3065,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -3090,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3100,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "futures",
  "iced_core",
@@ -3114,7 +3029,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -3135,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3144,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3156,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -3171,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3188,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.1",
@@ -3219,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3237,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "cosmic-client-toolkit",
  "cursor-icon",
@@ -3848,15 +3763,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3878,9 +3784,9 @@ checksum = "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1"
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3888,14 +3794,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-link 0.2.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.27"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3987,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4104,7 +4010,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#59bebbdffeb8ed4abd3f2577c099745b9a2f2c37"
+source = "git+https://github.com/pop-os/libcosmic#758c13723fc35b1d82d7fa4f35859c9f7f3c1b0c"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
@@ -4190,35 +4096,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.8.0",
-]
-
-[[package]]
-name = "libspa"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
-dependencies = [
- "bitflags 2.11.1",
- "cc",
- "convert_case",
- "cookie-factory",
- "libc",
- "libspa-sys",
- "nix 0.30.1",
- "nom 8.0.0",
- "system-deps",
-]
-
-[[package]]
-name = "libspa-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0"
-dependencies = [
- "bindgen",
- "cc",
- "system-deps",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -4306,9 +4184,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logind-zbus"
@@ -4404,9 +4282,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -4465,12 +4343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -4590,18 +4462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nm-secret-agent-manager"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
@@ -4611,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "nmrs"
-version = "3.1.5"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d907d6da103106d84189d3fd229d9aac921f9131b8ba38b40341c53d24409077"
+checksum = "f9493a0dfbe50783b53ef52ec8ddb8d1f85fd45098be8210205236ff0f43bb7b"
 dependencies = [
  "async-trait",
  "base64",
@@ -4627,16 +4487,6 @@ dependencies = [
  "uuid",
  "zbus",
  "zvariant",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -4796,12 +4646,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "numtoa"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4d8a81ede501fad07191e746a299f4d79f6dcd053bab1b97af4ff5a90099f2"
 
 [[package]]
 name = "objc"
@@ -5025,9 +4869,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.55"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
 dependencies = [
  "libc",
  "libredox",
@@ -5285,34 +5129,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pipewire"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "libc",
- "libspa",
- "libspa-sys",
- "nix 0.30.1",
- "once_cell",
- "pipewire-sys",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "pipewire-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36"
-dependencies = [
- "bindgen",
- "libspa-sys",
- "system-deps",
 ]
 
 [[package]]
@@ -5647,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -5909,6 +5725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6051,9 +5873,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -6072,15 +5894,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -6278,9 +6091,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6447,19 +6260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "7.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
-dependencies = [
- "cfg-expr",
- "heck 0.5.0",
- "pkg-config",
- "toml 1.1.2+spec-1.1.0",
- "version-compare",
-]
-
-[[package]]
 name = "taffy"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6470,12 +6270,6 @@ dependencies = [
  "serde",
  "slotmap",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "temp-dir"
@@ -6702,6 +6496,20 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -6711,21 +6519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
 ]
 
 [[package]]
@@ -6739,9 +6532,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -6757,12 +6550,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -7067,12 +6854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "version-compare"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7114,9 +6895,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7127,9 +6908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7137,9 +6918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7147,9 +6928,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7160,9 +6941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -7367,9 +7148,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8649,18 +8430,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8727,6 +8508,73 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zlink"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b895b99588dceb73f4d349b8323eabad9a97d48ce83698d475c7223727c6148"
+dependencies = [
+ "zlink-smol",
+ "zlink-tokio",
+]
+
+[[package]]
+name = "zlink-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd12701bd1d42a982b931f0159cf5054bf13d90e7828a8377dfc02ed4b00342d"
+dependencies = [
+ "futures-util",
+ "itoa",
+ "libc",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "ryu",
+ "serde",
+ "serde_json",
+ "tracing",
+ "zlink-macros",
+]
+
+[[package]]
+name = "zlink-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f2416a5f504dfd7e04fee49f31abafe3314a3f62b4ddaa8e9a5fd496d4dd50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zlink-smol"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc53cd0d636ad753f759aab0abb1f456e985c3938a279d11ebda92340ae37b1"
+dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-io",
+ "futures-lite",
+ "futures-util",
+ "pin-project-lite",
+ "zlink-core",
+]
+
+[[package]]
+name = "zlink-tokio"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cbf366ac77ab41bf9a8d43535d3d620a072f7957813e03355d3d010c16cc4f"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+ "zlink-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "cosmic-dbus-a11y"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "cosmic-dbus-networkmanager"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "bitflags 2.11.1",
  "derive_builder",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-audio-client"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon?branch=varlink#70513d8e3ac904bd87e6fc7a0d60328cdc0e6ad7"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon#e7936f0d4f01c8c5a436908c7ee9f6ad43e6a7d8"
 dependencies = [
  "cosmic-settings-audio-core",
  "dirs",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-audio-core"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon?branch=varlink#70513d8e3ac904bd87e6fc7a0d60328cdc0e6ad7"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon#e7936f0d4f01c8c5a436908c7ee9f6ad43e6a7d8"
 dependencies = [
  "dirs",
  "ron 0.12.1",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -1962,7 +1962,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2160,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3794,7 +3794,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3945,7 +3945,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "mpris2-zbus"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "futures-util",
  "jiff",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "nm-secret-agent-manager"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -4531,7 +4531,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5697,7 +5697,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6223,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "switcheroo-control"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -6284,10 +6284,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "timedate-zbus"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -6769,7 +6769,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "upower_dbus"
 version = "0.3.2"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "serde",
  "serde_repr",
@@ -7344,7 +7344,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ tokio = { version = "1.49.0", features = ["full"] }
 # cosmic-config = { path = "../libcosmic/cosmic-config" }
 cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 serde = { version = "1.0.228", features = ["derive"] }
+zlink = "0.5.0"
 
 [profile.release]
 opt-level = 3

--- a/cosmic-applet-audio/Cargo.toml
+++ b/cosmic-applet-audio/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2024"
 license = "GPL-3.0-only"
 
 [dependencies]
+futures.workspace = true
 i18n-embed-fl.workspace = true
 i18n-embed.workspace = true
 libcosmic.workspace = true
 mpris2-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
-# mpris2-zbus = { path = "../../dbus-settings-bindings/mpris2" }
 rust-embed.workspace = true
 serde.workspace = true
 tokio.workspace = true
@@ -19,7 +19,11 @@ tracing.workspace = true
 url = "2"
 urlencoding = "2.1.3"
 zbus.workspace = true
+zlink.workspace = true
+intmap = "3.1.3"
 
-[dependencies.cosmic-settings-sound-subscription]
-git = "https://github.com/pop-os/cosmic-settings"
-# path = "../../cosmic-settings/subscriptions/sound"
+[dependencies.cosmic-settings-audio-client]
+# path = "../../cosmic-settings-daemon/audio-client"
+git = "https://github.com/pop-os/cosmic-settings-daemon"
+branch = "varlink"
+features = ["codec"]

--- a/cosmic-applet-audio/Cargo.toml
+++ b/cosmic-applet-audio/Cargo.toml
@@ -23,7 +23,5 @@ zlink.workspace = true
 intmap = "3.1.3"
 
 [dependencies.cosmic-settings-audio-client]
-# path = "../../cosmic-settings-daemon/audio-client"
 git = "https://github.com/pop-os/cosmic-settings-daemon"
-branch = "varlink"
 features = ["codec"]

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod localize;
+mod model;
 mod mouse_area;
 
 use crate::localize::localize;
 use config::{AudioAppletConfig, amplification_sink, amplification_source};
 use cosmic::{
-    Element, Renderer, Task, Theme, app,
+    Apply, Element, Renderer, Task, Theme, app,
     applet::{
         column as applet_column,
         cosmic_panel_config::PanelAnchor,
@@ -26,10 +27,12 @@ use cosmic::{
     surface, theme,
     widget::{Row, button, container, divider, icon, space, text, toggler},
 };
-use cosmic_settings_sound_subscription as css;
+use cosmic_settings_audio_client::{self as audio_client, CosmicAudioProxy};
+use futures::SinkExt;
 use iced::platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup};
 use mpris_subscription::{MprisRequest, MprisUpdate};
 use mpris2_zbus::player::PlaybackStatus;
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 mod config;
 mod mpris_subscription;
@@ -50,8 +53,10 @@ pub struct Audio {
     core: cosmic::app::Core,
     /// Track the applet's popup window.
     popup: Option<window::Id>,
-    /// The model from cosmic-settings for managing pipewire devices.
-    model: css::Model,
+    /// Varlink connection to `com.system76.CosmicSettings.Audio`.
+    audio_client: Option<Rc<RefCell<audio_client::Client>>>,
+    /// Known audio device state
+    model: model::Model,
     /// Whether to expand the revealer of a source or sink device.
     is_open: IsOpen,
     /// Max slider volume for the sink device, as determined by the amplification property.
@@ -72,8 +77,8 @@ pub struct Audio {
 
 impl Audio {
     fn output_icon_name(&self) -> &'static str {
-        let volume = self.model.sink_volume;
-        let mute = self.model.sink_mute;
+        let volume = self.model.active_sink.volume;
+        let mute = self.model.active_sink.mute;
         if mute || volume == 0 {
             "audio-volume-muted-symbolic"
         } else if volume < 33 {
@@ -88,8 +93,8 @@ impl Audio {
     }
 
     fn input_icon_name(&self) -> &'static str {
-        let volume = self.model.source_volume;
-        let mute = self.model.source_mute;
+        let volume = self.model.active_source.volume;
+        let mute = self.model.active_source.mute;
         if mute || volume == 0 {
             "microphone-sensitivity-muted-symbolic"
         } else if volume < 33 {
@@ -110,8 +115,10 @@ enum IsOpen {
     Input,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub enum Message {
+    /// Connection to `com.system76.CosmicSettings`.
+    Client(Arc<audio_client::Client>),
     Ignore,
     SetSinkVolume(u32),
     SetSourceVolume(u32),
@@ -129,7 +136,7 @@ pub enum Message {
     MprisRequest(MprisRequest),
     Token(TokenUpdate),
     OpenSettings,
-    Subscription(css::Message),
+    Subscription(audio_client::Event),
     Surface(surface::Action),
 }
 
@@ -242,15 +249,9 @@ impl cosmic::Application for Audio {
     const APP_ID: &'static str = "com.system76.CosmicAppletAudio";
 
     fn init(core: cosmic::app::Core, _flags: ()) -> (Self, app::Task<Message>) {
-        let mut model = css::Model::default();
-        model.unplugged_text = "Unplugged".into();
-        model.hd_audio_text = "HD Audio".into();
-        model.usb_audio_text = "USB Audio".into();
-
         (
             Self {
                 core,
-                model,
                 ..Default::default()
             },
             Task::none(),
@@ -318,42 +319,63 @@ impl cosmic::Application for Audio {
                 }
             }
             Message::Subscription(message) => {
-                return self
-                    .model
-                    .update(message)
-                    .map(|message| Message::Subscription(message).into());
+                self.model.update(message);
             }
 
             Message::SetDefaultSink(pos) => {
-                return self
-                    .model
-                    .set_default_sink(pos)
-                    .map(|message| Message::Subscription(message).into());
+                if let Some(&node_id) = self.model.sinks.id.get(pos) {
+                    if let Some(client) = self.audio_client.as_mut() {
+                        futures::executor::block_on(async {
+                            _ = client.borrow_mut().conn.set_default(node_id, true).await;
+                        });
+                    }
+                }
             }
 
             Message::SetDefaultSource(pos) => {
-                return self
-                    .model
-                    .set_default_source(pos)
-                    .map(|message| Message::Subscription(message).into());
+                if let Some(&node_id) = self.model.sources.id.get(pos) {
+                    if let Some(client) = self.audio_client.as_mut() {
+                        futures::executor::block_on(async {
+                            _ = client.borrow_mut().conn.set_default(node_id, true).await;
+                        });
+                    }
+                }
             }
 
-            Message::ToggleSinkMute => self.model.toggle_sink_mute(),
+            Message::ToggleSinkMute => {
+                if let Some(ref mut client) = self.audio_client {
+                    futures::executor::block_on(async {
+                        _ = client.borrow_mut().conn.sink_mute_toggle().await;
+                    });
+                }
+            }
 
-            Message::ToggleSourceMute => self.model.toggle_source_mute(),
+            Message::ToggleSourceMute => {
+                if let Some(ref mut client) = self.audio_client {
+                    futures::executor::block_on(async {
+                        _ = client.borrow_mut().conn.source_mute_toggle().await;
+                    });
+                }
+            }
 
             Message::SetSinkVolume(volume) => {
-                return self
-                    .model
-                    .set_sink_volume(volume)
-                    .map(|message| Message::Subscription(message).into());
+                if let Some(ref mut client) = self.audio_client {
+                    self.model.active_sink.volume = volume;
+                    self.model.active_sink.volume_text = volume.to_string();
+                    futures::executor::block_on(async {
+                        _ = client.borrow_mut().conn.set_sink_volume(volume).await;
+                    });
+                }
             }
 
             Message::SetSourceVolume(volume) => {
-                return self
-                    .model
-                    .set_source_volume(volume)
-                    .map(|message| Message::Subscription(message).into());
+                if let Some(ref mut client) = self.audio_client {
+                    self.model.active_source.volume = volume;
+                    self.model.active_source.volume_text = volume.to_string();
+                    futures::executor::block_on(async {
+                        _ = client.borrow_mut().conn.set_source_volume(volume).await;
+                    });
+                }
             }
 
             Message::ToggleMediaControlsInTopPanel(enabled) => {
@@ -461,6 +483,12 @@ impl cosmic::Application for Audio {
                     cosmic::app::Action::Surface(a),
                 ));
             }
+            Message::Client(client) => {
+                if let Some(client) = Arc::into_inner(client) {
+                    self.audio_client = Some(Rc::new(RefCell::new(client)));
+                    self.model = model::Model::default();
+                }
+            }
         }
 
         Task::none()
@@ -476,7 +504,49 @@ impl cosmic::Application for Audio {
             }),
             mpris_subscription::mpris_subscription(0).map(Message::Mpris),
             activation_token_subscription(0).map(Message::Token),
-            Subscription::run(|| css::watch().map(Message::Subscription)),
+            Subscription::run(|| {
+                iced::stream::channel(
+                    1,
+                    move |mut emitter: futures::channel::mpsc::Sender<_>| async move {
+                        loop {
+                            let mut client = match audio_client::connect().await {
+                                Ok(client) => client,
+                                Err(why) => {
+                                    if let zlink::Error::Io(ref why) = why
+                                        && why.kind() == std::io::ErrorKind::NotFound
+                                    {
+                                        tracing::error!(
+                                            "cosmic-settings-daemon varlink service not found."
+                                        );
+                                    } else {
+                                        tracing::error!(
+                                            ?why,
+                                            "failed to connect to cosmic-settings's varlink service"
+                                        );
+                                    }
+
+                                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                                    continue;
+                                }
+                            };
+
+                            if let Ok(Ok(mut stream)) = client.recv_events().await {
+                                _ = emitter.send(Message::Client(Arc::new(client))).await;
+                                while let Some(message) = stream.next().await {
+                                    match message {
+                                        Ok(event) => {
+                                            _ = emitter.send(Message::Subscription(event)).await;
+                                        }
+                                        Err(why) => {
+                                            tracing::error!(?why, "event error");
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                )
+            }),
         ])
     }
 
@@ -497,7 +567,7 @@ impl cosmic::Application for Audio {
                 return Message::Ignore;
             }
 
-            let new_volume = (self.model.sink_volume as f64 + (scroll_vector as f64))
+            let new_volume = (self.model.active_sink.volume as f64 + (scroll_vector as f64))
                 .clamp(0.0, self.max_sink_volume as f64);
             Message::SetSinkVolume(new_volume as u32)
         });
@@ -553,17 +623,19 @@ impl cosmic::Application for Audio {
 
         let sink = self
             .model
-            .active_sink()
-            .and_then(|pos| self.model.sinks().get(pos));
+            .sinks
+            .active
+            .map(|pos| self.model.sinks.display[pos].as_str());
         let source = self
             .model
-            .active_source()
-            .and_then(|pos| self.model.sources().get(pos));
+            .sources
+            .active
+            .map(|pos| self.model.sources.display[pos].as_str());
 
         let mut audio_content = {
             let output_slider = slider(
                 0..=self.max_sink_volume,
-                self.model.sink_volume,
+                self.model.active_sink.volume,
                 Message::SetSinkVolume,
             )
             .width(Length::FillPortion(5))
@@ -571,7 +643,7 @@ impl cosmic::Application for Audio {
 
             let input_slider = slider(
                 0..=self.max_source_volume,
-                self.model.source_volume,
+                self.model.active_source.volume,
                 Message::SetSourceVolume,
             )
             .width(Length::FillPortion(5))
@@ -590,7 +662,7 @@ impl cosmic::Application for Audio {
                         .line_height(24)
                         .on_press(Message::ToggleSinkMute),
                         output_slider,
-                        container(text(&self.model.sink_volume_text).size(16))
+                        container(text(&self.model.active_sink.volume_text).size(16))
                             .width(Length::FillPortion(1))
                             .align_x(Alignment::End)
                     ]
@@ -609,7 +681,7 @@ impl cosmic::Application for Audio {
                         .line_height(24)
                         .on_press(Message::ToggleSourceMute),
                         input_slider,
-                        container(text(&self.model.source_volume_text).size(16))
+                        container(text(&self.model.active_source.volume_text).size(16))
                             .width(Length::FillPortion(1))
                             .align_x(Alignment::End)
                     ]
@@ -624,7 +696,7 @@ impl cosmic::Application for Audio {
                         Some(sink) => sink.to_owned(),
                         None => fl!("no-device"),
                     },
-                    self.model.sinks(),
+                    &self.model.sinks.display,
                     Message::OutputToggle,
                     Message::SetDefaultSink,
                 ),
@@ -635,7 +707,7 @@ impl cosmic::Application for Audio {
                         Some(source) => source.to_owned(),
                         None => fl!("no-device"),
                     },
-                    self.model.sources(),
+                    &self.model.sources.display,
                     Message::InputToggle,
                     Message::SetDefaultSource,
                 )
@@ -691,19 +763,15 @@ impl cosmic::Application for Audio {
             }
             if let Some(play) = self.is_play() {
                 control_elements.push(
-                    button::icon(
-                        icon::from_name(if play { PLAY } else { PAUSE })
-                            .size(32)
-                            .symbolic(true),
-                    )
-                    .extra_small()
-                    .class(cosmic::theme::Button::AppletIcon)
-                    .on_press(if play {
-                        Message::MprisRequest(MprisRequest::Play)
-                    } else {
-                        Message::MprisRequest(MprisRequest::Pause)
-                    })
-                    .into(),
+                    button::icon(icon::from_name(if play { PLAY } else { PAUSE }).symbolic(true))
+                        .extra_small()
+                        .class(cosmic::theme::Button::AppletIcon)
+                        .on_press(if play {
+                            Message::MprisRequest(MprisRequest::Play)
+                        } else {
+                            Message::MprisRequest(MprisRequest::Pause)
+                        })
+                        .into(),
                 );
             }
             if let Some(go_next) = self.go_next(32) {
@@ -767,7 +835,8 @@ fn revealer(
             column![revealer_head(open, title, selected, toggle)].width(Length::Fill),
             |col, (id, name)| {
                 col.push(
-                    menu_button(text::body(name))
+                    text::body(name)
+                        .apply(menu_button)
                         .on_press(change(id))
                         .width(Length::Fill)
                         .padding([8, 48]),
@@ -785,9 +854,9 @@ fn revealer_head(
     selected: String,
     toggle: Message,
 ) -> cosmic::widget::Button<'static, Message> {
-    menu_button(column![
-        text::body(title).width(Length::Fill),
-        text::caption(selected),
-    ])
-    .on_press(toggle)
+    cosmic::widget::column::with_capacity(2)
+        .push(text::body(title).width(Length::Fill))
+        .push(text::caption(selected))
+        .apply(menu_button)
+        .on_press(toggle)
 }

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -323,22 +323,24 @@ impl cosmic::Application for Audio {
             }
 
             Message::SetDefaultSink(pos) => {
-                if let Some(&node_id) = self.model.sinks.id.get(pos) {
-                    if let Some(client) = self.audio_client.as_mut() {
-                        futures::executor::block_on(async {
-                            _ = client.borrow_mut().conn.set_default(node_id, true).await;
-                        });
-                    }
+                if let Some(&pos) = self.model.sinks.sorted_index.get(pos)
+                    && let Some(&node_id) = self.model.sinks.id.get(pos as usize)
+                    && let Some(client) = self.audio_client.as_mut()
+                {
+                    futures::executor::block_on(async {
+                        _ = client.borrow_mut().conn.set_default(node_id, true).await;
+                    });
                 }
             }
 
             Message::SetDefaultSource(pos) => {
-                if let Some(&node_id) = self.model.sources.id.get(pos) {
-                    if let Some(client) = self.audio_client.as_mut() {
-                        futures::executor::block_on(async {
-                            _ = client.borrow_mut().conn.set_default(node_id, true).await;
-                        });
-                    }
+                if let Some(&pos) = self.model.sources.sorted_index.get(pos)
+                    && let Some(&node_id) = self.model.sources.id.get(pos as usize)
+                    && let Some(client) = self.audio_client.as_mut()
+                {
+                    futures::executor::block_on(async {
+                        _ = client.borrow_mut().conn.set_default(node_id, true).await;
+                    });
                 }
             }
 
@@ -382,10 +384,9 @@ impl cosmic::Application for Audio {
                 self.config.show_media_controls_in_top_panel = enabled;
                 if let Ok(helper) =
                     cosmic::cosmic_config::Config::new(Self::APP_ID, AudioAppletConfig::VERSION)
+                    && let Err(err) = self.config.write_entry(&helper)
                 {
-                    if let Err(err) = self.config.write_entry(&helper) {
-                        tracing::error!(?err, "Error writing config");
-                    }
+                    tracing::error!(?err, "Error writing config");
                 }
             }
             Message::CloseRequested(id) => {
@@ -621,16 +622,16 @@ impl cosmic::Application for Audio {
             space_xxs, space_s, ..
         } = theme::active().cosmic().spacing;
 
-        let sink = self
+        let sink: Option<&str> = self
             .model
             .sinks
-            .active
-            .map(|pos| self.model.sinks.display[pos].as_str());
-        let source = self
+            .active()
+            .map(|pos| self.model.sinks.sorted_display[pos].as_ref());
+        let source: Option<&str> = self
             .model
             .sources
-            .active
-            .map(|pos| self.model.sources.display[pos].as_str());
+            .active()
+            .map(|pos| self.model.sources.sorted_display[pos].as_ref());
 
         let mut audio_content = {
             let output_slider = slider(
@@ -696,7 +697,7 @@ impl cosmic::Application for Audio {
                         Some(sink) => sink.to_owned(),
                         None => fl!("no-device"),
                     },
-                    &self.model.sinks.display,
+                    &self.model.sinks.sorted_display,
                     Message::OutputToggle,
                     Message::SetDefaultSink,
                 ),
@@ -707,7 +708,7 @@ impl cosmic::Application for Audio {
                         Some(source) => source.to_owned(),
                         None => fl!("no-device"),
                     },
-                    &self.model.sources.display,
+                    &self.model.sources.sorted_display,
                     Message::InputToggle,
                     Message::SetDefaultSource,
                 )
@@ -822,20 +823,20 @@ impl cosmic::Application for Audio {
     }
 }
 
-fn revealer(
+fn revealer<'a>(
     open: bool,
     title: String,
     selected: String,
-    devices: &[String],
+    devices: &'a [Arc<str>],
     toggle: Message,
     mut change: impl FnMut(usize) -> Message + 'static,
-) -> widget::Column<'static, Message, crate::Theme, Renderer> {
+) -> widget::Column<'a, Message, crate::Theme, Renderer> {
     if open {
-        devices.iter().cloned().enumerate().fold(
+        devices.iter().enumerate().fold(
             column![revealer_head(open, title, selected, toggle)].width(Length::Fill),
-            |col, (id, name)| {
+            move |col, (id, name)| {
                 col.push(
-                    text::body(name)
+                    text::body(name.as_ref())
                         .apply(menu_button)
                         .on_press(change(id))
                         .width(Length::Fill)

--- a/cosmic-applet-audio/src/model.rs
+++ b/cosmic-applet-audio/src/model.rs
@@ -1,0 +1,358 @@
+// Copyright 2026 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use cosmic_settings_audio_client::{self as audio_client, Availability, RouteInfo};
+use intmap::IntMap;
+
+pub type DeviceId = u32;
+pub type NodeId = u32;
+
+#[derive(Debug, Default)]
+pub struct Model {
+    pub device_routes: IntMap<DeviceId, Vec<RouteInfo>>,
+    pub node_devices: IntMap<NodeId, Option<u32>>,
+    pub sinks: Nodes,
+    pub sources: Nodes,
+    pub active_sink: ActiveNode,
+    pub active_source: ActiveNode,
+    pub default_sink: Option<NodeId>,
+    pub default_source: Option<NodeId>,
+}
+
+#[derive(Debug, Default)]
+pub struct Nodes {
+    pub active: Option<usize>,
+    pub balance: Vec<Option<f32>>,
+    pub card_profile_device: Vec<Option<u32>>,
+    pub description: Vec<String>,
+    pub devices: Vec<Option<NodeId>>,
+    pub display: Vec<String>,
+    pub mute: Vec<bool>,
+    pub name: Vec<String>,
+    pub id: Vec<NodeId>,
+    pub volume: Vec<u32>,
+}
+
+impl Nodes {
+    pub fn remove(&mut self, node_id: u32) -> bool {
+        let Some(pos) = self.id.iter().position(|id| node_id == *id) else {
+            return false;
+        };
+        self.balance.remove(pos);
+        self.card_profile_device.remove(pos);
+        self.description.remove(pos);
+        self.devices.remove(pos);
+        self.display.remove(pos);
+        self.mute.remove(pos);
+        self.name.remove(pos);
+        self.id.remove(pos);
+        self.volume.remove(pos);
+        if self.active == Some(pos) {
+            self.active = None;
+        }
+        true
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ActiveNode {
+    pub volume_text: String,
+    pub volume: u32,
+    pub mute: bool,
+}
+
+impl Model {
+    pub fn update(&mut self, event: audio_client::Event) {
+        tracing::debug!(?event, "update");
+        match event {
+            audio_client::Event::NodeMute(node_id, mute) => {
+                if let Some(pos) = self.sinks.id.iter().position(|id| node_id == *id) {
+                    self.sinks.mute[pos] = mute;
+                    if self.sinks.active == Some(pos) {
+                        self.active_sink.mute = mute;
+                    }
+                } else if let Some(pos) = self.sources.id.iter().position(|id| node_id == *id) {
+                    self.sources.mute[pos] = mute;
+                    if self.sources.active == Some(pos) {
+                        self.active_source.mute = mute;
+                    }
+                }
+            }
+
+            audio_client::Event::NodeVolume(node_id, volume, balance) => {
+                if let Some(pos) = self.sinks.id.iter().position(|id| node_id == *id) {
+                    self.sinks.volume[pos] = volume;
+                    self.sinks.balance[pos] = balance;
+                    if self.default_sink.as_ref().is_some_and(|&id| id == node_id)
+                        && let Some(pos) = self.sinks.active
+                    {
+                        self.active_sink.mute = self.sinks.mute[pos];
+                        self.active_sink.volume = self.sinks.volume[pos];
+                        self.active_sink.volume_text = self.active_sink.volume.to_string();
+                    }
+                } else if let Some(pos) = self.sources.id.iter().position(|id| node_id == *id) {
+                    self.sources.volume[pos] = volume;
+                    self.sources.balance[pos] = balance;
+                    if self
+                        .default_source
+                        .as_ref()
+                        .is_some_and(|&id| id == node_id)
+                        && let Some(pos) = self.sources.active
+                    {
+                        self.active_source.mute = self.sources.mute[pos];
+                        self.active_source.volume = self.sources.volume[pos];
+                        self.active_source.volume_text = self.active_source.volume.to_string();
+                    }
+                }
+            }
+
+            audio_client::Event::DefaultSink(node_id) => {
+                self.default_sink = Some(node_id);
+                if let Some(pos) = self.sinks.id.iter().position(|&id| id == node_id) {
+                    self.sinks.active = Some(pos);
+                    self.active_sink.mute = self.sinks.mute[pos];
+                    self.active_sink.volume = self.sinks.volume[pos];
+                    self.active_sink.volume_text = self.active_sink.volume.to_string();
+                }
+            }
+
+            audio_client::Event::DefaultSource(node_id) => {
+                self.default_source = Some(node_id);
+                if let Some(pos) = self.sources.id.iter().position(|&id| id == node_id) {
+                    self.sources.active = Some(pos);
+                    self.active_source.mute = self.sources.mute[pos];
+                    self.active_source.volume = self.sources.volume[pos];
+                    self.active_source.volume_text = self.active_source.volume.to_string();
+                }
+            }
+
+            audio_client::Event::Node(node_id, node) => {
+                self.node_devices.insert(node_id, node.device_id);
+                if node.is_sink {
+                    let pos = if let Some(pos) = self.sinks.id.iter().position(|&id| id == node_id)
+                    {
+                        self.sinks.description[pos] = self.translate(&node.description);
+                        self.sinks.name[pos] = node.name;
+                        self.sinks.card_profile_device[pos] = node.card_profile_device;
+                        pos
+                    } else {
+                        self.sinks.display.push(String::new());
+                        self.sinks
+                            .description
+                            .push(self.translate(&node.description));
+                        self.sinks.id.push(node_id);
+                        self.sinks.volume.push(0);
+                        self.sinks.balance.push(None);
+                        self.sinks.mute.push(false);
+                        self.sinks.name.push(node.name);
+                        self.sinks.devices.push(node.device_id);
+                        self.sinks
+                            .card_profile_device
+                            .push(node.card_profile_device);
+                        self.sinks.id.len() - 1
+                    };
+
+                    self.sinks.display[pos] = node
+                        .device_id
+                        .zip(node.card_profile_device)
+                        .and_then(|(device_id, node_card_profile_device)| {
+                            let routes = self.device_routes.get(device_id)?;
+                            for route in routes {
+                                if matches!(route.availability, Availability::No) || !route.is_sink
+                                {
+                                    continue;
+                                }
+
+                                if route.devices.contains(&node_card_profile_device) {
+                                    return Some(
+                                        [
+                                            &*self.translate(&route.description),
+                                            " - ",
+                                            &self.sinks.description[pos],
+                                        ]
+                                        .concat(),
+                                    );
+                                }
+                            }
+
+                            None
+                        })
+                        .unwrap_or_else(|| {
+                            [
+                                &node.device_profile_description,
+                                " - ",
+                                &*self.sinks.description[pos],
+                            ]
+                            .concat()
+                        });
+
+                    if let Some(default_node_id) = self.default_sink
+                        && default_node_id == node_id
+                    {
+                        self.sinks.active = Some(pos);
+                        self.active_sink.mute = self.sinks.mute[pos];
+                        self.active_sink.volume = self.sinks.volume[pos];
+                        self.active_sink.volume_text = self.active_sink.volume.to_string();
+                    }
+                } else {
+                    let pos =
+                        if let Some(pos) = self.sources.id.iter().position(|&id| id == node_id) {
+                            self.sources.description[pos] = self.translate(&node.description);
+                            self.sources.name[pos] = node.name;
+                            self.sources.card_profile_device[pos] = node.card_profile_device;
+                            pos
+                        } else {
+                            self.sources
+                                .description
+                                .push(self.translate(&node.description));
+                            self.sources.display.push(String::new());
+                            self.sources.id.push(node_id);
+                            self.sources.volume.push(0);
+                            self.sources.balance.push(None);
+                            self.sources.mute.push(false);
+                            self.sources.name.push(node.name);
+                            self.sources.devices.push(node.device_id);
+                            self.sources
+                                .card_profile_device
+                                .push(node.card_profile_device);
+                            self.sources.id.len() - 1
+                        };
+
+                    if let Some(name) = node
+                        .device_id
+                        .zip(node.card_profile_device)
+                        .map(|(device_id, node_card_profile_device)| {
+                            let routes = self.device_routes.get(device_id)?;
+                            for route in routes {
+                                if route.is_sink || matches!(route.availability, Availability::No) {
+                                    continue;
+                                }
+
+                                if route.devices.contains(&node_card_profile_device) {
+                                    return Some(
+                                        [
+                                            &*self.translate(&route.description),
+                                            " - ",
+                                            &self.sources.description[pos],
+                                        ]
+                                        .concat(),
+                                    );
+                                }
+                            }
+
+                            None
+                        })
+                        .unwrap_or_else(|| {
+                            Some(
+                                [
+                                    &node.device_profile_description,
+                                    " - ",
+                                    &*self.sources.description[pos],
+                                ]
+                                .concat(),
+                            )
+                        })
+                    {
+                        self.sources.display[pos] = name;
+                    } else {
+                        // Remove sources that are unplugged.
+                        self.sources.remove(node_id);
+                        return;
+                    }
+
+                    if let Some(default_node_id) = self.default_source
+                        && default_node_id == node_id
+                    {
+                        self.sources.active = Some(pos);
+                        self.active_source.mute = self.sources.mute[pos];
+                        self.active_source.volume = self.sources.volume[pos];
+                        self.active_source.volume_text = self.active_source.volume.to_string();
+                    }
+                }
+            }
+
+            audio_client::Event::ActiveRoute(device_id, _index, route) => {
+                self.update_device_names(device_id, &route);
+            }
+
+            audio_client::Event::Route(device_id, index, route) => {
+                let routes = self.device_routes.entry(device_id).or_default();
+                if routes.len() < index as usize + 1 {
+                    let additional = (index as usize + 1) - routes.capacity();
+                    routes.reserve_exact(additional);
+                    routes.extend(std::iter::repeat_n(RouteInfo::default(), additional));
+                }
+                routes[index as usize] = route;
+            }
+
+            audio_client::Event::RemoveNode(node_id) => {
+                self.node_devices.remove(node_id);
+
+                if !self.sinks.remove(node_id) {
+                    self.sources.remove(node_id);
+                }
+            }
+
+            audio_client::Event::RemoveDevice(device_id) => {
+                self.device_routes.remove(device_id);
+            }
+
+            _ => (),
+        }
+    }
+
+    fn update_device_names(&mut self, device_id: DeviceId, route: &RouteInfo) {
+        if matches!(route.availability, Availability::No) {
+            return;
+        }
+
+        let compatible_nodes = self.node_devices.iter().filter_map(|(node, &dev_id)| {
+            if dev_id? == device_id {
+                Some(node)
+            } else {
+                None
+            }
+        });
+
+        if route.is_sink {
+            for n_id in compatible_nodes {
+                let Some(pos) = self.sinks.id.iter().position(|&node| node == n_id) else {
+                    continue;
+                };
+
+                let Some(card_profile_device) = self.sinks.card_profile_device[pos] else {
+                    continue;
+                };
+
+                if route.devices.contains(&card_profile_device) {
+                    self.sinks.display[pos] =
+                        [&route.description, " - ", &self.sinks.description[pos]].concat();
+                    break;
+                }
+            }
+        } else {
+            for n_id in compatible_nodes {
+                let Some(pos) = self.sources.id.iter().position(|&node| node == n_id) else {
+                    continue;
+                };
+
+                let Some(card_profile_device) = self.sources.card_profile_device[pos] else {
+                    continue;
+                };
+
+                if route.devices.contains(&card_profile_device) {
+                    self.sources.display[pos] =
+                        [&route.description, " - ", &self.sources.description[pos]].concat();
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn translate(&self, description: &str) -> String {
+        description
+            .replace("High Definition", "HD")
+            .replace("DisplayPort", "DP")
+            .replace("Controller", "")
+    }
+}

--- a/cosmic-applet-audio/src/model.rs
+++ b/cosmic-applet-audio/src/model.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::sync::Arc;
+
 use cosmic_settings_audio_client::{self as audio_client, Availability, RouteInfo};
 use intmap::IntMap;
 
@@ -21,12 +23,14 @@ pub struct Model {
 
 #[derive(Debug, Default)]
 pub struct Nodes {
-    pub active: Option<usize>,
+    active: Option<usize>,
+    pub sorted_display: Box<[Arc<str>]>,
+    pub sorted_index: Box<[u16]>,
     pub balance: Vec<Option<f32>>,
     pub card_profile_device: Vec<Option<u32>>,
     pub description: Vec<String>,
     pub devices: Vec<Option<NodeId>>,
-    pub display: Vec<String>,
+    pub display: Vec<Arc<str>>,
     pub mute: Vec<bool>,
     pub name: Vec<String>,
     pub id: Vec<NodeId>,
@@ -34,6 +38,28 @@ pub struct Nodes {
 }
 
 impl Nodes {
+    pub fn active(&self) -> Option<usize> {
+        self.active.and_then(|active| {
+            self.sorted_index
+                .iter()
+                .position(|idx| *idx as usize == active)
+        })
+    }
+
+    pub fn dropdown_sort(&mut self) {
+        let mut enumerated_displays = self
+            .display
+            .clone()
+            .into_iter()
+            .enumerate()
+            .map(|(index, display)| (index as u16, display))
+            .collect::<Vec<_>>();
+        enumerated_displays.sort_by_key(|v| v.1.clone());
+        let (indexes, displays): (Vec<_>, Vec<_>) = enumerated_displays.into_iter().unzip();
+        self.sorted_display = displays.into_boxed_slice();
+        self.sorted_index = indexes.into_boxed_slice();
+    }
+
     pub fn remove(&mut self, node_id: u32) -> bool {
         let Some(pos) = self.id.iter().position(|id| node_id == *id) else {
             return false;
@@ -47,6 +73,7 @@ impl Nodes {
         self.name.remove(pos);
         self.id.remove(pos);
         self.volume.remove(pos);
+        self.dropdown_sort();
         if self.active == Some(pos) {
             self.active = None;
         }
@@ -136,7 +163,7 @@ impl Model {
                         self.sinks.card_profile_device[pos] = node.card_profile_device;
                         pos
                     } else {
-                        self.sinks.display.push(String::new());
+                        self.sinks.display.push(Arc::default());
                         self.sinks
                             .description
                             .push(self.translate(&node.description));
@@ -180,6 +207,8 @@ impl Model {
                             )
                         });
 
+                    self.sinks.dropdown_sort();
+
                     if let Some(default_node_id) = self.default_sink
                         && default_node_id == node_id
                     {
@@ -199,7 +228,7 @@ impl Model {
                             self.sources
                                 .description
                                 .push(self.translate(&node.description));
-                            self.sources.display.push(String::new());
+                            self.sources.display.push(Arc::default());
                             self.sources.id.push(node_id);
                             self.sources.volume.push(0);
                             self.sources.balance.push(None);
@@ -240,6 +269,7 @@ impl Model {
                         })
                     {
                         self.sources.display[pos] = name;
+                        self.sources.dropdown_sort();
                     } else {
                         // Remove sources that are unplugged.
                         self.sources.remove(node_id);
@@ -319,6 +349,7 @@ impl Model {
                         &self.translate(&route.description),
                         &self.sinks.description[pos],
                     );
+                    self.sinks.dropdown_sort();
                     break;
                 }
             }
@@ -337,6 +368,7 @@ impl Model {
                         &self.translate(&route.description),
                         &self.sources.description[pos],
                     );
+                    self.sources.dropdown_sort();
                     break;
                 }
             }
@@ -351,10 +383,11 @@ impl Model {
     }
 }
 
-fn node_name(route: &str, node: &str) -> String {
+fn node_name(route: &str, node: &str) -> Arc<str> {
     if route.is_empty() {
         node.to_owned()
     } else {
         [route, " - ", node].concat()
     }
+    .into()
 }

--- a/cosmic-applet-audio/src/model.rs
+++ b/cosmic-applet-audio/src/model.rs
@@ -277,12 +277,16 @@ impl Model {
 
             audio_client::Event::Route(device_id, index, route) => {
                 let routes = self.device_routes.entry(device_id).or_default();
-                if routes.len() < index as usize + 1 {
-                    let additional = (index as usize + 1) - routes.capacity();
-                    routes.reserve_exact(additional);
-                    routes.extend(std::iter::repeat_n(RouteInfo::default(), additional));
+                if index == 0 {
+                    *routes = vec![route];
+                } else {
+                    if routes.len() < index as usize + 1 {
+                        let additional = (index as usize + 1) - routes.capacity();
+                        routes.reserve_exact(additional);
+                        routes.extend(std::iter::repeat_n(RouteInfo::default(), additional));
+                    }
+                    routes[index as usize] = route;
                 }
-                routes[index as usize] = route;
             }
 
             audio_client::Event::RemoveNode(node_id) => {

--- a/cosmic-applet-audio/src/model.rs
+++ b/cosmic-applet-audio/src/model.rs
@@ -164,26 +164,20 @@ impl Model {
                                 }
 
                                 if route.devices.contains(&node_card_profile_device) {
-                                    return Some(
-                                        [
-                                            &*self.translate(&route.description),
-                                            " - ",
-                                            &self.sinks.description[pos],
-                                        ]
-                                        .concat(),
-                                    );
+                                    return Some(node_name(
+                                        &self.translate(&route.description),
+                                        &self.sinks.description[pos],
+                                    ));
                                 }
                             }
 
                             None
                         })
                         .unwrap_or_else(|| {
-                            [
+                            node_name(
                                 &node.device_profile_description,
-                                " - ",
-                                &*self.sinks.description[pos],
-                            ]
-                            .concat()
+                                &self.sinks.description[pos],
+                            )
                         });
 
                     if let Some(default_node_id) = self.default_sink
@@ -229,28 +223,20 @@ impl Model {
                                 }
 
                                 if route.devices.contains(&node_card_profile_device) {
-                                    return Some(
-                                        [
-                                            &*self.translate(&route.description),
-                                            " - ",
-                                            &self.sources.description[pos],
-                                        ]
-                                        .concat(),
-                                    );
+                                    return Some(node_name(
+                                        &self.translate(&route.description),
+                                        &self.sources.description[pos],
+                                    ));
                                 }
                             }
 
                             None
                         })
                         .unwrap_or_else(|| {
-                            Some(
-                                [
-                                    &node.device_profile_description,
-                                    " - ",
-                                    &*self.sources.description[pos],
-                                ]
-                                .concat(),
-                            )
+                            Some(node_name(
+                                &node.device_profile_description,
+                                &self.sources.description[pos],
+                            ))
                         })
                     {
                         self.sources.display[pos] = name;
@@ -329,8 +315,10 @@ impl Model {
                 };
 
                 if route.devices.contains(&card_profile_device) {
-                    self.sinks.display[pos] =
-                        [&route.description, " - ", &self.sinks.description[pos]].concat();
+                    self.sinks.display[pos] = node_name(
+                        &self.translate(&route.description),
+                        &self.sinks.description[pos],
+                    );
                     break;
                 }
             }
@@ -345,8 +333,10 @@ impl Model {
                 };
 
                 if route.devices.contains(&card_profile_device) {
-                    self.sources.display[pos] =
-                        [&route.description, " - ", &self.sources.description[pos]].concat();
+                    self.sources.display[pos] = node_name(
+                        &self.translate(&route.description),
+                        &self.sources.description[pos],
+                    );
                     break;
                 }
             }
@@ -358,5 +348,13 @@ impl Model {
             .replace("High Definition", "HD")
             .replace("DisplayPort", "DP")
             .replace("Controller", "")
+    }
+}
+
+fn node_name(route: &str, node: &str) -> String {
+    if route.is_empty() {
+        node.to_owned()
+    } else {
+        [route, " - ", node].concat()
     }
 }

--- a/cosmic-applet-audio/src/mouse_area.rs
+++ b/cosmic-applet-audio/src/mouse_area.rs
@@ -5,7 +5,7 @@ use cosmic::iced::core::Point;
 
 use cosmic::iced::core::{
     Clipboard, Element, Layout, Length, Rectangle, Shell, Size, Widget,
-    event::{self, Event},
+    event::Event,
     layout, mouse, overlay, renderer, touch,
     widget::{Operation, Tree, tree},
 };


### PR DESCRIPTION
Must be merged and tested alongside https://github.com/pop-os/cosmic-settings-daemon/pull/135

- Integrates with https://github.com/pop-os/cosmic-settings-daemon/pull/135
    - Uses varlink to switch sink and source nodes, set volume and mute status, and to watch for device changes
    - The settings-daemon must be running in the background with the new varlink socket though

The audio applet previously connected directly to pipewire with a crate that it shared with cosmic-settings, and that contains quite a few issues that the settings-daemon implementation has resolved.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

