### PR TITLE
fix(applet-audio): prevent accidental mute on scroll from uninitialized state

### DIFF
--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -518,10 +518,6 @@ impl cosmic::Application for Audio {
 
         const WHEEL_STEP: f32 = 5.0; // 5% per wheel event
         let btn = crate::mouse_area::MouseArea::new(btn).on_mouse_wheel(|delta| {
-            if self.max_sink_volume == 0 {
-                return Message::Ignore;
-            }
-
             let scroll_vector = match delta {
                 iced::mouse::ScrollDelta::Lines { y, .. } => y.signum() * WHEEL_STEP, // -1/0/1
                 iced::mouse::ScrollDelta::Pixels { y, .. } => y.signum(),             // -1/0/1

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -254,10 +254,26 @@ impl cosmic::Application for Audio {
         model.hd_audio_text = "HD Audio".into();
         model.usb_audio_text = "USB Audio".into();
 
+        let (max_sink_volume, sink_breakpoints) = if amplification_sink() {
+            (150, &[100][..])
+        } else {
+            (100, &[][..])
+        };
+
+        let (max_source_volume, source_breakpoints) = if amplification_source() {
+            (150, &[100][..])
+        } else {
+            (100, &[][..])
+        };
+
         (
             Self {
                 core,
                 model,
+                max_sink_volume,
+                max_source_volume,
+                sink_breakpoints,
+                source_breakpoints,
                 ..Default::default()
             },
             Task::none(),
@@ -502,6 +518,10 @@ impl cosmic::Application for Audio {
 
         const WHEEL_STEP: f32 = 5.0; // 5% per wheel event
         let btn = crate::mouse_area::MouseArea::new(btn).on_mouse_wheel(|delta| {
+            if self.max_sink_volume == 0 {
+                return Message::Ignore;
+            }
+
             let scroll_vector = match delta {
                 iced::mouse::ScrollDelta::Lines { y, .. } => y.signum() * WHEEL_STEP, // -1/0/1
                 iced::mouse::ScrollDelta::Pixels { y, .. } => y.signum(),             // -1/0/1


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

--- 
The issue is easy to replicate:
- Run
  ```
  killall cosmic-panel
  ```
- Hover the volume icon on the panel and scroll down. It will mute the audio regardless of the previous volume level due to an uninitialized state.

Closes #1215
