### PR TITLE
fix(network): pre-fill saved VPN password from keyring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
  "nmrs",
  "rust-embed",
  "rustc-hash 2.1.2",
+ "secret-service",
  "secure-string",
  "tokio",
  "tracing",

--- a/cosmic-applet-network/Cargo.toml
+++ b/cosmic-applet-network/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 zbus.workspace = true
 indexmap = "2.13.0"
 secure-string = "0.3.0"
+secret-service = { version = "5.1.0", features = ["rt-tokio-crypto-rust"] }
 uuid = { version = "1.21.0", features = ["v4"] }
 nmrs = "3.1.3"
 

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -45,11 +45,18 @@ use cosmic_dbus_networkmanager::interface::enums::{
 use futures::{StreamExt, lock::Mutex as AsyncMutex};
 use zbus::Connection;
 
-use crate::{config, fl};
+use crate::{config, fl, secret_store};
 
 pub fn run() -> cosmic::iced::Result {
     cosmic::applet::run::<CosmicNetworkApplet>(())
 }
+
+/// `NM_SETTING_SECRET_FLAG_NOT_SAVED`: secret must be requested every time
+/// (e.g. OTP), so it is never cached or pre-filled.
+const SECRET_FLAG_NOT_SAVED: u32 = 0x2;
+
+/// NM VPN setting name, used as the keyring `setting_name`.
+const VPN_SETTING: &str = "vpn";
 
 #[derive(Debug, Clone)]
 enum NewConnectionState {
@@ -111,11 +118,13 @@ pub struct RequestedVpn {
     /// VPN secret keys NM hinted as needed (e.g. `["password"]`). When empty,
     /// `"password"` is used as a fallback.
     secret_keys: Vec<String>,
+    /// `vpn.password-flags`; controls whether the secret is cached/pre-filled.
+    password_flags: u32,
 }
 
 #[derive(Clone, Debug)]
 pub enum ConnectionSettings {
-    Vpn { id: String },
+    Vpn { id: String, password_flags: u32 },
     Wireguard { id: String },
 }
 
@@ -256,7 +265,7 @@ fn vpn_section<'a>(
         if show_available_vpns {
             for (uuid, connection) in &nm_state.known_vpns {
                 let id = match connection {
-                    ConnectionSettings::Vpn { id } | ConnectionSettings::Wireguard { id } => {
+                    ConnectionSettings::Vpn { id, .. } | ConnectionSettings::Wireguard { id } => {
                         id.as_str()
                     }
                 };
@@ -523,6 +532,11 @@ pub(crate) enum Message {
     ToggleVPNPasswordVisibility,
     ConnectVPNWithPassword,
     VPNPasswordUpdate(SecureString),
+    /// Pre-fill the VPN password dialog with a cached secret from the keyring.
+    VpnPasswordPrefill {
+        uuid: Arc<str>,
+        password: SecureString,
+    },
     CancelVPNConnection,
     /// Selects a device to display connections from
     SelectDevice(Option<Arc<network_manager::devices::DeviceInfo>>),
@@ -675,7 +689,10 @@ fn load_vpns(_conn: zbus::Connection) -> Task<crate::app::Message> {
             let uuid: UUID = Arc::from(c.uuid.as_str());
             let entry = match c.summary {
                 SettingsSummary::WireGuard { .. } => ConnectionSettings::Wireguard { id: c.id },
-                SettingsSummary::Vpn { .. } => ConnectionSettings::Vpn { id: c.id },
+                SettingsSummary::Vpn { password_flags, .. } => ConnectionSettings::Vpn {
+                    id: c.id,
+                    password_flags: password_flags.0,
+                },
                 _ => continue,
             };
             map.insert(uuid, entry);
@@ -1265,15 +1282,43 @@ impl cosmic::Application for CosmicNetworkApplet {
                             AgentSetting::Vpn { secret_keys } => secret_keys.clone(),
                             _ => Vec::new(),
                         };
+                        let password_flags =
+                            match self.nm_state.known_vpns.get(connection_uuid.as_str()) {
+                                Some(ConnectionSettings::Vpn { password_flags, .. }) => {
+                                    *password_flags
+                                }
+                                _ => 0,
+                            };
+                        let uuid: Arc<str> = connection_uuid.as_str().into();
                         self.nm_state.requested_vpn = Some(RequestedVpn {
-                            uuid: connection_uuid.into(),
+                            uuid: uuid.clone(),
                             description,
                             password: SecureString::from(String::new()),
                             password_hidden: true,
                             responder: responder.clone(),
-                            secret_keys,
+                            secret_keys: secret_keys.clone(),
+                            password_flags,
                         });
                         consumed = true;
+
+                        // Pre-fill from the keyring cache, unless NM flags this
+                        // secret not-to-save (OTP); a stale value would mislead.
+                        if password_flags & SECRET_FLAG_NOT_SAVED == 0 {
+                            return cosmic::task::future(async move {
+                                let stored = secret_store::lookup(&uuid, VPN_SETTING).await;
+                                let password = secret_keys
+                                    .iter()
+                                    .find_map(|k| stored.get(k))
+                                    .or_else(|| stored.get("password"))
+                                    .cloned();
+                                match password {
+                                    Some(password) => {
+                                        Message::VpnPasswordPrefill { uuid, password }
+                                    }
+                                    None => Message::NoOp,
+                                }
+                            });
+                        }
                     }
 
                     // The applet's Wi-Fi flow re-issues the password through
@@ -1311,9 +1356,11 @@ impl cosmic::Application for CosmicNetworkApplet {
             }
             Message::ConnectVPNWithPassword => {
                 if let Some(RequestedVpn {
+                    uuid,
                     password,
                     responder,
                     secret_keys,
+                    password_flags,
                     ..
                 }) = self.nm_state.requested_vpn.take()
                 {
@@ -1332,12 +1379,26 @@ impl cosmic::Application for CosmicNetworkApplet {
                             }
                         }
 
+                        // Cache for next time's pre-fill, unless flagged not-to-save (OTP).
+                        if password_flags & SECRET_FLAG_NOT_SAVED == 0 {
+                            secret_store::store(&uuid, VPN_SETTING, &secrets).await;
+                        }
+
                         if let Err(e) = responder.vpn_secrets(secrets).await {
                             tracing::error!("vpn secret reply failed: {e}");
                         }
                         Message::Refresh
                     })
                     .map(cosmic::Action::App);
+                }
+            }
+            Message::VpnPasswordPrefill { uuid, password } => {
+                // Only fill if it's still the same request and untouched.
+                if let Some(requested_vpn) = self.nm_state.requested_vpn.as_mut()
+                    && requested_vpn.uuid == uuid
+                    && requested_vpn.password.unsecure().is_empty()
+                {
+                    requested_vpn.password = password;
                 }
             }
             Message::VPNPasswordUpdate(secure_string) => {

--- a/cosmic-applet-network/src/lib.rs
+++ b/cosmic-applet-network/src/lib.rs
@@ -3,6 +3,7 @@
 mod app;
 mod config;
 mod localize;
+mod secret_store;
 mod utils;
 
 use crate::localize::localize;

--- a/cosmic-applet-network/src/secret_store.rs
+++ b/cosmic-applet-network/src/secret_store.rs
@@ -1,0 +1,89 @@
+// Best-effort keyring cache of network secrets. nmrs doesn't surface the
+// secrets NM sends with GetSecrets, so the applet caches them itself to
+// pre-fill the password dialog, keyed as the pre-nmrs agent did
+// (application/uuid/setting_name/name) so older secrets still read.
+
+use std::collections::HashMap;
+
+use secret_service::{EncryptionType, SecretService};
+use secure_string::SecureString;
+
+const SECRET_ID: &str = "com.system76.CosmicSettings.NetworkManager";
+
+/// Look up stored secrets for a connection's setting, keyed by secret name
+/// (e.g. `"password"`). Empty on any error.
+pub async fn lookup(uuid: &str, setting_name: &str) -> HashMap<String, SecureString> {
+    match lookup_inner(uuid, setting_name).await {
+        Ok(secrets) => secrets,
+        Err(e) => {
+            tracing::debug!("keyring lookup failed for {uuid}/{setting_name}: {e}");
+            HashMap::new()
+        }
+    }
+}
+
+async fn lookup_inner(
+    uuid: &str,
+    setting_name: &str,
+) -> Result<HashMap<String, SecureString>, secret_service::Error> {
+    let ss = SecretService::connect(EncryptionType::Dh).await?;
+    let collection = ss.get_default_collection().await?;
+    let attributes = HashMap::from([
+        ("application", SECRET_ID),
+        ("uuid", uuid),
+        ("setting_name", setting_name),
+    ]);
+    let items = collection.search_items(attributes).await?;
+
+    let mut secrets = HashMap::new();
+    for item in &items {
+        let name = item
+            .get_attributes()
+            .await?
+            .get("name")
+            .cloned()
+            .unwrap_or_default();
+        if name.is_empty() {
+            continue;
+        }
+        if let Ok(value) = String::from_utf8(item.get_secret().await?) {
+            secrets.insert(name, SecureString::from(value));
+        }
+    }
+    Ok(secrets)
+}
+
+/// Persist secrets for a connection's setting, overwriting matching entries.
+/// Best-effort: logs on error.
+pub async fn store(uuid: &str, setting_name: &str, secrets: &HashMap<String, String>) {
+    if let Err(e) = store_inner(uuid, setting_name, secrets).await {
+        tracing::warn!("failed to store secret for {uuid}/{setting_name}: {e}");
+    }
+}
+
+async fn store_inner(
+    uuid: &str,
+    setting_name: &str,
+    secrets: &HashMap<String, String>,
+) -> Result<(), secret_service::Error> {
+    let ss = SecretService::connect(EncryptionType::Dh).await?;
+    let collection = ss.get_default_collection().await?;
+    for (name, secret) in secrets {
+        let attributes = HashMap::from([
+            ("application", SECRET_ID),
+            ("uuid", uuid),
+            ("setting_name", setting_name),
+            ("name", name.as_str()),
+        ]);
+        collection
+            .create_item(
+                "NetworkManager Secret",
+                attributes,
+                secret.as_bytes(),
+                true,
+                "text/plain",
+            )
+            .await?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
This is a follow up to https://github.com/pop-os/cosmic-applets/pull/1445 and the second part of the issue raised in https://github.com/pop-os/cosmic-applets/issues/1444. I decided to do this as a separate PR since it felt like a distinct issue, and it makes the PR more focused.

`cosmic-applet-network` stopped pre-filling the saved VPN password after the nmrs migration (`8d84396`, first shipped in 1.0.14): the secret prompt always opens blank, even for a connection whose password was previously entered.

The pre-nmrs agent kept its own Secret Service cache — it stored every entered secret and re-offered it on the next `GetSecrets`. `nmrs` discards the existing secrets NM includes in the `GetSecrets` payload and provides no keyring integration, so the applet now reinstates that cache (new `secret_store` module, keyed `application`/`uuid`/`setting_name`/`name` exactly as the old agent so secrets saved before 1.0.14 are recovered). Entered VPN secrets are stored at the `ConnectVPNWithPassword` reply site and looked up at the `RequestSecret` site to pre-fill the dialog; `NM_SETTING_SECRET_FLAG_NOT_SAVED` secrets (e.g. OTP) are neither cached nor pre-filled. The flag is read from nmrs's `SettingsSummary::Vpn.password_flags`, threaded through `load_vpns()`.

This restores agent-owned secrets only; surfacing NM's payload secrets (system-owned) would need an upstream nmrs change.

Note: There are a few ways this could be addressed. This follows the way it was before quite closely, but I appreciate it might not be what we want.

Note 2: I used Claude to help me diagnose the issue and write the code.

## Test plan

- Built and deployed against a real OTP OpenVPN connection on Pop!_OS. Before: the password now gets prefilled

- [x ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x ] I understand these changes in full and will be able to respond to review comments.
- [x ] My change is accurately described in the commit message.
- [ x] My contribution is tested and working as described.
- [x ] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

