### PR TITLE
fix: minimize/unminimize animation stuttering

### DIFF
--- a/cosmic-applet-minimize/src/wayland_handler.rs
+++ b/cosmic-applet-minimize/src/wayland_handler.rs
@@ -121,6 +121,7 @@ struct AppData {
     toplevel_info_state: ToplevelInfoState,
     toplevel_manager_state: ToplevelManagerState,
     seat_state: SeatState,
+    captured_toplevels: std::collections::HashSet<ExtForeignToplevelHandleV1>,
 }
 
 struct CaptureData {
@@ -351,6 +352,36 @@ impl AppData {
             }
         });
     }
+
+    fn handle_toplevel(&mut self, toplevel: &ExtForeignToplevelHandleV1, is_new: bool) {
+        let Some(info) = self.toplevel_info_state.info(toplevel) else {
+            return;
+        };
+        if info
+            .state
+            .contains(&zcosmic_toplevel_handle_v1::State::Minimized)
+        {
+            // Capture a thumbnail once, on the transition into minimized.
+            if self.captured_toplevels.insert(toplevel.clone()) {
+                self.send_image(toplevel.clone());
+            }
+            let update = if is_new {
+                ToplevelUpdate::Add(info.clone())
+            } else {
+                ToplevelUpdate::Update(info.clone())
+            };
+            let _ = futures::executor::block_on(self.tx.send(WaylandUpdate::Toplevel(update)));
+        } else {
+            self.remove_toplevel(toplevel);
+        }
+    }
+
+    fn remove_toplevel(&mut self, toplevel: &ExtForeignToplevelHandleV1) {
+        self.captured_toplevels.remove(toplevel);
+        let _ = futures::executor::block_on(self.tx.send(WaylandUpdate::Toplevel(
+            ToplevelUpdate::Remove(toplevel.clone()),
+        )));
+    }
 }
 
 impl ToplevelInfoHandler for AppData {
@@ -364,23 +395,7 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
-        if let Some(info) = self.toplevel_info_state.info(toplevel) {
-            if info
-                .state
-                .contains(&zcosmic_toplevel_handle_v1::State::Minimized)
-            {
-                // spawn thread for sending the image
-                self.send_image(toplevel.clone());
-                let _ = futures::executor::block_on(
-                    self.tx
-                        .send(WaylandUpdate::Toplevel(ToplevelUpdate::Add(info.clone()))),
-                );
-            } else {
-                let _ = futures::executor::block_on(self.tx.send(WaylandUpdate::Toplevel(
-                    ToplevelUpdate::Remove(toplevel.clone()),
-                )));
-            }
-        }
+        self.handle_toplevel(toplevel, true);
     }
 
     fn update_toplevel(
@@ -389,21 +404,7 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
-        if let Some(info) = self.toplevel_info_state.info(toplevel) {
-            if info
-                .state
-                .contains(&zcosmic_toplevel_handle_v1::State::Minimized)
-            {
-                self.send_image(toplevel.clone());
-                let _ = futures::executor::block_on(self.tx.send(WaylandUpdate::Toplevel(
-                    ToplevelUpdate::Update(info.clone()),
-                )));
-            } else {
-                let _ = futures::executor::block_on(self.tx.send(WaylandUpdate::Toplevel(
-                    ToplevelUpdate::Remove(toplevel.clone()),
-                )));
-            }
-        }
+        self.handle_toplevel(toplevel, false);
     }
 
     fn toplevel_closed(
@@ -412,9 +413,7 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
-        let _ = futures::executor::block_on(self.tx.send(WaylandUpdate::Toplevel(
-            ToplevelUpdate::Remove(toplevel.clone()),
-        )));
+        self.remove_toplevel(toplevel);
     }
 }
 
@@ -482,6 +481,7 @@ pub(crate) fn wayland_handler(
         toplevel_manager_state: ToplevelManagerState::new(&registry_state, &qh),
         queue_handle: qh,
         registry_state,
+        captured_toplevels: std::collections::HashSet::new(),
     };
 
     loop {


### PR DESCRIPTION
- Fixes:
  pop-os/cosmic-comp#2482, #1249 
- Reduces memory pressure (but not fixing the root cause) of:
   pop-os/cosmic-comp#2073


**The problem**
(Un)minimizing a window makes the whole desktop (including the cursor) stutter/hang for a moment. Reported in pop-os/cosmic-comp#2482.

**Root cause**
- `ToplevelInfoHandler::update_toplevel` fires on **every** toplevel metadata change (state, geometry, …)
- For a minimized window, it calls `send_image()`, which creates a one-shot screencopy session that leads to a blocking GPU-to-CPU readback (pretty slow) on every frame during unminimize animation

Each readback is approx ~8-16 ms on the compositor's main thread, so depending on the refresh frame rate (for example, 60Hz) and animation duration, we can get ~14 frames with readback for the same frozen window content, which brings us to ~100- 200 ms total freezing time, which is not that subtle.

**Fix**
Capture toplevels once per minimize (re-captured on every subsequent minimize).

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.