### PR TITLE
fix(bluetooth): applet showing bluetooth off despite active connection

### DIFF
--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -568,22 +568,21 @@ impl BluerSessionState {
                 tick(&mut interval).await;
                 let new_status = adapter_clone.is_powered().await.unwrap_or_default();
                 devices = build_device_list(devices, &adapter_clone).await;
-                if new_status != status {
-                    status = new_status;
-                    let state = BluerState {
-                        devices: devices.clone(),
-                        bluetooth_enabled: status,
-                    };
-                    if state.bluetooth_enabled {
-                        for d in &state.devices {
-                            if d.paired_and_trusted() {
-                                _ = req_tx.send(BluerRequest::ConnectDevice(d.address)).await;
-                            }
+                let power_changed = new_status != status;
+                status = new_status;
+                let state = BluerState {
+                    devices: devices.clone(),
+                    bluetooth_enabled: status,
+                };
+                if power_changed && state.bluetooth_enabled {
+                    for d in &state.devices {
+                        if d.paired_and_trusted() {
+                            _ = req_tx.send(BluerRequest::ConnectDevice(d.address)).await;
                         }
                     }
                     _ = wake_up_discover_tx.send(()).await;
-                    let _ = tx.send(BluerSessionEvent::ChangesProcessed(state)).await;
                 }
+                let _ = tx.send(BluerSessionEvent::ChangesProcessed(state)).await;
             }
         });
     }
@@ -674,6 +673,9 @@ impl BluerSessionState {
                                 }
                             }
 
+                            // Always refresh power state from the adapter
+                            // to avoid stale cached is_powered values
+                            is_powered = adapter_clone.is_powered().await.unwrap_or_default();
                             let _ = tx
                                 .send(BluerSessionEvent::ChangesProcessed(BluerState {
                                     devices: devices.clone(),


### PR DESCRIPTION
Fixes #972

## Problem

The bluetooth applet sometimes shows bluetooth as turned off (crossed-out icon, 
toggle off) even when bluetooth is powered on and a device is connected.

## Root Cause

Two functions in `bluetooth.rs` could leave the UI with a permanently stale 
power state:

1. **`listen_bluetooth_power_changes()`** only sent state updates to the UI when 
   the power status *changed*. If bluetooth was already on at startup, no update 
   was ever sent.

2. **`process_changes()`** cached `is_powered` once at initialization and only 
   updated it via `PropertyChanged` D-Bus events during active discovery. Outside 
   of discovery, the cached value could go permanently stale.

## Fix

- `listen_bluetooth_power_changes()` now always sends the current state every 
  poll cycle (10s), ensuring the UI stays in sync. Reconnect logic is still 
  only triggered on actual power transitions.

- `process_changes()` now re-reads `is_powered` from the adapter before sending 
  each `ChangesProcessed` event, instead of relying on the cached value.
  
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

