### PR TITLE
feat(audio): add application volume controls

### DIFF
--- a/cosmic-applet-audio/i18n/en/cosmic_applet_audio.ftl
+++ b/cosmic-applet-audio/i18n/en/cosmic_applet_audio.ftl
@@ -1,5 +1,6 @@
 output = Output
 input = Input
+applications = Application Volume
 show-media-controls = Show media controls on panel
 sound-settings = Sound Settings...
 disconnected = PulseAudio Disconnected

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -18,8 +18,10 @@ use cosmic::{
     cctk::sctk::reexports::calloop,
     cosmic_config::CosmicConfigEntry,
     cosmic_theme::Spacing,
+    desktop::{IconSourceExt, fde},
     iced::{
         self, Alignment, Length, Rectangle, Subscription,
+        advanced::text::EllipsizeHeightLimit,
         futures::StreamExt,
         widget::{self, column, row, slider},
         window,
@@ -33,10 +35,9 @@ use cosmic::{
 };
 use cosmic_settings_audio_client::{self as audio_client, CosmicAudioProxy};
 use futures::SinkExt;
-use iced::platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup};
 use mpris_subscription::{MprisRequest, MprisUpdate};
 use mpris2_zbus::player::PlaybackStatus;
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{cell::RefCell, path::Path, rc::Rc, sync::Arc};
 
 mod config;
 mod mpris_subscription;
@@ -45,6 +46,7 @@ const GO_BACK: &str = "media-skip-backward-symbolic";
 const GO_NEXT: &str = "media-skip-forward-symbolic";
 const PAUSE: &str = "media-playback-pause-symbolic";
 const PLAY: &str = "media-playback-start-symbolic";
+const STREAM_LABEL_WIDTH: f32 = 80.0;
 
 pub fn run() -> cosmic::iced::Result {
     localize();
@@ -79,6 +81,9 @@ pub struct Audio {
     token_tx: Option<calloop::channel::Sender<TokenRequest>>,
     rectangle_tracker: Option<RectangleTracker<u32>>,
     rectangle: Option<iced::Rectangle>,
+    /// Cached desktop entries, used to resolve stream icons by app id.
+    desktop_entries: Vec<fde::DesktopEntry>,
+    locales: Vec<String>,
 }
 
 impl Audio {
@@ -111,6 +116,102 @@ impl Audio {
             "microphone-sensitivity-high-symbolic"
         }
     }
+
+    fn update_desktop_entries(&mut self) {
+        self.desktop_entries = fde::Iter::new(fde::default_paths())
+            .filter_map(|p| fde::DesktopEntry::from_path(p, Some(&self.locales)).ok())
+            .collect::<Vec<_>>();
+    }
+
+    /// Resolves an icon for a stream, preferring PipeWire's
+    /// `application.icon-name` over a desktop-entry lookup.
+    ///
+    /// This is a looser match than a true desktop-file app-id, so lookups may
+    /// occasionally miss — pavucontrol has the same limitation.
+    fn stream_icon(&self, app_id: &str, icon_name: Option<&str>) -> cosmic::widget::icon::Handle {
+        let icon_name = icon_name.unwrap_or_else(|| {
+            let unicase_appid = fde::unicase::Ascii::new(app_id);
+            fde::find_app_by_id(&self.desktop_entries, unicase_appid)
+                // PipeWire commonly reports a process binary (e.g. `zen-bin`),
+                // while the desktop-entry ID is unrelated (e.g. `zen.desktop`).
+                .or_else(|| {
+                    self.desktop_entries.iter().find(|entry| {
+                        entry
+                            .exec()
+                            .and_then(|exec| exec.split_whitespace().next())
+                            .and_then(|command| Path::new(command).file_name())
+                            .is_some_and(|binary| binary.eq_ignore_ascii_case(app_id))
+                    })
+                })
+                .and_then(|de| de.icon())
+                .unwrap_or(app_id)
+        });
+        fde::IconSource::from_unknown(icon_name).as_cosmic_icon()
+    }
+
+    fn stream_row(&self, pos: usize) -> Element<'_, Message> {
+        let node_id = self.model.streams.id[pos];
+        let volume = self.model.streams.volume[pos];
+        let display_name = self.model.streams.display_name[pos].as_ref();
+        let media_name = self.model.streams.media_name[pos].as_ref();
+
+        let stream_slider = slider(0..=100, volume, move |v| {
+            Message::SetStreamVolume(node_id, v)
+        })
+        .width(Length::FillPortion(5));
+
+        let mut label = column![
+            text::body(display_name)
+                .width(Length::Fixed(STREAM_LABEL_WIDTH))
+                .wrapping(widget::text::Wrapping::None)
+                .ellipsize(widget::text::Ellipsize::End(EllipsizeHeightLimit::Lines(1)))
+        ];
+        if let Some(media_name) = media_name {
+            label = label.push(
+                text::caption(media_name.as_ref())
+                    .width(Length::Fixed(STREAM_LABEL_WIDTH))
+                    .wrapping(widget::text::Wrapping::None)
+                    .ellipsize(widget::text::Ellipsize::End(EllipsizeHeightLimit::Lines(1))),
+            );
+        }
+
+        padded_control(
+            row![
+                icon(self.stream_icon(
+                    &self.model.streams.app_id[pos],
+                    self.model.streams.icon_name[pos].as_deref(),
+                ))
+                .size(24),
+                label,
+                stream_slider,
+                container(text(volume.to_string()).size(16))
+                    .width(Length::FillPortion(1))
+                    .align_x(Alignment::End)
+            ]
+            .spacing(12)
+            .align_y(Alignment::Center),
+        )
+        .into()
+    }
+
+    fn applications_revealer(&self) -> Element<'_, Message> {
+        let open = self.is_open == IsOpen::Applications;
+        let count = self.model.streams.id.len();
+
+        let head = cosmic::widget::column::with_capacity(1)
+            .push(text::body(fl!("applications")).width(Length::Fill))
+            .apply(menu_button)
+            .on_press(Message::ApplicationsToggle);
+
+        if open {
+            (0..count).fold(column![head].width(Length::Fill), |col, pos| {
+                col.push(self.stream_row(pos))
+            })
+        } else {
+            column![head]
+        }
+        .into()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Default)]
@@ -119,6 +220,7 @@ enum IsOpen {
     None,
     Output,
     Input,
+    Applications,
 }
 
 #[derive(Clone, Debug)]
