### PR TITLE
fix(status-area): don't let one hung SNI item stall the whole tray at startup

### DIFF
--- a/cosmic-applet-status-area/src/subscriptions/status_notifier_watcher/client.rs
+++ b/cosmic-applet-status-area/src/subscriptions/status_notifier_watcher/client.rs
@@ -51,13 +51,16 @@ pub async fn watch(connection: &zbus::Connection) -> zbus::Result<EventStream> {
 
     let items = watcher.registered_status_notifier_items().await?;
     let connection = connection.clone();
+    // Seed concurrently (bounded); `buffered` keeps the watcher's enumeration order.
     let items_stream = futures::stream::iter(items.into_iter())
-        .then(move |name| status_notifier_item(connection.clone(), name));
-
-    Ok(Box::pin(items_stream.chain(futures::stream_select!(
+        .map(move |name| status_notifier_item(connection.clone(), name))
+        .buffered(16);
+    // Merge seed with live streams so live registrations flow during seeding.
+    Ok(Box::pin(futures::stream_select!(
+        items_stream,
         registered_stream,
         unregistered_stream
-    ))))
+    )))
 }
 
 async fn item_registered(connection: zbus::Connection, evt: StatusNotifierItemRegistered) -> Event {
@@ -68,8 +71,13 @@ async fn item_registered(connection: zbus::Connection, evt: StatusNotifierItemRe
 }
 
 async fn status_notifier_item(connection: zbus::Connection, name: String) -> Event {
-    match StatusNotifierItem::new(&connection, name).await {
-        Ok(item) => Event::Registered(item),
-        Err(err) => Event::Error(err.to_string()),
+    // Cap construction; zbus' default method timeout is unbounded.
+    let build = StatusNotifierItem::new(&connection, name.clone());
+    match tokio::time::timeout(std::time::Duration::from_secs(5), build).await {
+        Ok(Ok(item)) => Event::Registered(item),
+        Ok(Err(err)) => Event::Error(err.to_string()),
+        Err(_) => Event::Error(format!(
+            "status notifier item `{name}` timed out during construction"
+        )),
     }
 }


### PR DESCRIPTION
Serial seeding of already-registered StatusNotifierItems plus zbus' unbounded default method timeout let one hung SNI service block every later seed item. The seed stream was also `.chain`ed ahead of the live signal streams, so no live Registered/Unregistered event was delivered until seeding finished — one wedged item stalled the entire tray subscription. This seeds concurrently with bounded fan-out (`buffered(16)`, which preserves the watcher's enumeration order), merges the seed with the live streams via `stream_select!` so live registrations flow during seeding, and caps per-item construction with a 5s timeout so a wedged item yields `Event::Error` instead of stalling.

## Test plan

- In-container `cargo build -p cosmic-applet-status-area` is green.
- The stream wiring is not unit-tested (would require a hang-on-demand fake watcher).

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.