### PR TITLE
fix(network): pre-fill saved VPN password from the GetSecrets payload

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -297,6 +297,8 @@ pub enum NmAgentEvent {
         connection_id: String,
         setting: AgentSetting,
         responder: SecretResponderHandle,
+        /// Secrets NM already holds (system-owned), for pre-fill.
+        existing_secrets: HashMap<String, String>,
     },
     CancelGetSecrets,
     Failed(String),
@@ -985,7 +987,16 @@ fn secret_request_to_event(req: SecretRequest) -> NmAgentEvent {
         connection_id: req.connection_id,
         setting,
         responder: Arc::new(AsyncMutex::new(Some(req.responder))),
+        existing_secrets: req.existing_secrets,
     }
+}
+
+/// Pick a VPN secret from NM's payload: a hinted key first, else `"password"`.
+fn pick_secret(src: &HashMap<String, String>, keys: &[String]) -> Option<String> {
+    keys.iter()
+        .find_map(|k| src.get(k).filter(|s| !s.is_empty()))
+        .or_else(|| src.get("password").filter(|s| !s.is_empty()))
+        .cloned()
 }
 
 /// Reply with [`NoSecrets`](nmrs::agent::SecretResponder::no_secrets) to free
@@ -1460,6 +1471,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                     connection_id,
                     setting,
                     responder,
+                    existing_secrets,
                 } => {
                     let description = (!connection_id.is_empty()).then_some(connection_id);
                     let known_vpn = self
@@ -1503,10 +1515,15 @@ impl cosmic::Application for CosmicNetworkApplet {
                             AgentSetting::Vpn { secret_keys } => secret_keys.clone(),
                             _ => Vec::new(),
                         };
+                        // Pre-fill with the saved secret NM sends in the request
+                        // (system-owned secrets are included in the payload).
+                        let password = pick_secret(&existing_secrets, &secret_keys)
+                            .map(SecureString::from)
+                            .unwrap_or_else(|| SecureString::from(String::new()));
                         self.nm_state.requested_vpn = Some(RequestedVpn {
                             uuid: connection_uuid.into(),
                             description,
-                            password: SecureString::from(String::new()),
+                            password,
                             password_hidden: true,
                             responder: responder.clone(),
                             secret_keys,
@@ -2253,5 +2270,47 @@ fn active_conn_hw_address(conn: &ActiveConnectionInfo) -> HwAddress {
             HwAddress::from_str(hw_address).unwrap_or_default()
         }
         ActiveConnectionInfo::Vpn { .. } => HwAddress::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secrets(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn hinted_key_is_preferred() {
+        let s = secrets(&[("password", "pw"), ("otp", "123")]);
+        assert_eq!(pick_secret(&s, &["otp".into()]).as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn empty_hint_list_falls_back_to_password() {
+        let s = secrets(&[("password", "pw")]);
+        assert_eq!(pick_secret(&s, &[]).as_deref(), Some("pw"));
+    }
+
+    #[test]
+    fn missing_hinted_key_falls_back_to_password() {
+        let s = secrets(&[("password", "pw")]);
+        assert_eq!(pick_secret(&s, &["absent".into()]).as_deref(), Some("pw"));
+    }
+
+    #[test]
+    fn empty_hinted_value_does_not_shadow_populated_fallback() {
+        let s = secrets(&[("otp", ""), ("password", "pw")]);
+        assert_eq!(pick_secret(&s, &["otp".into()]).as_deref(), Some("pw"));
+    }
+
+    #[test]
+    fn nothing_usable_returns_none() {
+        let s = secrets(&[("password", "")]);
+        assert_eq!(pick_secret(&s, &["otp".into()]), None);
     }
 }


### PR DESCRIPTION
`cosmic-applet-network` opened the VPN secret prompt with an empty password field even when NetworkManager already had the password saved, because the nmrs agent request discarded the secrets NM includes in its `GetSecrets` payload.

nmrs 3.4.0 ( https://github.com/freedesktop-rs/nmrs/issues/456 ) surfaces them as `SecretRequest.existing_secrets`, so the applet pre-fills the dialog from that map, a hinted key, else `"password"`, at the `RequestSecret` site. Only system-owned secrets appear in the payload (agent-owned and not-saved secrets are never sent to agents), so this covers the common "saved for all users" case with no keyring handling.

- Built and deployed against a real OpenVPN connection (`yoti_vpn`, `password-flags=0`) on Pop!_OS. Before: the field opened blank. After: the saved password is pre-filled on the first prompt.

Note: claude Opus 4.8 was used for coding assistance.

- [X ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X ] I understand these changes in full and will be able to respond to review comments.
- [X ] My change is accurately described in the commit message.
- [X ] My contribution is tested and working as described.
- [X ] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This closes #1444 
