### PR TITLE
Removed known wifi from visible wireless networks section

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -1953,28 +1953,42 @@ impl cosmic::Application for CosmicNetworkApplet {
                 }
             }
         } else {
-            let mut list_col =
-                Vec::with_capacity(self.nm_state.nm_state.wireless_access_points.len());
-            for ap in &self.nm_state.nm_state.wireless_access_points {
-                if self.nm_state.nm_state.active_conns.iter().any(|a| {
-                    let hw_address = active_conn_hw_address(a);
-                    ap.ssid.as_ref() == &a.name() && ap.hw_address == hw_address
-                }) {
-                    continue;
-                }
-                let button = menu_button(
-                    row![
-                        icon::from_name(wifi_icon(ap.strength))
-                            .size(16)
-                            .symbolic(true),
-                        text::body(ap.ssid.as_ref()).align_y(Alignment::Center)
-                    ]
-                    .align_y(Alignment::Center)
-                    .spacing(12),
-                )
-                .on_press(Message::SelectWirelessAccessPoint(ap.clone()));
-                list_col.push(button.into());
-            }
+            let list_col = self
+                .nm_state
+                .nm_state
+                .wireless_access_points
+                .iter()
+                .filter(|ap| {
+                    let among_active = self.nm_state.nm_state.active_conns.iter().any(|a| {
+                        let hw_address = active_conn_hw_address(a);
+                        ap.ssid.as_ref() == &a.name() && ap.hw_address == hw_address
+                    });
+                    let among_known =
+                        self.nm_state
+                            .nm_state
+                            .known_access_points
+                            .iter()
+                            .any(|known_ap| {
+                                ap.network_type == known_ap.network_type
+                                    && ap.hw_address == known_ap.hw_address
+                                    && ap.ssid == known_ap.ssid
+                            });
+                    !among_active && !among_known
+                })
+                .map(|ap| {
+                    let button = menu_button(
+                        row![
+                            icon::from_name(wifi_icon(ap.strength))
+                                .size(16)
+                                .symbolic(true),
+                            text::body(ap.ssid.as_ref()).align_y(Alignment::Center)
+                        ]
+                        .align_y(Alignment::Center)
+                        .spacing(12),
+                    )
+                    .on_press(Message::SelectWirelessAccessPoint(ap.clone()));
+                    button.into()
+                });
             content = content
                 .push(scrollable(Column::with_children(list_col)).height(Length::Fixed(300.0)));
         }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Desciption
In scope of this PR I decided to perform change, where all known wireless networks will not be displayed in visible network list due to redundancy. In old implementation known networks list cannot be hidden, so when displaying both visible and known connection, all known connection was displayed twice: once in known connection, and second time in visible connection(only connected network has different behaviour). I decided to get rid of this redundancy by removing known networks from visible ones

In addition to that, I also changed how list on visible network buttons are created. Instead of using loop + filter via `continue` + push to vector, I user `.iter()` + filter + collect

## UI change
<img width="1018" height="681" alt="image" src="https://github.com/user-attachments/assets/e7c000bf-0b68-407c-9fd2-375842917bb0" />
