### PR TITLE
input-sources: Use `cosmic-keymap-unstable-v1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,9 @@ dependencies = [
 name = "cosmic-applet-input-sources"
 version = "1.0.15"
 dependencies = [
+ "cosmic-client-toolkit",
  "cosmic-comp-config",
+ "futures",
  "i18n-embed",
  "i18n-embed-fl",
  "libcosmic",
@@ -1308,7 +1310,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#c253ec1d6804afbcdf250f5cc37ae1194bba7bd2"
+source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#0d0b0b573fe4836ede4c237dadd365033cd28296"
 dependencies = [
  "bitflags 2.11.1",
  "cosmic-protocols",
@@ -1446,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#c253ec1d6804afbcdf250f5cc37ae1194bba7bd2"
+source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#0d0b0b573fe4836ede4c237dadd365033cd28296"
 dependencies = [
  "bitflags 2.11.1",
  "wayland-backend",
@@ -1962,7 +1964,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2160,7 +2162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3794,7 +3796,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3945,7 +3947,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4531,7 +4533,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5684,7 +5686,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5697,7 +5699,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6096,7 +6098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6284,10 +6286,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6663,7 +6665,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,9 @@ dependencies = [
 name = "cosmic-applet-input-sources"
 version = "1.0.15"
 dependencies = [
+ "cosmic-client-toolkit",
  "cosmic-comp-config",
+ "futures",
  "i18n-embed",
  "i18n-embed-fl",
  "libcosmic",

--- a/cosmic-applet-input-sources/Cargo.toml
+++ b/cosmic-applet-input-sources/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2024"
 license = "GPL-3.0-only"
 
 [dependencies]
+cctk.workspace = true
 cosmic-comp-config = { git = "https://github.com/pop-os/cosmic-comp.git", rev = "5eb5af4" }
+futures.workspace = true
 i18n-embed-fl.workspace = true
 i18n-embed.workspace = true
 libcosmic.workspace = true

--- a/cosmic-applet-input-sources/data/com.system76.CosmicAppletInputSources.desktop
+++ b/cosmic-applet-input-sources/data/com.system76.CosmicAppletInputSources.desktop
@@ -12,4 +12,5 @@ NoDisplay=true
 X-CosmicApplet=true
 X-CosmicShrinkable=true
 X-CosmicHoverPopup=Auto
+X-HostWaylandDisplay=true
 X-OverflowPriority=10

--- a/cosmic-applet-input-sources/src/lib.rs
+++ b/cosmic-applet-input-sources/src/lib.rs
@@ -3,37 +3,60 @@
 
 mod localize;
 
-use cosmic::iced::{Alignment, Length};
+use cctk::{
+    cosmic_protocols::keyboard_layout::v1::client::zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1,
+    wayland_client::{Connection, Proxy, backend::Backend},
+};
 use cosmic::{
     app,
     app::Core,
     applet::{self},
-    cosmic_config::{self, ConfigSet, CosmicConfigEntry},
+    cosmic_config::{self, CosmicConfigEntry},
     cosmic_theme::Spacing,
     iced::Subscription,
+    iced::core::window,
     iced::{
-        Rectangle, Task,
+        self, Rectangle, Task,
+        event::wayland::{Event as WaylandEvent, OutputEvent},
         platform_specific::shell::commands::popup::{destroy_popup, get_popup},
-        widget::{column, row},
         window::Id,
     },
-    iced::{core::window, runtime::Appearance},
     prelude::*,
     surface, theme,
     widget::{
         self, autosize,
         rectangle_tracker::{RectangleTracker, RectangleUpdate, rectangle_tracker_subscription},
-        space,
     },
 };
 use cosmic_comp_config::CosmicCompConfig;
-use std::sync::LazyLock;
+use std::{
+    os::unix::{
+        io::{FromRawFd, RawFd},
+        net::UnixStream,
+    },
+    sync::LazyLock,
+};
 use xkb_data::KeyboardLayout;
+
+mod wayland;
 
 static AUTOSIZE_MAIN_ID: LazyLock<widget::Id> = LazyLock::new(|| widget::Id::new("autosize-main"));
 pub const ID: &str = "com.system76.CosmicAppletInputSources";
 
 pub fn run() -> cosmic::iced::Result {
+    let socket = std::env::var("X_PRIVILEGED_WAYLAND_SOCKET")
+        .ok()
+        .and_then(|fd| {
+            fd.parse::<RawFd>()
+                .ok()
+                .map(|fd| unsafe { UnixStream::from_raw_fd(fd) })
+        });
+    let wayland_connection = if let Some(socket) = socket {
+        Some(Connection::from_socket(socket).unwrap())
+    } else {
+        None
+    };
+
     localize::localize();
 
     let layouts = match xkb_data::all_keyboard_layouts() {
@@ -44,7 +67,7 @@ pub fn run() -> cosmic::iced::Result {
         }
     };
 
-    let (comp_config_handler, comp_config) =
+    let comp_config =
         match cosmic_config::Config::new("com.system76.CosmicComp", CosmicCompConfig::VERSION) {
             Ok(config_handler) => {
                 let config = match CosmicCompConfig::get_entry(&config_handler) {
@@ -54,17 +77,17 @@ pub fn run() -> cosmic::iced::Result {
                         config
                     }
                 };
-                (Some(config_handler), config)
+                config
             }
             Err(err) => {
                 tracing::error!("failed to create config handler: {}", err);
-                (None, CosmicCompConfig::default())
+                CosmicCompConfig::default()
             }
         };
 
     cosmic::applet::run::<Window>(Flags {
+        wayland_connection,
         comp_config,
-        comp_config_handler,
         layouts: layouts.layout_list.layout,
     })
 }
@@ -80,11 +103,13 @@ pub struct Window {
     core: Core,
     popup: Option<Id>,
     comp_config: CosmicCompConfig,
-    comp_config_handler: Option<cosmic_config::Config>,
     layouts: Vec<KeyboardLayout>,
     active_layouts: Vec<ActiveLayout>,
     rectangle_tracker: Option<RectangleTracker<u32>>,
     rectangle: Rectangle,
+    wayland_connection: Option<Connection>,
+    keyboard_layout: Option<ZcosmicKeyboardLayoutV1>,
+    current_layout: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -96,12 +121,14 @@ pub enum Message {
     KeyboardSettings,
     Surface(surface::Action),
     Rectangle(RectangleUpdate<u32>),
+    WaylandConnection(Backend),
+    Wayland(wayland::Event),
 }
 
 #[derive(Debug)]
 pub struct Flags {
+    wayland_connection: Option<Connection>,
     pub comp_config: CosmicCompConfig,
-    pub comp_config_handler: Option<cosmic_config::Config>,
     pub layouts: Vec<KeyboardLayout>,
 }
 
@@ -122,7 +149,6 @@ impl cosmic::Application for Window {
 
     fn init(core: Core, flags: Self::Flags) -> (Self, app::Task<Self::Message>) {
         let window = Window {
-            comp_config_handler: flags.comp_config_handler,
             layouts: flags.layouts,
             core,
             popup: None,
@@ -130,6 +156,9 @@ impl cosmic::Application for Window {
             active_layouts: Vec::new(),
             rectangle_tracker: None,
             rectangle: Rectangle::default(),
+            wayland_connection: flags.wayland_connection,
+            keyboard_layout: None,
+            current_layout: 0,
         };
         (window, Task::none())
     }
@@ -172,31 +201,10 @@ impl cosmic::Application for Window {
                 tokio::spawn(cosmic::process::spawn(cmd));
             }
             Message::SetActiveLayout(pos) => {
-                if pos == 0 {
-                    return Task::none();
-                }
-
-                self.active_layouts.swap(0, pos);
-                let mut new_layout = String::new();
-                let mut new_variant = String::new();
-
-                for layout in &self.active_layouts {
-                    new_layout.push_str(&layout.layout);
-                    new_layout.push(',');
-                    new_variant.push_str(&layout.variant);
-                    new_variant.push(',');
-                }
-
-                let _excess_comma = new_layout.pop();
-                let _excess_comma = new_variant.pop();
-
-                self.comp_config.xkb_config.layout = new_layout;
-                self.comp_config.xkb_config.variant = new_variant;
-                if let Some(comp_config_handler) = &self.comp_config_handler {
-                    if let Err(err) =
-                        comp_config_handler.set("xkb_config", &self.comp_config.xkb_config)
-                    {
-                        tracing::error!("Failed to set config 'xkb_config' {err}");
+                if let Some(keyboard_layout) = &self.keyboard_layout {
+                    keyboard_layout.set_group(pos as u32);
+                    if let Some(backend) = keyboard_layout.backend().upgrade() {
+                        let _ = backend.flush();
                     }
                 }
             }
@@ -213,13 +221,26 @@ impl cosmic::Application for Window {
                     self.rectangle_tracker = Some(tracker);
                 }
             },
+            Message::WaylandConnection(backend) => {
+                if self.wayland_connection.is_none() {
+                    self.wayland_connection = Some(Connection::from_backend(backend));
+                }
+            }
+            Message::Wayland(w) => match w {
+                wayland::Event::KeyboardLayout(keyboard_layout) => {
+                    self.keyboard_layout = Some(keyboard_layout);
+                }
+                wayland::Event::Group(group) => {
+                    self.current_layout = group as usize;
+                }
+            },
         }
 
         Task::none()
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        let applet_text = if let Some(l) = self.active_layouts.first() {
+        let applet_text = if let Some(l) = self.active_layouts.get(self.current_layout) {
             if !l.variant.is_empty() {
                 format!("{} ({})", l.layout, l.variant)
             } else {
@@ -252,8 +273,13 @@ impl cosmic::Application for Window {
         let mut content_list =
             widget::column::with_capacity(4 + self.active_layouts.len()).padding([8, 0]);
         for (id, layout) in self.active_layouts.iter().enumerate() {
+            let font = if id == self.current_layout {
+                cosmic::font::bold()
+            } else {
+                cosmic::font::default()
+            };
             let group = widget::column::with_capacity(2)
-                .push(widget::text::body(layout.description.as_str()))
+                .push(widget::text::body(layout.description.as_str()).font(font))
                 .push(widget::text::caption(layout.layout.as_str()));
             content_list = content_list
                 .push(applet::menu_button(group).on_press(Message::SetActiveLayout(id)));
@@ -274,7 +300,7 @@ impl cosmic::Application for Window {
     }
 
     fn subscription(&self) -> Subscription<Self::Message> {
-        Subscription::batch(vec![
+        let mut subscriptions = vec![
             rectangle_tracker_subscription(0).map(|e| Message::Rectangle(e.1)),
             self.core
                 .watch_config("com.system76.CosmicComp")
@@ -288,7 +314,23 @@ impl cosmic::Application for Window {
                     }
                     Message::CompConfig(Box::new(update.config))
                 }),
-        ])
+        ];
+        subscriptions.push(if let Some(connection) = &self.wayland_connection {
+            wayland::subscription(connection.clone()).map(Message::Wayland)
+        } else {
+            iced::event::listen_with(|evt, _, _| match evt {
+                iced::Event::PlatformSpecific(iced::event::PlatformSpecific::Wayland(evt)) => {
+                    if let WaylandEvent::Output(OutputEvent::Created(_), output) = evt {
+                        if let Some(backend) = output.backend().upgrade() {
+                            return Some(Message::WaylandConnection(backend));
+                        }
+                    }
+                    None
+                }
+                _ => None,
+            })
+        });
+        Subscription::batch(subscriptions)
     }
 
     fn style(&self) -> Option<cosmic::iced::theme::Style> {

--- a/cosmic-applet-input-sources/src/lib.rs
+++ b/cosmic-applet-input-sources/src/lib.rs
@@ -11,7 +11,6 @@ use cosmic::{
     app,
     app::Core,
     applet::{self},
-    cosmic_config::{self, CosmicConfigEntry},
     cosmic_theme::Spacing,
     iced::Subscription,
     iced::core::window,
@@ -28,7 +27,7 @@ use cosmic::{
         rectangle_tracker::{RectangleTracker, RectangleUpdate, rectangle_tracker_subscription},
     },
 };
-use cosmic_comp_config::CosmicCompConfig;
+use cosmic_comp_config::{CosmicCompConfig, XkbConfig};
 use std::{
     os::unix::{
         io::{FromRawFd, RawFd},
@@ -67,27 +66,8 @@ pub fn run() -> cosmic::iced::Result {
         }
     };
 
-    let comp_config =
-        match cosmic_config::Config::new("com.system76.CosmicComp", CosmicCompConfig::VERSION) {
-            Ok(config_handler) => {
-                let config = match CosmicCompConfig::get_entry(&config_handler) {
-                    Ok(ok) => ok,
-                    Err((errs, config)) => {
-                        tracing::error!("errors loading config: {:?}", errs);
-                        config
-                    }
-                };
-                config
-            }
-            Err(err) => {
-                tracing::error!("failed to create config handler: {}", err);
-                CosmicCompConfig::default()
-            }
-        };
-
     cosmic::applet::run::<Window>(Flags {
         wayland_connection,
-        comp_config,
         layouts: layouts.layout_list.layout,
     })
 }
@@ -102,7 +82,6 @@ pub struct ActiveLayout {
 pub struct Window {
     core: Core,
     popup: Option<Id>,
-    comp_config: CosmicCompConfig,
     layouts: Vec<KeyboardLayout>,
     active_layouts: Vec<ActiveLayout>,
     rectangle_tracker: Option<RectangleTracker<u32>>,
@@ -128,7 +107,6 @@ pub enum Message {
 #[derive(Debug)]
 pub struct Flags {
     wayland_connection: Option<Connection>,
-    pub comp_config: CosmicCompConfig,
     pub layouts: Vec<KeyboardLayout>,
 }
 
@@ -152,7 +130,6 @@ impl cosmic::Application for Window {
             layouts: flags.layouts,
             core,
             popup: None,
-            comp_config: flags.comp_config,
             active_layouts: Vec::new(),
             rectangle_tracker: None,
             rectangle: Rectangle::default(),
@@ -197,8 +174,7 @@ impl cosmic::Application for Window {
                 }
             }
             Message::CompConfig(config) => {
-                self.comp_config = *config;
-                self.active_layouts = self.update_xkb();
+                self.active_layouts = self.update_xkb(&config.xkb_config);
             }
             Message::KeyboardSettings => {
                 let mut cmd = std::process::Command::new("cosmic-settings");
@@ -343,9 +319,8 @@ impl cosmic::Application for Window {
     }
 }
 impl Window {
-    fn update_xkb(&self) -> Vec<ActiveLayout> {
+    fn update_xkb(&self, xkb: &XkbConfig) -> Vec<ActiveLayout> {
         let mut active_layouts = Vec::new();
-        let xkb = &self.comp_config.xkb_config;
 
         let layouts = xkb.layout.split_terminator(',');
 

--- a/cosmic-applet-input-sources/src/lib.rs
+++ b/cosmic-applet-input-sources/src/lib.rs
@@ -11,7 +11,6 @@ use cosmic::{
     app,
     app::Core,
     applet::{self},
-    cosmic_config::{self, CosmicConfigEntry},
     cosmic_theme::Spacing,
     iced::Subscription,
     iced::core::window,
@@ -28,7 +27,7 @@ use cosmic::{
         rectangle_tracker::{RectangleTracker, RectangleUpdate, rectangle_tracker_subscription},
     },
 };
-use cosmic_comp_config::CosmicCompConfig;
+use cosmic_comp_config::{CosmicCompConfig, XkbConfig};
 use std::{
     os::unix::{
         io::{FromRawFd, RawFd},
@@ -67,27 +66,8 @@ pub fn run() -> cosmic::iced::Result {
         }
     };
 
-    let comp_config =
-        match cosmic_config::Config::new("com.system76.CosmicComp", CosmicCompConfig::VERSION) {
-            Ok(config_handler) => {
-                let config = match CosmicCompConfig::get_entry(&config_handler) {
-                    Ok(ok) => ok,
-                    Err((errs, config)) => {
-                        tracing::error!("errors loading config: {:?}", errs);
-                        config
-                    }
-                };
-                config
-            }
-            Err(err) => {
-                tracing::error!("failed to create config handler: {}", err);
-                CosmicCompConfig::default()
-            }
-        };
-
     cosmic::applet::run::<Window>(Flags {
         wayland_connection,
-        comp_config,
         layouts: layouts.layout_list.layout,
     })
 }
@@ -102,7 +82,6 @@ pub struct ActiveLayout {
 pub struct Window {
     core: Core,
     popup: Option<Id>,
-    comp_config: CosmicCompConfig,
     layouts: Vec<KeyboardLayout>,
     active_layouts: Vec<ActiveLayout>,
     rectangle_tracker: Option<RectangleTracker<u32>>,
@@ -128,7 +107,6 @@ pub enum Message {
 #[derive(Debug)]
 pub struct Flags {
     wayland_connection: Option<Connection>,
-    pub comp_config: CosmicCompConfig,
     pub layouts: Vec<KeyboardLayout>,
 }
 
@@ -152,7 +130,6 @@ impl cosmic::Application for Window {
             layouts: flags.layouts,
             core,
             popup: None,
-            comp_config: flags.comp_config,
             active_layouts: Vec::new(),
             rectangle_tracker: None,
             rectangle: Rectangle::default(),
@@ -192,8 +169,7 @@ impl cosmic::Application for Window {
                 }
             }
             Message::CompConfig(config) => {
-                self.comp_config = *config;
-                self.active_layouts = self.update_xkb();
+                self.active_layouts = self.update_xkb(&config.xkb_config);
             }
             Message::KeyboardSettings => {
                 let mut cmd = std::process::Command::new("cosmic-settings");
@@ -338,9 +314,8 @@ impl cosmic::Application for Window {
     }
 }
 impl Window {
-    fn update_xkb(&self) -> Vec<ActiveLayout> {
+    fn update_xkb(&self, xkb: &XkbConfig) -> Vec<ActiveLayout> {
         let mut active_layouts = Vec::new();
-        let xkb = &self.comp_config.xkb_config;
 
         let layouts = xkb.layout.split_terminator(',');
 

--- a/cosmic-applet-input-sources/src/lib.rs
+++ b/cosmic-applet-input-sources/src/lib.rs
@@ -3,37 +3,60 @@
 
 mod localize;
 
-use cosmic::iced::{Alignment, Length};
+use cctk::{
+    cosmic_protocols::keyboard_layout::v1::client::zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1,
+    wayland_client::{Connection, Proxy, backend::Backend},
+};
 use cosmic::{
     app,
     app::Core,
     applet::{self},
-    cosmic_config::{self, ConfigSet, CosmicConfigEntry},
+    cosmic_config::{self, CosmicConfigEntry},
     cosmic_theme::Spacing,
     iced::Subscription,
+    iced::core::window,
     iced::{
-        Rectangle, Task,
+        self, Rectangle, Task,
+        event::wayland::{Event as WaylandEvent, OutputEvent},
         platform_specific::shell::commands::popup::{destroy_popup, get_popup},
-        widget::{column, row},
         window::Id,
     },
-    iced::{core::window, runtime::Appearance},
     prelude::*,
     surface, theme,
     widget::{
         self, autosize,
         rectangle_tracker::{RectangleTracker, RectangleUpdate, rectangle_tracker_subscription},
-        space,
     },
 };
 use cosmic_comp_config::CosmicCompConfig;
-use std::sync::LazyLock;
+use std::{
+    os::unix::{
+        io::{FromRawFd, RawFd},
+        net::UnixStream,
+    },
+    sync::LazyLock,
+};
 use xkb_data::KeyboardLayout;
+
+mod wayland;
 
 static AUTOSIZE_MAIN_ID: LazyLock<widget::Id> = LazyLock::new(|| widget::Id::new("autosize-main"));
 pub const ID: &str = "com.system76.CosmicAppletInputSources";
 
 pub fn run() -> cosmic::iced::Result {
+    let socket = std::env::var("X_PRIVILEGED_WAYLAND_SOCKET")
+        .ok()
+        .and_then(|fd| {
+            fd.parse::<RawFd>()
+                .ok()
+                .map(|fd| unsafe { UnixStream::from_raw_fd(fd) })
+        });
+    let wayland_connection = if let Some(socket) = socket {
+        Some(Connection::from_socket(socket).unwrap())
+    } else {
+        None
+    };
+
     localize::localize();
 
     let layouts = match xkb_data::all_keyboard_layouts() {
@@ -44,7 +67,7 @@ pub fn run() -> cosmic::iced::Result {
         }
     };
 
-    let (comp_config_handler, comp_config) =
+    let comp_config =
         match cosmic_config::Config::new("com.system76.CosmicComp", CosmicCompConfig::VERSION) {
             Ok(config_handler) => {
                 let config = match CosmicCompConfig::get_entry(&config_handler) {
@@ -54,17 +77,17 @@ pub fn run() -> cosmic::iced::Result {
                         config
                     }
                 };
-                (Some(config_handler), config)
+                config
             }
             Err(err) => {
                 tracing::error!("failed to create config handler: {}", err);
-                (None, CosmicCompConfig::default())
+                CosmicCompConfig::default()
             }
         };
 
     cosmic::applet::run::<Window>(Flags {
+        wayland_connection,
         comp_config,
-        comp_config_handler,
         layouts: layouts.layout_list.layout,
     })
 }
@@ -80,11 +103,13 @@ pub struct Window {
     core: Core,
     popup: Option<Id>,
     comp_config: CosmicCompConfig,
-    comp_config_handler: Option<cosmic_config::Config>,
     layouts: Vec<KeyboardLayout>,
     active_layouts: Vec<ActiveLayout>,
     rectangle_tracker: Option<RectangleTracker<u32>>,
     rectangle: Rectangle,
+    wayland_connection: Option<Connection>,
+    keyboard_layout: Option<ZcosmicKeyboardLayoutV1>,
+    current_layout: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -96,12 +121,14 @@ pub enum Message {
     KeyboardSettings,
     Surface(surface::Action),
     Rectangle(RectangleUpdate<u32>),
+    WaylandConnection(Backend),
+    Wayland(wayland::Event),
 }
 
 #[derive(Debug)]
 pub struct Flags {
+    wayland_connection: Option<Connection>,
     pub comp_config: CosmicCompConfig,
-    pub comp_config_handler: Option<cosmic_config::Config>,
     pub layouts: Vec<KeyboardLayout>,
 }
 
@@ -122,7 +149,6 @@ impl cosmic::Application for Window {
 
     fn init(core: Core, flags: Self::Flags) -> (Self, app::Task<Self::Message>) {
         let window = Window {
-            comp_config_handler: flags.comp_config_handler,
             layouts: flags.layouts,
             core,
             popup: None,
@@ -130,6 +156,9 @@ impl cosmic::Application for Window {
             active_layouts: Vec::new(),
             rectangle_tracker: None,
             rectangle: Rectangle::default(),
+            wayland_connection: flags.wayland_connection,
+            keyboard_layout: None,
+            current_layout: 0,
         };
         (window, Task::none())
     }
@@ -177,31 +206,10 @@ impl cosmic::Application for Window {
                 tokio::spawn(cosmic::process::spawn(cmd));
             }
             Message::SetActiveLayout(pos) => {
-                if pos == 0 {
-                    return Task::none();
-                }
-
-                self.active_layouts.swap(0, pos);
-                let mut new_layout = String::new();
-                let mut new_variant = String::new();
-
-                for layout in &self.active_layouts {
-                    new_layout.push_str(&layout.layout);
-                    new_layout.push(',');
-                    new_variant.push_str(&layout.variant);
-                    new_variant.push(',');
-                }
-
-                let _excess_comma = new_layout.pop();
-                let _excess_comma = new_variant.pop();
-
-                self.comp_config.xkb_config.layout = new_layout;
-                self.comp_config.xkb_config.variant = new_variant;
-                if let Some(comp_config_handler) = &self.comp_config_handler {
-                    if let Err(err) =
-                        comp_config_handler.set("xkb_config", &self.comp_config.xkb_config)
-                    {
-                        tracing::error!("Failed to set config 'xkb_config' {err}");
+                if let Some(keyboard_layout) = &self.keyboard_layout {
+                    keyboard_layout.set_group(pos as u32);
+                    if let Some(backend) = keyboard_layout.backend().upgrade() {
+                        let _ = backend.flush();
                     }
                 }
             }
@@ -218,13 +226,26 @@ impl cosmic::Application for Window {
                     self.rectangle_tracker = Some(tracker);
                 }
             },
+            Message::WaylandConnection(backend) => {
+                if self.wayland_connection.is_none() {
+                    self.wayland_connection = Some(Connection::from_backend(backend));
+                }
+            }
+            Message::Wayland(w) => match w {
+                wayland::Event::KeyboardLayout(keyboard_layout) => {
+                    self.keyboard_layout = Some(keyboard_layout);
+                }
+                wayland::Event::Group(group) => {
+                    self.current_layout = group as usize;
+                }
+            },
         }
 
         Task::none()
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        let applet_text = if let Some(l) = self.active_layouts.first() {
+        let applet_text = if let Some(l) = self.active_layouts.get(self.current_layout) {
             if !l.variant.is_empty() {
                 format!("{} ({})", l.layout, l.variant)
             } else {
@@ -257,8 +278,13 @@ impl cosmic::Application for Window {
         let mut content_list =
             widget::column::with_capacity(4 + self.active_layouts.len()).padding([8, 0]);
         for (id, layout) in self.active_layouts.iter().enumerate() {
+            let font = if id == self.current_layout {
+                cosmic::font::bold()
+            } else {
+                cosmic::font::default()
+            };
             let group = widget::column::with_capacity(2)
-                .push(widget::text::body(layout.description.as_str()))
+                .push(widget::text::body(layout.description.as_str()).font(font))
                 .push(widget::text::caption(layout.layout.as_str()));
             content_list = content_list
                 .push(applet::menu_button(group).on_press(Message::SetActiveLayout(id)));
@@ -279,7 +305,7 @@ impl cosmic::Application for Window {
     }
 
     fn subscription(&self) -> Subscription<Self::Message> {
-        Subscription::batch(vec![
+        let mut subscriptions = vec![
             rectangle_tracker_subscription(0).map(|e| Message::Rectangle(e.1)),
             self.core
                 .watch_config("com.system76.CosmicComp")
@@ -293,7 +319,23 @@ impl cosmic::Application for Window {
                     }
                     Message::CompConfig(Box::new(update.config))
                 }),
-        ])
+        ];
+        subscriptions.push(if let Some(connection) = &self.wayland_connection {
+            wayland::subscription(connection.clone()).map(Message::Wayland)
+        } else {
+            iced::event::listen_with(|evt, _, _| match evt {
+                iced::Event::PlatformSpecific(iced::event::PlatformSpecific::Wayland(evt)) => {
+                    if let WaylandEvent::Output(OutputEvent::Created(_), output) = evt {
+                        if let Some(backend) = output.backend().upgrade() {
+                            return Some(Message::WaylandConnection(backend));
+                        }
+                    }
+                    None
+                }
+                _ => None,
+            })
+        });
+        Subscription::batch(subscriptions)
     }
 
     fn style(&self) -> Option<cosmic::iced::theme::Style> {

--- a/cosmic-applet-input-sources/src/wayland.rs
+++ b/cosmic-applet-input-sources/src/wayland.rs
@@ -1,0 +1,157 @@
+use cctk::{
+    cosmic_protocols::keyboard_layout::v1::client::zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1,
+    keyboard_layout::{KeyboardLayoutHandler, KeyboardLayoutState},
+    sctk::{
+        self,
+        registry::{ProvidesRegistryState, RegistryState},
+        seat::{Capability, SeatHandler, SeatState},
+    },
+    wayland_client::{
+        Connection, QueueHandle, delegate_noop,
+        globals::registry_queue_init,
+        protocol::{wl_keyboard, wl_seat},
+    },
+};
+use cosmic::iced;
+use futures::{SinkExt, channel::mpsc, executor::block_on};
+use std::{hash::Hash, thread};
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    KeyboardLayout(ZcosmicKeyboardLayoutV1),
+    Group(usize),
+}
+
+pub fn subscription(connection: Connection) -> iced::Subscription<Event> {
+    #[derive(Clone)]
+    struct WaylandSubscription(Connection);
+    impl Hash for WaylandSubscription {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.0.backend().display_id().hash(state);
+        }
+    }
+    iced::Subscription::run_with(
+        WaylandSubscription(connection),
+        |WaylandSubscription(connection)| {
+            let connection = connection.clone();
+            iced::stream::channel(8, move |sender| async move {
+                thread::spawn(move || thread(connection, sender));
+            })
+        },
+    )
+}
+
+struct Keyboard {
+    seat: wl_seat::WlSeat,
+    keyboard_layout: ZcosmicKeyboardLayoutV1,
+}
+
+impl Drop for Keyboard {
+    fn drop(&mut self) {
+        self.keyboard_layout.destroy();
+    }
+}
+
+struct AppData {
+    seat_state: SeatState,
+    registry_state: RegistryState,
+    keyboard_layout_state: KeyboardLayoutState,
+    keyboard: Option<Keyboard>,
+    sender: mpsc::Sender<Event>,
+}
+
+impl KeyboardLayoutHandler for AppData {
+    fn group(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _keyboard_layout: &ZcosmicKeyboardLayoutV1,
+        group: u32,
+    ) {
+        let _ = block_on(self.sender.send(Event::Group(group as usize)));
+    }
+}
+
+impl ProvidesRegistryState for AppData {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+
+    sctk::registry_handlers![SeatState,];
+}
+
+impl SeatHandler for AppData {
+    fn seat_state(&mut self) -> &mut SeatState {
+        &mut self.seat_state
+    }
+
+    fn new_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+
+    fn new_capability(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        if capability == Capability::Keyboard && self.keyboard.is_none() {
+            let keyboard = seat.get_keyboard(qh, ());
+            let keyboard_layout = self
+                .keyboard_layout_state
+                .get_keyboard_layout(&keyboard, qh);
+            keyboard.release();
+
+            if let Some(keyboard_layout) = keyboard_layout {
+                let _ = block_on(
+                    self.sender
+                        .send(Event::KeyboardLayout(keyboard_layout.clone())),
+                );
+                self.keyboard = Some(Keyboard {
+                    seat,
+                    keyboard_layout,
+                });
+            } else {
+                keyboard.release();
+            }
+        }
+    }
+
+    fn remove_capability(
+        &mut self,
+        _conn: &Connection,
+        _: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        _capability: Capability,
+    ) {
+        self.keyboard.take_if(|x| x.seat == seat);
+    }
+
+    fn remove_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, seat: wl_seat::WlSeat) {
+        self.keyboard.take_if(|x| x.seat == seat);
+    }
+}
+
+fn thread(conn: Connection, sender: mpsc::Sender<Event>) {
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
+    let qh = event_queue.handle();
+    let registry_state = RegistryState::new(&globals);
+    let seat_state = SeatState::new(&globals, &qh);
+    let keyboard_layout_state = KeyboardLayoutState::new(&registry_state, &qh);
+
+    let mut app_data = AppData {
+        seat_state,
+        registry_state,
+        keyboard_layout_state,
+        keyboard: None,
+        sender,
+    };
+    loop {
+        event_queue.blocking_dispatch(&mut app_data).unwrap();
+    }
+}
+
+sctk::delegate_registry!(AppData);
+sctk::delegate_seat!(AppData);
+cctk::delegate_keyboard_layout!(AppData);
+delegate_noop!(AppData: ignore wl_keyboard::WlKeyboard);


### PR DESCRIPTION
Replacement for https://github.com/pop-os/cosmic-applets/pull/1139 that still uses cosmic-config to get list of layouts,but just uses protocol to get/set active one.

Requires https://github.com/pop-os/cosmic-protocols/pull/28 and https://github.com/pop-os/cosmic-comp/pull/660.

Should update to share wayland connection instead of adding another one. Maybe protocol should take `wl_seat` instead of `wl_keyboard`, or we should destroy `wl_keyboard` after creation to avoid redundant events.

Currently this uses bold text to indicate which layout is active. Not sure what we want it to do.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

