### PR TITLE
fix: bluetooth broken filter

### DIFF
--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -855,13 +855,7 @@ async fn bluer_state(adapter: &Adapter) -> BluerState {
 
 #[inline(never)]
 async fn build_device_list(mut devices: Vec<BluerDevice>, adapter: &Adapter) -> Vec<BluerDevice> {
-    let addrs: Vec<Address> = adapter
-        .device_addresses()
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|addr| !devices.iter().any(|d| d.address == *addr))
-        .collect();
+    let addrs = adapter.device_addresses().await.unwrap_or_default();
 
     devices.clear();
     if addrs.len() > devices.capacity() {


### PR DESCRIPTION
**Problem**
Each new scan excludes known devices, clears the device list, and rebuilds it using only new addresses. 
As a result, known and connected devices simply vanish from the list.

**Fix**
Don't filter out known devices.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