@@ -134,6 +236,8 @@ pub enum Message {
     SetDefaultSource(usize),
     OutputToggle,
     InputToggle,
+    ApplicationsToggle,
+    SetStreamVolume(u32, u32),
     TogglePopup,
     CloseRequested(window::Id),
     ToggleMediaControlsInTopPanel(bool),
@@ -256,13 +360,13 @@ impl cosmic::Application for Audio {
     const APP_ID: &'static str = "com.system76.CosmicAppletAudio";
 
     fn init(core: cosmic::app::Core, _flags: ()) -> (Self, app::Task<Message>) {
-        (
-            Self {
-                core,
-                ..Default::default()
-            },
-            Task::none(),
-        )
+        let mut app = Self {
+            core,
+            locales: fde::get_languages_from_env(),
+            ..Default::default()
+        };
+        app.update_desktop_entries();
+        (app, Task::none())
     }
 
     fn core(&self) -> &cosmic::app::Core {
@@ -347,6 +451,27 @@ impl cosmic::Application for Audio {
                     IsOpen::None
                 } else {
                     IsOpen::Input
+                }
+            }
+            Message::ApplicationsToggle => {
+                self.is_open = if self.is_open == IsOpen::Applications {
+                    IsOpen::None
+                } else {
+                    IsOpen::Applications
+                }
+            }
+            Message::SetStreamVolume(node_id, volume) => {
+                if let Some(pos) = self.model.streams.id.iter().position(|&id| id == node_id) {
+                    self.model.streams.volume[pos] = volume;
+                }
+                if let Some(ref mut client) = self.audio_client {
+                    futures::executor::block_on(async {
+                        _ = client
+                            .borrow_mut()
+                            .conn
+                            .set_node_volume(node_id, volume)
+                            .await;
+                    });
                 }
             }
             Message::Subscription(message) => {
@@ -758,6 +883,12 @@ impl cosmic::Application for Audio {
             ]
             .align_x(Alignment::Start)
         };
+
+        if !self.model.streams.id.is_empty() {
+            audio_content = audio_content
+                .push(padded_control(divider::horizontal::default()).padding([space_xxs, space_s]))
+                .push(self.applications_revealer());
+        }
 
         if let Some(s) = self.player_status.as_ref() {
             let mut elements = Vec::with_capacity(5);

--- a/cosmic-applet-audio/src/lib.rs
+++ b/cosmic-applet-audio/src/lib.rs
@@ -128,20 +128,29 @@ impl Audio {
     ///
     /// This is a looser match than a true desktop-file app-id, so lookups may
     /// occasionally miss — pavucontrol has the same limitation.
-    fn stream_icon(&self, app_id: &str, icon_name: Option<&str>) -> cosmic::widget::icon::Handle {
+    fn stream_icon(
+        &self,
+        app_id: &str,
+        app_name: &str,
+        icon_name: Option<&str>,
+    ) -> cosmic::widget::icon::Handle {
         let icon_name = icon_name.unwrap_or_else(|| {
-            let unicase_appid = fde::unicase::Ascii::new(app_id);
-            fde::find_app_by_id(&self.desktop_entries, unicase_appid)
-                // PipeWire commonly reports a process binary (e.g. `zen-bin`),
-                // while the desktop-entry ID is unrelated (e.g. `zen.desktop`).
-                .or_else(|| {
-                    self.desktop_entries.iter().find(|entry| {
-                        entry
-                            .exec()
-                            .and_then(|exec| exec.split_whitespace().next())
-                            .and_then(|command| Path::new(command).file_name())
-                            .is_some_and(|binary| binary.eq_ignore_ascii_case(app_id))
-                    })
+            [app_id, app_name]
+                .into_iter()
+                .find_map(|candidate| {
+                    let unicase_appid = fde::unicase::Ascii::new(candidate);
+                    fde::find_app_by_id(&self.desktop_entries, unicase_appid)
+                        // PipeWire commonly reports a process binary (e.g. `zen-bin`),
+                        // while the desktop-entry ID is unrelated (e.g. `zen.desktop`).
+                        .or_else(|| {
+                            self.desktop_entries.iter().find(|entry| {
+                                entry
+                                    .exec()
+                                    .and_then(|exec| exec.split_whitespace().next())
+                                    .and_then(|command| Path::new(command).file_name())
+                                    .is_some_and(|binary| binary.eq_ignore_ascii_case(candidate))
+                            })
+                        })
                 })
                 .and_then(|de| de.icon())
                 .unwrap_or(app_id)
@@ -179,6 +188,7 @@ impl Audio {
             row![
                 icon(self.stream_icon(
                     &self.model.streams.app_id[pos],
+                    display_name,
                     self.model.streams.icon_name[pos].as_deref(),
                 ))
                 .size(24),

--- a/cosmic-applet-audio/src/model.rs
+++ b/cosmic-applet-audio/src/model.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use cosmic_settings_audio_client::{self as audio_client, Availability, RouteInfo};
+use cosmic_settings_audio_client::{self as audio_client, Availability, NodeKind, RouteInfo};
 use intmap::IntMap;
 
 pub type DeviceId = u32;
@@ -15,6 +15,7 @@ pub struct Model {
     pub node_devices: IntMap<NodeId, Option<u32>>,
     pub sinks: Nodes,
     pub sources: Nodes,
+    pub streams: Streams,
     pub active_sink: ActiveNode,
     pub active_source: ActiveNode,
     pub default_sink: Option<NodeId>,
@@ -88,6 +89,36 @@ pub struct ActiveNode {
     pub mute: bool,
 }
 
+/// Per-application playback streams (sink-input equivalent).
+///
+/// Unlike `Nodes`, there is no "active"/"default" stream concept, so this doesn't
+/// carry the `sorted_display`/`sorted_index`/`active` machinery `Nodes` needs to back
+/// a device-selection dropdown — streams are always enumerated in full.
+#[derive(Debug, Default)]
+pub struct Streams {
+    pub id: Vec<NodeId>,
+    pub volume: Vec<u32>,
+    pub display_name: Vec<Arc<str>>,
+    pub app_id: Vec<Arc<str>>,
+    pub icon_name: Vec<Option<Arc<str>>>,
+    pub media_name: Vec<Option<Arc<str>>>,
+}
+
+impl Streams {
+    pub fn remove(&mut self, node_id: u32) -> bool {
+        let Some(pos) = self.id.iter().position(|id| node_id == *id) else {
+            return false;
+        };
+        self.volume.remove(pos);
+        self.display_name.remove(pos);
+        self.app_id.remove(pos);
+        self.icon_name.remove(pos);
+        self.media_name.remove(pos);
+        self.id.remove(pos);
+        true
+    }
+}
+
 impl Model {
     pub fn update(&mut self, event: audio_client::Event) {
         tracing::debug!(?event, "update");
@@ -130,6 +161,8 @@ impl Model {
                         self.active_source.volume = self.sources.volume[pos];
                         self.active_source.volume_text = self.active_source.volume.to_string();
                     }
+                } else if let Some(pos) = self.streams.id.iter().position(|id| node_id == *id) {
+                    self.streams.volume[pos] = volume;
                 }
             }
 
@@ -155,7 +188,42 @@ impl Model {
 
             audio_client::Event::Node(node_id, node) => {
                 self.node_devices.insert(node_id, node.device_id);
-                if node.is_sink {
+                if matches!(node.kind, Some(NodeKind::StreamOutput)) {
+                    let app_id: Arc<str> = node
+                        .application_binary
+                        .clone()
+                        .or_else(|| node.application_name.clone())
+                        .unwrap_or_else(|| node.name.clone())
+                        .into();
+                    let display_name: Arc<str> = node
+                        .application_name
+                        .clone()
+                        .or_else(|| node.application_binary.clone())
+                        .unwrap_or_else(|| node.name.clone())
+                        .into();
+                    let media_name: Option<Arc<str>> = node.media_name.clone().map(Into::into);
+                    let icon_name: Option<Arc<str>> =
+                        node.application_icon_name.clone().map(Into::into);
+                    if let Some(pos) = self.streams.id.iter().position(|&id| id == node_id) {
+                        self.streams.app_id[pos] = app_id;
+                        self.streams.display_name[pos] = display_name;
+                        self.streams.icon_name[pos] = icon_name;
+                        self.streams.media_name[pos] = media_name;
+                    } else {
+                        self.streams.id.push(node_id);
+                        self.streams.volume.push(0);
+                        self.streams.display_name.push(display_name);
+                        self.streams.app_id.push(app_id);
+                        self.streams.icon_name.push(icon_name);
+                        self.streams.media_name.push(media_name);
+                    }
+
+                    return;
+                }
+
+                if matches!(node.kind, Some(NodeKind::Sink))
+                    || (node.kind.is_none() && node.is_sink)
+                {
                     let pos = if let Some(pos) = self.sinks.id.iter().position(|&id| id == node_id)
                     {
                         self.sinks.description[pos] = self.translate(&node.description);
@@ -308,8 +376,8 @@ impl Model {
             audio_client::Event::RemoveNode(node_id) => {
                 self.node_devices.remove(node_id);
 
-                if !self.sinks.remove(node_id) {
-                    self.sources.remove(node_id);
+                if !self.sinks.remove(node_id) && !self.sources.remove(node_id) {
+                    self.streams.remove(node_id);
                 }
             }
 
@@ -390,4 +458,63 @@ fn node_name(route: &str, node: &str) -> Arc<str> {
         [route, " - ", node].concat()
     }
     .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(kind: NodeKind) -> audio_client::NodeInfo {
+        audio_client::NodeInfo {
+            name: "test-node".into(),
+            description: String::new(),
+            device_profile_description: String::new(),
+            device_id: None,
+            card_profile_device: None,
+            is_sink: matches!(kind, NodeKind::Sink),
+            kind: Some(kind),
+            application_name: Some("Test Player".into()),
+            application_binary: Some("test-player".into()),
+            application_icon_name: Some("media-playback-start".into()),
+            media_name: Some("A test track".into()),
+        }
+    }
+
+    #[test]
+    fn playback_stream_tracks_volume_and_removal() {
+        let mut model = Model::default();
+        model.update(audio_client::Event::Node(42, node(NodeKind::StreamOutput)));
+
+        assert_eq!(model.streams.id, [42]);
+        assert_eq!(&*model.streams.display_name[0], "Test Player");
+        assert_eq!(&*model.streams.app_id[0], "test-player");
+        assert_eq!(model.streams.volume, [0]);
+
+        model.update(audio_client::Event::NodeVolume(42, 64, None));
+        assert_eq!(model.streams.volume, [64]);
+
+        model.update(audio_client::Event::RemoveNode(42));
+        assert!(model.streams.id.is_empty());
+        assert!(model.streams.volume.is_empty());
+    }
+
+    #[test]
+    fn device_nodes_do_not_appear_as_playback_streams() {
+        let mut model = Model::default();
+        model.update(audio_client::Event::Node(7, node(NodeKind::Source)));
+
+        assert!(model.streams.id.is_empty());
+    }
+
+    #[test]
+    fn legacy_sink_node_uses_is_sink() {
+        let mut model = Model::default();
+        let mut legacy_sink = node(NodeKind::Sink);
+        legacy_sink.kind = None;
+        legacy_sink.is_sink = true;
+
+        model.update(audio_client::Event::Node(7, legacy_sink));
+
+        assert_eq!(model.sinks.id, [7]);
+    }
 }


### PR DESCRIPTION
Closes #453

## Summary

Add an expandable **Application Volume** section to the audio applet. Each active application playback stream has an icon, a compact single-line title, and an independent volume slider.

This PR depends on pop-os/cosmic-settings-daemon#174, which adds the playback-stream events and metadata consumed here. It intentionally contains no local Cargo patch; CI will become compatible when that dependency lands upstream.

## Testing

- Tested the daemon and applet together from the paired local feature branches.
- Verified two concurrent applications (Cider and Zen) appear independently and their sliders control only the selected application.
- `cargo test -p cosmic-applet-audio model::tests` (3 passed, including legacy `is_sink` compatibility).

## Screenshots

| Collapsed | Expanded |
| - | - |
| ![Collapsed Application Volume](https://raw.githubusercontent.com/AdityaHebballe/cosmic-applets/pr-assets/application-volume/.github/pr-assets/application-volume-collapsed.png) | ![Expanded Application Volume](https://raw.githubusercontent.com/AdityaHebballe/cosmic-applets/pr-assets/application-volume/.github/pr-assets/application-volume-expanded.png) |

- [x] I have disclosed use of AI-generated code in the commit message.
- [x] I understand these changes and can respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the Developer Certificate of Origin and certify my contribution under its conditions.