### PR TITLE
fix(process): prevent zombie shell processes

### DIFF
--- a/cosmic-panel-button/src/lib.rs
+++ b/cosmic-panel-button/src/lib.rs
@@ -123,11 +123,15 @@ impl cosmic::Application for Button {
     fn update(&mut self, message: Msg) -> app::Task<Msg> {
         match message {
             Msg::Press => {
-                let _ = Command::new("sh")
+                if let Ok(mut child) = Command::new("sh")
                     .arg("-c")
-                    .arg(&self.desktop.exec)
+                    .arg(format!("exec {}", self.desktop.exec))
                     .spawn()
-                    .unwrap();
+                {
+                    std::thread::spawn(move || {
+                        let _ = child.wait();
+                    });
+                }
             }
             Msg::ConfigUpdated(conf) => {
                 self.config = conf


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
---

## Summary

This PR fixes zombie `sh` processes created when launching applications from `cosmic-panel-button`.

Currently, applications are launched through `sh -c`, but the spawned shell process is not waited on. As a result, the shell process may remain in the process table as a zombie after it exits.

## Before

When an application is launched from `cosmic-panel-button`, the code spawns a shell process and immediately drops the child handle

Because the spawned child process is not waited on, the finished `sh` process can remain as a zombie.

Example symptoms:

- zombie `sh` / `<defunct>` processes remain in the system
- repeated application launches may accumulate more dead shell processes
- related COSMIC components may become unstable or behave incorrectly until restarted

## How to reproduce

1. Click `Applications` button on a `cosmic-panel` few times
2. Check for zombie processes:

```bash
ps -eo pid,ppid,stat,cmd | grep -E ' Z|defunct'
```

3. Observe that dead `sh` processes may remain after launching applications.

#Issue

Related to pop-os/cosmic-panel#326

## After

The spawned shell process is now kept as a `Child` and waited on from a separate thread

This allows the parent process to reap the shell process properly and prevents it from remaining as a zombie.

The command is also executed through `exec`, so the shell process is replaced by the launched application process instead of staying around as an unnecessary intermediate process.

## Impact

- Prevents zombie `sh` processes from accumulating.
- Improves process cleanup after launching applications.
- Reduces the chance of COSMIC components entering a broken state due to unreaped child processes.
- Keeps the UI update path non-blocking by waiting for the child process in a separate thread.

