### PR TITLE
Hide the wireless networks list when Wi-Fi is off

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -1871,14 +1871,16 @@ impl cosmic::Application for CosmicNetworkApplet {
             return self.view_window_return(content);
         }
 
-        if !self.nm_state.nm_state.wifi_enabled && !self.nm_state.known_vpns.is_empty() {
+        if !self.nm_state.nm_state.wifi_enabled {
             // Add VPN connections section when WiFi is disabled
-            content = content.push(vpn_section(
-                &self.nm_state,
-                self.show_available_vpns,
-                space_xxs,
-                space_s,
-            ));
+            if !self.nm_state.known_vpns.is_empty() {
+                content = content.push(vpn_section(
+                    &self.nm_state,
+                    self.show_available_vpns,
+                    space_xxs,
+                    space_s,
+                ));
+            }
 
             return self.view_window_return(content);
         }
@@ -2221,7 +2223,7 @@ impl cosmic::Application for CosmicNetworkApplet {
         }
 
         // Add VPN connections section after wireless networks when they are expanded
-        if !self.nm_state.known_vpns.is_empty() && self.nm_state.nm_state.wifi_enabled {
+        if !self.nm_state.known_vpns.is_empty() {
             content = content.push(vpn_section(
                 &self.nm_state,
                 self.show_available_vpns,


### PR DESCRIPTION
The early return that skips the wireless section required a known VPN to be
present as well, so with Wi-Fi turned off and no VPN configured the list of
visible wireless networks was still built and shown. That is why the issue is
not reproducible on systems that have a VPN.

`view_window` now returns whenever Wi-Fi is off, and pushes the VPN section only
when there is one, which is what the airplane mode branch just above it already
does.

The VPN section that follows the wireless networks is only reachable with Wi-Fi
on now, so its `wifi_enabled` check is dropped.

Fixes #1470

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
