### PR TITLE
fix(status-area): honor StatusNotifierItem IconThemePath

### DIFF
--- a/cosmic-applet-status-area/src/components/status_menu.rs
+++ b/cosmic-applet-status-area/src/components/status_menu.rs
@@ -63,6 +63,7 @@ impl State {
             }
             Msg::Icon(update) => {
                 let icon_name = update.name.unwrap_or_default();
+                let theme_path = update.theme_path;
 
                 // Use the icon pixmap if an icon was not defined by name.
                 if icon_name.is_empty() {
@@ -92,6 +93,11 @@ impl State {
                 // Load icon by path if the name is a path.
                 self.icon_handle = if Path::new(&icon_name).exists() {
                     icon::from_path(Path::new(&icon_name).to_path_buf()).symbolic(true)
+                } else if let Some(resolved) = theme_path
+                    .as_deref()
+                    .and_then(|tp| find_icon_in_theme_path(tp, &icon_name))
+                {
+                    icon::from_path(resolved)
                 } else {
                     icon::from_name(icon_name)
                         .prefer_svg(true)
@@ -272,4 +278,50 @@ fn row_button(content: Vec<cosmic::Element<Msg>>) -> cosmic::widget::Button<Msg>
             .align_y(iced::Alignment::Center)
             .width(iced::Length::Fill),
     )
+}
+
+// Search an SNI item's IconThemePath for `name`.<svg|png|xpm>. The path is not
+// guaranteed to follow the XDG icon theme spec — JetBrains Toolbox stores
+// icons flat at the root, Dropbox uses hicolor/<size>/<context>/<file> — so
+// check the path directly first, then walk a small depth.
+fn find_icon_in_theme_path(theme_path: &Path, name: &str) -> Option<PathBuf> {
+    const EXTS: &[&str] = &["svg", "png", "xpm"];
+    const WALK_DEPTH: u32 = 5;
+
+    let candidates: Vec<String> = EXTS.iter().map(|e| format!("{name}.{e}")).collect();
+
+    for cand in &candidates {
+        let path = theme_path.join(cand);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    walk_for_icon(theme_path, &candidates, WALK_DEPTH)
+}
+
+fn walk_for_icon(dir: &Path, candidates: &[String], depth: u32) -> Option<PathBuf> {
+    if depth == 0 {
+        return None;
+    }
+    let entries = std::fs::read_dir(dir).ok()?;
+    let mut subdirs = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else { continue };
+        let path = entry.path();
+        if file_type.is_file() {
+            let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if candidates.iter().any(|c| c == file_name) {
+                return Some(path);
+            }
+        } else if file_type.is_dir() {
+            subdirs.push(path);
+        }
+    }
+    for subdir in subdirs {
+        if let Some(found) = walk_for_icon(&subdir, candidates, depth - 1) {
+            return Some(found);
+        }
+    }
+    None
 }

--- a/cosmic-applet-status-area/src/subscriptions/status_notifier_item.rs
+++ b/cosmic-applet-status-area/src/subscriptions/status_notifier_item.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::hash::Hash;
+use std::{hash::Hash, path::PathBuf};
 
 use cosmic::iced::{self, Subscription};
 use futures::{FutureExt, StreamExt};
@@ -27,7 +27,7 @@ pub struct Icon {
 pub struct IconUpdate {
     pub name: Option<String>,
     pub pixmap: Option<Vec<Icon>>,
-    // pub theme_path: Option<PathBuf>,
+    pub theme_path: Option<PathBuf>,
 }
 
 impl StatusNotifierItem {
@@ -118,11 +118,11 @@ impl StatusNotifierItem {
         async fn icon_events(item_proxy: StatusNotifierItemProxy<'static>) -> IconUpdate {
             let icon_name = item_proxy.icon_name().await;
             let icon_pixmap = item_proxy.icon_pixmap().await;
-            // let icon_theme_path = item_proxy.icon_theme_path().await.map(PathBuf::from);
+            let icon_theme_path = item_proxy.icon_theme_path().await.map(PathBuf::from);
             IconUpdate {
                 name: icon_name.ok(),
                 pixmap: icon_pixmap.ok(),
-                // theme_path: icon_theme_path.ok().filter(|x| !x.as_os_str().is_empty()),
+                theme_path: icon_theme_path.ok().filter(|x| !x.as_os_str().is_empty()),
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #1414. Refs #1078.

`cosmic-applet-status-area` reads `IconName` from SNI items but ignores the companion `IconThemePath` property. Apps that ship their icons in a private directory (Dropbox under `~/.dropbox-dist/.../images`, JetBrains Toolbox under `~/.local/share/JetBrains/Toolbox/bin`, pcloud, etc.) advertise their location via `IconThemePath` per the [SNI spec](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/). The renderer's only fallbacks are `icon::from_path` (when the name is itself a filesystem path) and `icon::from_name` (system theme lookup), so these icons never resolve and nothing renders in the panel.

## Fix

The `IconThemePath` plumbing was already partially present in the code but commented out:

- `IconUpdate.theme_path` field — `subscriptions/status_notifier_item.rs:30`
- the `icon_theme_path()` D-Bus read in `icon_events()` — `subscriptions/status_notifier_item.rs:121`
- the population that sets it on `IconUpdate` — `subscriptions/status_notifier_item.rs:125`

Restored those three lines, then taught `components/status_menu.rs` to resolve icons under `IconThemePath` between the path-as-name check and the system-theme fallback.

SNI's `IconThemePath` isn't required to follow the XDG icon theme layout. JetBrains Toolbox dumps icons flat at the root (`<theme_path>/toolbox-tray-color.png`); Dropbox uses `hicolor/<size>/<context>/<file>` (`<theme_path>/hicolor/16x16/status/dropboxstatus-idle.png`). So the lookup checks the path directly first (covers JetBrains-style), then walks bounded depth 5 (covers Dropbox-style). SVG is preferred over raster.

## Test plan

- [x] Built locally on Pop!_OS COSMIC alpha (cosmic-applets 1.0.12 sources + patch).
- [x] Swapped `/usr/bin/cosmic-applet-status-area` symlink to point at the patched binary, bounced `cosmic-panel`.
- [x] With Dropbox running: panel renders `dropboxstatus-idle` (16x16 PNG from `~/.dropbox-dist/.../images/hicolor/16x16/status/`). Was: nothing.
- [x] With JetBrains Toolbox running: panel renders `toolbox-tray-color` (flat PNG at `~/.local/share/JetBrains/Toolbox/bin/`). Was: nothing.
- [x] Existing items that resolve via system theme (Wi-Fi etc. via other applets) unaffected.
- [x] Restored stock symlink and verified no lingering state.

## Notes

- Bounded depth of 5 is enough for the layouts I tested (Dropbox is 3 deep). A larger value would help worst-case theme indexes but would slow startup for paths pointing at deep trees; 5 is generous-but-safe.
- If multiple files for the same icon exist (e.g. multiple sizes), the first encountered via `read_dir` is used. A nicer impl would parse `index.theme` and prefer a target size, but the SNI spec doesn't require XDG layout so a name-match search seems pragmatic. Happy to follow up with size-aware selection if you'd prefer.
- No new dependencies. The walker uses `std::fs::read_dir` with a depth limit.
