### PR TITLE
feat: use rich_text for notifications-applet

### DIFF
--- a/cosmic-applet-notifications/src/lib.rs
+++ b/cosmic-applet-notifications/src/lib.rs
@@ -16,7 +16,7 @@ use cosmic::{
         Alignment, Length, Subscription,
         advanced::text::{Ellipsize, EllipsizeHeightLimit},
         platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup},
-        widget::{self, column, row},
+        widget::{self, column, rich_text, row},
         window,
     },
     surface, theme,
@@ -26,7 +26,7 @@ use cosmic::{
 use cosmic::iced::futures::executor::block_on;
 
 use cosmic_notifications_config::NotificationsConfig;
-use cosmic_notifications_util::{ActionId, Image, Notification};
+use cosmic_notifications_util::{ActionId, Image, Notification, markup};
 use std::{borrow::Cow, collections::HashMap, path::PathBuf, sync::LazyLock};
 use subscriptions::notifications::{self, NotificationsAppletProxy};
 use tokio::sync::mpsc::Sender;
@@ -456,8 +456,11 @@ impl cosmic::Application for Notifications {
                                     column![
                                         text::body(n.summary.lines().next().unwrap_or_default())
                                             .width(Length::Fill),
-                                        text::caption(n.body.lines().next().unwrap_or_default())
-                                            .width(Length::Fill)
+                                        Element::from(
+                                            rich_text(markup::html_to_spans(&n.body))
+                                                .size(12.0)
+                                                .width(Length::Fill)
+                                        )
                                     ]
                                 )
                                 .width(Length::Fill),


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Hi,
This will use rich_text the same way as in `cosmic-notifications` for applet, so HTML should be also parsed properly.