### PR TITLE
remove unnecessarry comma from `cosmic-applet-time`

### DIFF
--- a/cosmic-applet-time/src/window.rs
+++ b/cosmic-applet-time/src/window.rs
@@ -287,6 +287,7 @@ impl Window {
                         .unwrap()
                         .format(&datetime)
                         .to_string()
+                        .replace(",", "")
                 }
             } else {
                 let mut fs = fieldsets::T::medium();


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.



When the system locale is set to `pt-BR`, the date displayed in the top or bottom panel includes a comma between the abbreviated month and the time, resulting in two consecutive punctuation marks: `25 de abr., 09:35`. <img width="143" height="35" alt="Image" src="https://github.com/user-attachments/assets/62989893-6219-49df-89d8-fda8af3dd3b2" />


The vertical layout is not affected because it formats date and time separately.

The horizontal layout, however, combines them via ICU4X's datetime combining pattern for `pt-BR`, which appears to be `"{1}, {0}"` (comma-separated) instead of `"{1} {0}"`.

The `.` is correct, it belongs to the abbreviated month (`abr.`). 

The problem is the `,` that ICU4X inserts as a separator between the date and time parts, producing the awkward `.,` sequence which is not natural in Brazilian Portuguese.

## Steps to reproduce

1. Set system locale to `pt-BR`
2. Set Panel Position on screen to Bottom or Top

## Expected behavior

`25 de abr. 09:35` with no comma between date and time.

## Proposed fix

Strip the combining comma from the formatted string for `pt-BR`, or format date
and time separately and concatenate with a space, similar to what the vertical
layout already does.

<img width="798" height="277" alt="Image" src="https://github.com/user-attachments/assets/24cce829-b596-4900-badb-12e109395efd" />

I only need to know if in some other language this comma is necessary by some reason.