### PR TITLE
fix(status-area): constrain menu icon-data to icon size

### DIFF
--- a/cosmic-applet-status-area/src/components/status_menu.rs
+++ b/cosmic-applet-status-area/src/components/status_menu.rs
@@ -232,7 +232,11 @@ fn layout_view(layout: &Layout, expanded: Option<i32>) -> cosmic::Element<'_, Ms
             }
             if let Some(icon_data) = i.icon_data() {
                 let handle = iced::widget::image::Handle::from_bytes(icon_data.to_vec());
-                children.insert(0, iced::widget::Image::new(handle).into());
+                let icon = iced::widget::Image::new(handle)
+                    .width(iced::Length::Fixed(14.0))
+                    .height(iced::Length::Fixed(14.0))
+                    .content_fit(iced::core::ContentFit::Contain);
+                children.insert(0, icon.into());
             } else if let Some(icon_name) = i.icon_name() {
                 let icon = cosmic::widget::icon::from_name(icon_name)
                     .size(14)


### PR DESCRIPTION
Fixes #1147

Menu-item `icon-data` (raw PNG) rendered at its native size, unlike the `icon-name` branch which uses `.size(14)`, so apps sending full-resolution pixmaps show oversized icons in the menu.

**Spec:** `com.canonical.dbusmenu` defines `icon-data` only as [*"PNG data of the icon."*](https://salsa.debian.org/debian-ayatana-team/libdbusmenu/-/blob/f2eaa2cbe032de53dfb3058d214bddf7f173187e/libdbusmenu-glib/dbus-menu.xml#L103-105) — no size, no aspect ratio. It is an item icon just like `icon-name`, only delivered as raw bytes. Reference DEs render **both sources at the same fixed menu-icon size**:

- **KDE** (`libdbusmenuqt`, `dbusmenuimporter.cpp`): `icon-name` → [`QIcon::fromTheme`](https://github.com/KDE/plasma-workspace/blob/97f8d8d7c7a52e8cdddc8efc39a2bc5a0b6389df/libdbusmenuqt/dbusmenuimporter.cpp#L539-L541) and `icon-data` → [`QIcon(pixmap)`](https://github.com/KDE/plasma-workspace/blob/97f8d8d7c7a52e8cdddc8efc39a2bc5a0b6389df/libdbusmenuqt/dbusmenuimporter.cpp#L210-L226) both become a plain `QIcon` on the same `QAction`; `QMenu` then draws every action icon at `QStyle::PM_SmallIconSize`.
- **GNOME** (AppIndicator, `dbusMenu.js`): `_updateImage()` assigns [`icon-name`](https://github.com/ubuntu/gnome-shell-extension-appindicator/blob/d96341d34c9abcb01f33d7f63289007ba70f430a/dbusMenu.js#L768) and [`icon-data`](https://github.com/ubuntu/gnome-shell-extension-appindicator/blob/d96341d34c9abcb01f33d7f63289007ba70f430a/dbusMenu.js#L778) to the **same** [`St.Icon`](https://github.com/ubuntu/gnome-shell-extension-appindicator/blob/d96341d34c9abcb01f33d7f63289007ba70f430a/dbusMenu.js#L601-L604) (`popup-menu-icon`), which has one fixed size.

This applet's `icon-name` branch already does the same (`.size(14)`); this change renders `icon-data` in that same 14px box (`ContentFit::Contain`).

**Alternatives considered — for non-square icons** (square icons render 14×14 either way):
- *`height: 14`, variable width*: fills the row height, but the icon column then varies in width, so labels stop aligning with `icon-name` rows.
- *`height: 14`, `min-width: 14`*: would restore that alignment, but iced exposes no `min_width` on `image`/`container` — and even with it, a genuinely wide icon would still exceed 14px and misalign its row.

Both alternatives keep a non-square (variable-width) slot, which also deviates from KDE/GNOME (fixed **square** slot). The chosen fixed 14×14 box keeps every icon row aligned (aspect preserved via `Contain`) and matches their square slot.

Repro: NetBird's tray menu (0.74.2) ships a 256×256 logo. Note: NetBird 0.75.0 (will be released very soon) is a full UI rework and may not reproduce this.

#1147 has screenshots of the current state (before this fix) and KDE. This fix sizes menu item icons correctly:
<img width="540" height="808" alt="Screenshot_2026-07-06_15-36-09" src="https://github.com/user-attachments/assets/17219de8-ee51-4e5e-a475-f64bac825ed9" />


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
