### PR TITLE
fix(network): skip assumed NM connections in VPN list

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -664,6 +664,13 @@ fn load_vpns(_conn: zbus::Connection) -> Task<crate::app::Message> {
 
         let mut map: IndexMap<UUID, ConnectionSettings> = IndexMap::new();
         for c in saved {
+            // Skip in-memory-only NM connections — assumed connections that NM
+            // auto-generated from externally-managed interfaces (e.g. one
+            // brought up by wg-quick@wg0.service) report unsaved=true and
+            // evaporate on deactivate, leaving the applet's toggle dead.
+            if c.unsaved {
+                continue;
+            }
             let uuid: UUID = Arc::from(c.uuid.as_str());
             let entry = match c.summary {
                 SettingsSummary::WireGuard { .. } => ConnectionSettings::Wireguard { id: c.id },


### PR DESCRIPTION
Fixes #1412.

`cosmic-applet-network` listed every connection from `nm.list_saved_connections()` in the VPN dropdown, including the in-memory-only profiles NetworkManager auto-generates for externally-managed interfaces (e.g. a `wg-quick@wg0.service` tunnel). Toggling such an "assumed" connection off deletes it from NM — it was never persisted — leaving a dead toggle with no way back through the applet or `nmcli con up`.

Skip connections flagged `unsaved` (in-memory only) at the `load_vpns()` site so they no longer get a togglable entry. The active-connections section still shows the interface as connected (read-only). One-line change in `cosmic-applet-network/src/app.rs`.

## Test plan

- Built on Pop!_OS and ran the patched `cosmic-applet-network`: with `wg-quick@wg0` up and NM tracking `wg0` as connected-externally, the VPN dropdown no longer shows the destructive `wg0` toggle; the active-connections section still shows `wg0`; Wi-Fi toggling is unaffected.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
