### PR TITLE
fix(status-area): break from loop instead of unwrapping

### DIFF
--- a/cosmic-applet-status-area/src/unique_names.rs
+++ b/cosmic-applet-status-area/src/unique_names.rs
@@ -5,6 +5,7 @@
 // but only tracking unique names, and using tokio executor.
 
 use futures::StreamExt;
+use futures::stream::FusedStream;
 use std::{
     collections::HashSet,
     future::{Future, poll_fn},
@@ -36,9 +37,15 @@ impl Inner {
     /// Process all events so far on `stream`, and update `unique_names`.
     fn update_if_needed(&mut self) {
         let mut context = Context::from_waker(&self.waker);
-        while let Poll::Ready(val) = self.stream.poll_next_unpin(&mut context) {
-            let val = val.unwrap();
-            let args = val.args().unwrap();
+        while !self.stream.is_terminated()
+            && let Poll::Ready(val) = self.stream.poll_next_unpin(&mut context)
+        {
+            let Some(val) = val else {
+                break;
+            };
+            let Ok(args) = val.args() else {
+                break;
+            };
             match args.name {
                 BusName::Unique(name) => {
                     if args.new_owner.is_some() {
@@ -48,7 +55,7 @@ impl Inner {
                     }
                 }
                 BusName::WellKnown(_) => {}
-            }
+            };
         }
     }
 }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described. (I am not sure how to recreate the panic described in #1316)
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

