### PR TITLE
feat(network-applet): add cellular connection status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,6 +1126,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "uuid",
+ "zbus",
 ]
 
 [[package]]

--- a/cosmic-applet-network/Cargo.toml
+++ b/cosmic-applet-network/Cargo.toml
@@ -27,3 +27,4 @@ indexmap = "2.13.0"
 secure-string = "0.3.0"
 uuid = { version = "1.21.0", features = ["v4"] }
 nmrs = "3.4.0"
+zbus.workspace = true

--- a/cosmic-applet-network/i18n/en/cosmic_applet_network.ftl
+++ b/cosmic-applet-network/i18n/en/cosmic_applet_network.ftl
@@ -3,6 +3,7 @@ airplane-mode = Airplane mode
 airplane-mode-on = Airplane mode is on
 turn-off-airplane-mode = Turn off to enable Wi-Fi, Bluetooth and mobile broadband.
 wifi = Wi-Fi
+mobile-broadband = Mobile broadband
 identity = Identity
 ipv4 = IPv4 address
 ipv6 = IPv6 address

--- a/cosmic-applet-network/i18n/it/cosmic_applet_network.ftl
+++ b/cosmic-applet-network/i18n/it/cosmic_applet_network.ftl
@@ -3,6 +3,7 @@ airplane-mode = Modalità aereo
 airplane-mode-on = La modalità aereo è attiva
 turn-off-airplane-mode = Disabilita per attivare il Wi-Fi, il Bluetooth e la rete dati.
 wifi = Wi-Fi
+mobile-broadband = Banda larga mobile
 ipv4 = Indirizzo IPv4
 ipv6 = Indirizzo IPv6
 mac = MAC

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -940,12 +940,17 @@ impl CosmicNetworkApplet {
     }
 
     fn active_mobile_modem(&self) -> Option<&modem::Status> {
-        let active_interface = self.nm_state.nm_state.active_conns.iter().find_map(|connection| {
-            let ActiveConnectionInfo::Mobile { interface, .. } = connection else {
-                return None;
-            };
-            interface.as_deref()
-        })?;
+        let active_interface =
+            self.nm_state
+                .nm_state
+                .active_conns
+                .iter()
+                .find_map(|connection| {
+                    let ActiveConnectionInfo::Mobile { interface, .. } = connection else {
+                        return None;
+                    };
+                    interface.as_deref()
+                })?;
 
         modem_for_interface(&self.nm_state.modems, Some(active_interface))
     }
@@ -1803,11 +1808,9 @@ impl cosmic::Application for CosmicNetworkApplet {
                                     Element::from(
                                         icon::icon(
                                             icon::from_name(
-                                                modem
-                                                    .map(modem::Status::signal_icon)
-                                                    .unwrap_or(
-                                                        "network-cellular-connected-symbolic",
-                                                    ),
+                                                modem.map(modem::Status::signal_icon).unwrap_or(
+                                                    "network-cellular-connected-symbolic",
+                                                ),
                                             )
                                             .symbolic(true)
                                             .into(),

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -947,22 +947,11 @@ impl CosmicNetworkApplet {
             interface.as_deref()
         })?;
 
-        self.nm_state
-            .modems
-            .iter()
-            .find(|modem| modem.interface == active_interface)
-            .or_else(|| (self.nm_state.modems.len() == 1).then(|| self.nm_state.modems.first())?)
+        modem_for_interface(&self.nm_state.modems, Some(active_interface))
     }
 
     fn modem_for_interface(&self, interface: Option<&str>) -> Option<&modem::Status> {
-        interface
-            .and_then(|interface| {
-                self.nm_state
-                    .modems
-                    .iter()
-                    .find(|modem| modem.interface == interface)
-            })
-            .or_else(|| (self.nm_state.modems.len() == 1).then(|| self.nm_state.modems.first())?)
+        modem_for_interface(&self.nm_state.modems, interface)
     }
 
     fn view_window_return<'a>(
@@ -2503,5 +2492,48 @@ fn active_conn_hw_address(conn: &ActiveConnectionInfo) -> HwAddress {
         ActiveConnectionInfo::Mobile { .. } | ActiveConnectionInfo::Vpn { .. } => {
             HwAddress::default()
         }
+    }
+}
+
+fn modem_for_interface<'a>(
+    modems: &'a [modem::Status],
+    interface: Option<&str>,
+) -> Option<&'a modem::Status> {
+    interface
+        .and_then(|interface| modems.iter().find(|modem| modem.interface == interface))
+        .or_else(|| (modems.len() == 1).then(|| modems.first())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn modem(interface: &str) -> modem::Status {
+        modem::Status {
+            interface: interface.to_owned(),
+            ..modem::Status::default()
+        }
+    }
+
+    #[test]
+    fn modem_selection_uses_the_active_connection_interface() {
+        let modems = [modem("wwan0"), modem("wwan1")];
+
+        assert_eq!(
+            modem_for_interface(&modems, Some("wwan1")).map(|modem| modem.interface.as_str()),
+            Some("wwan1")
+        );
+        assert_eq!(modem_for_interface(&modems, Some("missing")), None);
+    }
+
+    #[test]
+    fn modem_selection_only_falls_back_when_unambiguous() {
+        let modem = modem("wwan0");
+
+        assert_eq!(
+            modem_for_interface(std::slice::from_ref(&modem), None)
+                .map(|modem| modem.interface.as_str()),
+            Some("wwan0")
+        );
     }
 }

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -41,7 +41,7 @@ use futures::{
     lock::Mutex as AsyncMutex,
 };
 
-use crate::{config, fl};
+use crate::{config, fl, modem};
 
 pub fn run() -> cosmic::iced::Result {
     cosmic::applet::run::<CosmicNetworkApplet>(())
@@ -167,6 +167,13 @@ pub struct AccessPoint {
 
 #[derive(Debug, Clone)]
 pub enum ActiveConnectionInfo {
+    Mobile {
+        name: String,
+        interface: Option<String>,
+        ip4_address: Option<String>,
+        ip6_address: Option<String>,
+        state: ActiveConnectionState,
+    },
     Wired {
         name: String,
         hw_address: String,
@@ -192,7 +199,10 @@ pub enum ActiveConnectionInfo {
 impl ActiveConnectionInfo {
     fn name(&self) -> &str {
         match self {
-            Self::Wired { name, .. } | Self::WiFi { name, .. } | Self::Vpn { name, .. } => name,
+            Self::Mobile { name, .. }
+            | Self::Wired { name, .. }
+            | Self::WiFi { name, .. }
+            | Self::Vpn { name, .. } => name,
         }
     }
 }
@@ -200,6 +210,8 @@ impl ActiveConnectionInfo {
 #[derive(Debug, Clone)]
 pub struct NetworkManagerState {
     pub wifi_enabled: bool,
+    pub wwan_enabled: bool,
+    pub wwan_available: bool,
     pub airplane_mode: bool,
     pub connectivity: ConnectivityState,
     pub active_conns: Vec<ActiveConnectionInfo>,
@@ -211,6 +223,8 @@ impl Default for NetworkManagerState {
     fn default() -> Self {
         Self {
             wifi_enabled: true,
+            wwan_enabled: true,
+            wwan_available: false,
             airplane_mode: false,
             connectivity: ConnectivityState::Unknown,
             active_conns: Vec::new(),
@@ -253,6 +267,7 @@ pub struct MyNetworkState {
     pub ssid_to_uuid: BTreeMap<Box<str>, Box<str>>,
     pub devices: Vec<Arc<DeviceInfo>>,
     pub nm_state: NetworkManagerState,
+    pub modems: Vec<modem::Status>,
     pub requested_vpn: Option<RequestedVpn>,
     pub pending_vpn: Option<PendingVpn>,
 }
@@ -666,6 +681,17 @@ fn snapshot_to_applet(snapshot: NetworkSnapshot) -> AppletSnapshot {
                 strength: wifi.strength.unwrap_or_default(),
                 hw_address: wifi.bssid.clone().unwrap_or_default(),
             }),
+            ActiveConnection::Other(connection)
+                if is_mobile_connection_type(connection.connection_type.as_deref()) =>
+            {
+                Some(ActiveConnectionInfo::Mobile {
+                    name: connection.id.clone(),
+                    interface: connection.interface.clone(),
+                    ip4_address: connection.ip4_address.clone(),
+                    ip6_address: connection.ip6_address.clone(),
+                    state: connection.state,
+                })
+            }
             ActiveConnection::Vpn(vpn) => Some(ActiveConnectionInfo::Vpn {
                 name: vpn.id.clone(),
                 ip4_address: vpn.ip4_address.clone(),
@@ -751,6 +777,8 @@ fn snapshot_to_applet(snapshot: NetworkSnapshot) -> AppletSnapshot {
     AppletSnapshot {
         state: NetworkManagerState {
             wifi_enabled: snapshot.wifi.enabled,
+            wwan_enabled: snapshot.wwan.enabled,
+            wwan_available: snapshot.wwan.present,
             airplane_mode: summary.airplane_mode.is_airplane_mode(),
             connectivity: summary.connectivity.state,
             active_conns,
@@ -762,6 +790,10 @@ fn snapshot_to_applet(snapshot: NetworkSnapshot) -> AppletSnapshot {
         ssid_to_uuid,
         captive_portal_url: summary.connectivity.captive_portal_url.clone(),
     }
+}
+
+fn is_mobile_connection_type(connection_type: Option<&str>) -> bool {
+    matches!(connection_type, Some("gsm") | Some("cdma"))
 }
 
 impl CosmicNetworkApplet {
@@ -865,6 +897,11 @@ impl CosmicNetworkApplet {
             return;
         }
 
+        if let Some(modem) = self.active_mobile_modem() {
+            self.icon_name = modem.signal_icon().to_owned();
+            return;
+        }
+
         self.icon_name = self
             .nm_state
             .nm_state
@@ -892,6 +929,40 @@ impl CosmicNetworkApplet {
         if self.nm_state.nm_state.airplane_mode != state.airplane_mode {
             self.nm_state.nm_state.airplane_mode = state.airplane_mode;
         }
+
+        if self.nm_state.nm_state.wwan_enabled != state.wwan_enabled {
+            self.nm_state.nm_state.wwan_enabled = state.wwan_enabled;
+        }
+
+        if self.nm_state.nm_state.wwan_available != state.wwan_available {
+            self.nm_state.nm_state.wwan_available = state.wwan_available;
+        }
+    }
+
+    fn active_mobile_modem(&self) -> Option<&modem::Status> {
+        let active_interface = self.nm_state.nm_state.active_conns.iter().find_map(|connection| {
+            let ActiveConnectionInfo::Mobile { interface, .. } = connection else {
+                return None;
+            };
+            interface.as_deref()
+        })?;
+
+        self.nm_state
+            .modems
+            .iter()
+            .find(|modem| modem.interface == active_interface)
+            .or_else(|| (self.nm_state.modems.len() == 1).then(|| self.nm_state.modems.first())?)
+    }
+
+    fn modem_for_interface(&self, interface: Option<&str>) -> Option<&modem::Status> {
+        interface
+            .and_then(|interface| {
+                self.nm_state
+                    .modems
+                    .iter()
+                    .find(|modem| modem.interface == interface)
+            })
+            .or_else(|| (self.nm_state.modems.len() == 1).then(|| self.nm_state.modems.first())?)
     }
 
     fn view_window_return<'a>(
@@ -929,6 +1000,47 @@ impl CosmicNetworkApplet {
             }
         })
         .map(cosmic::Action::App)
+    }
+
+    fn mobile_applet_view(&self, modem: &modem::Status) -> Element<'_, Message> {
+        let suggested_size = self.core.applet.suggested_size(true);
+        let applet_padding = self.core.applet.suggested_padding(true);
+        let (horizontal_padding, vertical_padding) = if self.core.applet.is_horizontal() {
+            (applet_padding.0, applet_padding.1)
+        } else {
+            (applet_padding.1, applet_padding.0)
+        };
+
+        let signal = icon::from_name(modem.signal_icon())
+            .size(suggested_size.0)
+            .symbolic(true);
+        let technology = self
+            .core
+            .applet
+            .text(modem.technology.label())
+            .height(Length::Fixed(suggested_size.1 as f32))
+            .align_y(Alignment::Center);
+        let content: Element<'_, Message> = if self.core.applet.is_horizontal() {
+            row::with_children([signal.into(), technology.into()])
+                .spacing(applet_padding.1)
+                .align_y(Alignment::Center)
+                .into()
+        } else {
+            column::with_children([signal.into(), technology.into()])
+                .spacing(applet_padding.1)
+                .align_x(Alignment::Center)
+                .into()
+        };
+
+        self.core
+            .applet
+            .autosize_window(
+                button::custom(content)
+                    .on_press_down(Message::TogglePopup)
+                    .class(theme::Button::AppletIcon)
+                    .padding([vertical_padding, horizontal_padding]),
+            )
+            .into()
     }
 }
 
@@ -1052,6 +1164,8 @@ pub(crate) enum Message {
     },
     /// An error occurred.
     Error(String),
+    /// A ModemManager update with mobile technology and signal quality.
+    ModemStatus(Vec<modem::Status>),
     /// Identity update from the dialog
     IdentityUpdate(String),
     /// An update from NetworkManager.
@@ -1062,6 +1176,8 @@ pub(crate) enum Message {
     Snapshot(AppletSnapshot),
     /// Toggle WiFi access
     WiFiEnable(bool),
+    /// Toggle mobile broadband access.
+    WWANEnable(bool),
     /// Refresh state
     Refresh,
     ToggleVPNPasswordVisibility,
@@ -1099,6 +1215,7 @@ impl cosmic::Application for CosmicNetworkApplet {
             Task::batch(vec![
                 snapshot_task(),
                 network_events_task(),
+                modem::events_task(),
                 secret_agent_task(my_id, secret_agent_reregister_rx).map(Message::SecretAgent),
             ])
             .map(cosmic::Action::App),
@@ -1396,7 +1513,8 @@ impl cosmic::Application for CosmicNetworkApplet {
                             | ActiveConnectionInfo::WiFi { hw_address, .. } => {
                                 HwAddress::from_str(hw_address).unwrap_or_default()
                             }
-                            ActiveConnectionInfo::Vpn { .. } => HwAddress::default(),
+                            ActiveConnectionInfo::Mobile { .. }
+                            | ActiveConnectionInfo::Vpn { .. } => HwAddress::default(),
                         };
                         c.name() == ssid.as_ref() && c_hw_address == hw_address
                     })
@@ -1416,6 +1534,10 @@ impl cosmic::Application for CosmicNetworkApplet {
             }
             Message::Error(error) => {
                 tracing::error!("error: {error:?}")
+            }
+            Message::ModemStatus(statuses) => {
+                self.nm_state.modems = statuses;
+                self.update_icon_name();
             }
             Message::IdentityUpdate(new_identity) => {
                 if let Some(NewConnectionState::EnterPassword { identity, .. }) =
@@ -1473,6 +1595,19 @@ impl cosmic::Application for CosmicNetworkApplet {
                         Ok(nm) => match nm.set_wireless_enabled(enable).await {
                             Ok(()) => Message::Refresh,
                             Err(e) => Message::Error(format!("set_wireless_enabled: {e}")),
+                        },
+                        Err(e) => Message::Error(format!("nmrs init: {e}")),
+                    }
+                })
+                .map(cosmic::Action::App);
+            }
+            Message::WWANEnable(enable) => {
+                self.nm_state.nm_state.wwan_enabled = enable;
+                return cosmic::task::future(async move {
+                    match NmrsManager::new().await {
+                        Ok(nm) => match nm.set_wwan_enabled(enable).await {
+                            Ok(()) => Message::Refresh,
+                            Err(e) => Message::Error(format!("set_wwan_enabled: {e}")),
                         },
                         Err(e) => Message::Error(format!("nmrs init: {e}")),
                     }
@@ -1614,6 +1749,10 @@ impl cosmic::Application for CosmicNetworkApplet {
     }
 
     fn view(&self) -> Element<'_, Message> {
+        if let Some(modem) = self.active_mobile_modem() {
+            return self.mobile_applet_view(modem);
+        }
+
         self.core
             .applet
             .icon_button(&self.icon_name)
@@ -1631,6 +1770,77 @@ impl cosmic::Application for CosmicNetworkApplet {
         let mut known_wifi = Vec::new();
         for conn in &self.nm_state.nm_state.active_conns {
             match conn {
+                ActiveConnectionInfo::Mobile {
+                    name,
+                    interface,
+                    ip4_address,
+                    ip6_address,
+                    state,
+                } => {
+                    if self.active_device.is_some() {
+                        continue;
+                    }
+                    let modem = self.modem_for_interface(interface.as_deref());
+                    let technology = modem
+                        .map(|modem| modem.technology.label())
+                        .unwrap_or("Mobile");
+                    let signal = modem.and_then(|modem| modem.signal_quality);
+                    let mut info_col = vec![text::body(name).into()];
+                    info_col.push(
+                        text(match signal {
+                            Some(signal) => format!("{technology} · {signal}%"),
+                            None => technology.to_owned(),
+                        })
+                        .size(12)
+                        .into(),
+                    );
+                    info_col.extend(ip_address_elements(ip4_address, ip6_address));
+
+                    let mut right_column = Vec::with_capacity(1);
+                    match state {
+                        ActiveConnectionState::Activating | ActiveConnectionState::Deactivating => {
+                            right_column.push(indeterminate_circular().size(24.0).into());
+                        }
+                        ActiveConnectionState::Activated => {
+                            right_column.push(text::body(fl!("connected")).into());
+                        }
+                        _ => {}
+                    }
+
+                    vpn_ethernet_col = vpn_ethernet_col
+                        .push(
+                            column::with_capacity(2).push(
+                                row::with_children([
+                                    Element::from(
+                                        icon::icon(
+                                            icon::from_name(
+                                                modem
+                                                    .map(modem::Status::signal_icon)
+                                                    .unwrap_or(
+                                                        "network-cellular-connected-symbolic",
+                                                    ),
+                                            )
+                                            .symbolic(true)
+                                            .into(),
+                                        )
+                                        .size(40),
+                                    ),
+                                    column::with_children(info_col).into(),
+                                    column::with_children(right_column)
+                                        .width(Length::Fill)
+                                        .align_x(Alignment::End)
+                                        .into(),
+                                ])
+                                .align_y(Alignment::Center)
+                                .spacing(8)
+                                .padding(menu_control_padding()),
+                            ),
+                        )
+                        .push(
+                            padded_control(divider::horizontal::default())
+                                .padding([space_xxs, space_s]),
+                        );
+                }
                 ActiveConnectionInfo::Vpn {
                     name,
                     ip4_address,
@@ -1862,6 +2072,19 @@ impl cosmic::Application for CosmicNetworkApplet {
                         .width(Length::Fill),
                 ))
                 .align_x(Alignment::Center);
+
+            if self.nm_state.nm_state.wwan_available {
+                content = content.push(
+                    padded_control(
+                        toggler(self.nm_state.nm_state.wwan_enabled)
+                            .label(fl!("mobile-broadband"))
+                            .on_toggle(Message::WWANEnable)
+                            .text_size(14)
+                            .width(Length::Fill),
+                    )
+                    .align_x(Alignment::Center),
+                );
+            }
         }
         if self.nm_state.nm_state.airplane_mode {
             content = content.push(
@@ -2277,6 +2500,8 @@ fn active_conn_hw_address(conn: &ActiveConnectionInfo) -> HwAddress {
         | ActiveConnectionInfo::WiFi { hw_address, .. } => {
             HwAddress::from_str(hw_address).unwrap_or_default()
         }
-        ActiveConnectionInfo::Vpn { .. } => HwAddress::default(),
+        ActiveConnectionInfo::Mobile { .. } | ActiveConnectionInfo::Vpn { .. } => {
+            HwAddress::default()
+        }
     }
 }

--- a/cosmic-applet-network/src/lib.rs
+++ b/cosmic-applet-network/src/lib.rs
@@ -3,6 +3,7 @@
 mod app;
 mod config;
 mod localize;
+mod modem;
 
 use crate::localize::localize;
 

--- a/cosmic-applet-network/src/modem.rs
+++ b/cosmic-applet-network/src/modem.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! ModemManager integration for mobile broadband state shown by the network applet.
+
+use futures::StreamExt;
+use zbus::{Connection, fdo::ObjectManagerProxy, proxy};
+
+const MODEM_MANAGER_SERVICE: &str = "org.freedesktop.ModemManager1";
+const MODEM_MANAGER_PATH: &str = "/org/freedesktop/ModemManager1";
+const MODEM_INTERFACE: &str = "org.freedesktop.ModemManager1.Modem";
+
+// `MMModemAccessTechnology` bit flags from ModemManager's public D-Bus API.
+const ACCESS_TECHNOLOGY_GPRS: u32 = 1 << 0;
+const ACCESS_TECHNOLOGY_EDGE: u32 = 1 << 1;
+const ACCESS_TECHNOLOGY_UMTS: u32 = 1 << 2;
+const ACCESS_TECHNOLOGY_HSDPA: u32 = 1 << 3;
+const ACCESS_TECHNOLOGY_HSUPA: u32 = 1 << 4;
+const ACCESS_TECHNOLOGY_HSPA: u32 = 1 << 5;
+const ACCESS_TECHNOLOGY_HSPA_PLUS: u32 = 1 << 6;
+const ACCESS_TECHNOLOGY_LTE: u32 = 1 << 14;
+const ACCESS_TECHNOLOGY_5GNR: u32 = 1 << 15;
+const ACCESS_TECHNOLOGY_5GNR_MMWAVE: u32 = 1 << 16;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Technology {
+    #[default]
+    Unknown,
+    TwoG,
+    ThreeG,
+    FourG,
+    FiveG,
+}
+
+impl Technology {
+    #[must_use]
+    pub fn from_access_technologies(access_technologies: u32) -> Self {
+        if access_technologies & (ACCESS_TECHNOLOGY_5GNR | ACCESS_TECHNOLOGY_5GNR_MMWAVE) != 0 {
+            Self::FiveG
+        } else if access_technologies & ACCESS_TECHNOLOGY_LTE != 0 {
+            Self::FourG
+        } else if access_technologies
+            & (ACCESS_TECHNOLOGY_UMTS
+                | ACCESS_TECHNOLOGY_HSDPA
+                | ACCESS_TECHNOLOGY_HSUPA
+                | ACCESS_TECHNOLOGY_HSPA
+                | ACCESS_TECHNOLOGY_HSPA_PLUS)
+            != 0
+        {
+            Self::ThreeG
+        } else if access_technologies & (ACCESS_TECHNOLOGY_GPRS | ACCESS_TECHNOLOGY_EDGE) != 0 {
+            Self::TwoG
+        } else {
+            Self::Unknown
+        }
+    }
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Unknown => "Mobile",
+            Self::TwoG => "2G",
+            Self::ThreeG => "3G",
+            Self::FourG => "4G",
+            Self::FiveG => "5G",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Status {
+    /// Network interface exposed by ModemManager, e.g. `wwan0mbim0`.
+    pub interface: String,
+    pub technology: Technology,
+    /// Percentage reported by ModemManager. `None` means no recent measurement.
+    pub signal_quality: Option<u8>,
+}
+
+impl Status {
+    #[must_use]
+    pub fn signal_icon(&self) -> &'static str {
+        match self.signal_quality.unwrap_or_default() {
+            0 => "network-cellular-signal-none-symbolic",
+            1..=24 => "network-cellular-signal-weak-symbolic",
+            25..=49 => "network-cellular-signal-ok-symbolic",
+            50..=74 => "network-cellular-signal-good-symbolic",
+            _ => "network-cellular-signal-excellent-symbolic",
+        }
+    }
+}
+
+#[proxy(
+    interface = "org.freedesktop.ModemManager1.Modem",
+    default_service = "org.freedesktop.ModemManager1"
+)]
+trait Modem {
+    #[zbus(property, name = "AccessTechnologies")]
+    fn access_technologies(&self) -> zbus::Result<u32>;
+
+    #[zbus(property, name = "PrimaryPort")]
+    fn primary_port(&self) -> zbus::Result<String>;
+
+    #[zbus(property, name = "SignalQuality")]
+    fn signal_quality(&self) -> zbus::Result<(u32, bool)>;
+
+    #[zbus(property, name = "State")]
+    fn state(&self) -> zbus::Result<i32>;
+}
+
+/// Subscribes to ModemManager property and object lifecycle changes. A new
+/// status is emitted immediately and every time signal strength, radio access
+/// technology, or the set of available modems changes.
+pub fn events_task() -> cosmic::Task<crate::app::Message> {
+    cosmic::Task::stream(async_fn_stream::fn_stream(|emitter| async move {
+        let connection = match Connection::system().await {
+            Ok(connection) => connection,
+            Err(error) => {
+                let _ = emitter
+                    .emit(Err(format!("connect to ModemManager: {error}")))
+                    .await;
+                return;
+            }
+        };
+
+        let manager = match ObjectManagerProxy::builder(&connection)
+            .destination(MODEM_MANAGER_SERVICE)
+            .and_then(|builder| builder.path(MODEM_MANAGER_PATH))
+        {
+            Ok(builder) => match builder.build().await {
+                Ok(manager) => manager,
+                Err(error) => {
+                    let _ = emitter
+                        .emit(Err(format!("connect to ModemManager: {error}")))
+                        .await;
+                    return;
+                }
+            },
+            Err(error) => {
+                let _ = emitter
+                    .emit(Err(format!("build ModemManager proxy: {error}")))
+                    .await;
+                return;
+            }
+        };
+
+        let mut interfaces_added = match manager.receive_interfaces_added().await {
+            Ok(stream) => stream,
+            Err(error) => {
+                let _ = emitter
+                    .emit(Err(format!("watch ModemManager devices: {error}")))
+                    .await;
+                return;
+            }
+        };
+        let mut interfaces_removed = match manager.receive_interfaces_removed().await {
+            Ok(stream) => stream,
+            Err(error) => {
+                let _ = emitter
+                    .emit(Err(format!("watch ModemManager devices: {error}")))
+                    .await;
+                return;
+            }
+        };
+
+        loop {
+            let paths = match modem_paths(&manager).await {
+                Ok(paths) => paths,
+                Err(error) => {
+                    let _ = emitter.emit(Err(error)).await;
+                    return;
+                }
+            };
+
+            match read_statuses(&connection, &paths).await {
+                Ok(statuses) => {
+                    emitter.emit(Ok(statuses)).await;
+                }
+                Err(error) => {
+                    emitter.emit(Err(error)).await;
+                }
+            }
+
+            let Some(path) = paths.first() else {
+                tokio::select! {
+                    _ = interfaces_added.next() => {},
+                    _ = interfaces_removed.next() => {},
+                }
+                continue;
+            };
+
+            let proxy = match ModemProxy::builder(&connection).path(path.as_str()) {
+                Ok(builder) => match builder.build().await {
+                    Ok(proxy) => proxy,
+                    Err(error) => {
+                        let _ = emitter
+                            .emit(Err(format!("watch modem properties: {error}")))
+                            .await;
+                        return;
+                    }
+                },
+                Err(error) => {
+                    let _ = emitter
+                        .emit(Err(format!("build modem proxy: {error}")))
+                        .await;
+                    return;
+                }
+            };
+
+            let (mut technologies, mut signal_quality, mut state) = (
+                proxy.receive_access_technologies_changed().await.skip(1),
+                proxy.receive_signal_quality_changed().await.skip(1),
+                proxy.receive_state_changed().await.skip(1),
+            );
+
+            tokio::select! {
+                _ = technologies.next() => {},
+                _ = signal_quality.next() => {},
+                _ = state.next() => {},
+                _ = interfaces_added.next() => {},
+                _ = interfaces_removed.next() => {},
+            }
+        }
+    }))
+    .map(|status| match status {
+        Ok(status) => crate::app::Message::ModemStatus(status),
+        Err(error) => crate::app::Message::Error(error),
+    })
+}
+
+async fn modem_paths(manager: &ObjectManagerProxy<'_>) -> Result<Vec<String>, String> {
+    let objects = manager
+        .get_managed_objects()
+        .await
+        .map_err(|error| format!("enumerate ModemManager devices: {error}"))?;
+
+    let mut paths = objects
+        .into_iter()
+        .filter(|(_, interfaces)| interfaces.contains_key(MODEM_INTERFACE))
+        .map(|(path, _)| path.to_string())
+        .collect::<Vec<_>>();
+    paths.sort();
+    Ok(paths)
+}
+
+async fn read_statuses(connection: &Connection, paths: &[String]) -> Result<Vec<Status>, String> {
+    let mut statuses = Vec::with_capacity(paths.len());
+    for path in paths {
+        let proxy = ModemProxy::builder(connection)
+            .path(path.as_str())
+            .map_err(|error| format!("build modem proxy: {error}"))?
+            .build()
+            .await
+            .map_err(|error| format!("read modem properties: {error}"))?;
+        let (interface, access_technologies, signal_quality) = futures::join!(
+            proxy.primary_port(),
+            proxy.access_technologies(),
+            proxy.signal_quality(),
+        );
+        let (signal_quality, recent) = signal_quality
+            .map_err(|error| format!("read modem signal quality: {error}"))?;
+        statuses.push(Status {
+            interface: interface.map_err(|error| format!("read modem interface: {error}"))?,
+            technology: Technology::from_access_technologies(
+                access_technologies
+                    .map_err(|error| format!("read modem access technology: {error}"))?,
+            ),
+            signal_quality: recent.then_some(signal_quality.min(100) as u8),
+        });
+    }
+    Ok(statuses)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn favors_5g_when_lte_and_5g_are_reported_together() {
+        assert_eq!(
+            Technology::from_access_technologies(ACCESS_TECHNOLOGY_LTE | ACCESS_TECHNOLOGY_5GNR),
+            Technology::FiveG
+        );
+    }
+
+    #[test]
+    fn maps_signal_quality_to_standard_icon_levels() {
+        let status = |signal_quality| Status {
+            signal_quality,
+            ..Status::default()
+        };
+        assert_eq!(status(Some(24)).signal_icon(), "network-cellular-signal-weak-symbolic");
+        assert_eq!(status(Some(25)).signal_icon(), "network-cellular-signal-ok-symbolic");
+        assert_eq!(status(Some(75)).signal_icon(), "network-cellular-signal-excellent-symbolic");
+    }
+}

--- a/cosmic-applet-network/src/modem.rs
+++ b/cosmic-applet-network/src/modem.rs
@@ -2,6 +2,8 @@
 
 //! ModemManager integration for mobile broadband state shown by the network applet.
 
+use std::time::Duration;
+
 use futures::StreamExt;
 use zbus::{Connection, fdo::ObjectManagerProxy, proxy};
 
@@ -102,13 +104,12 @@ trait Modem {
     #[zbus(property, name = "SignalQuality")]
     fn signal_quality(&self) -> zbus::Result<(u32, bool)>;
 
-    #[zbus(property, name = "State")]
-    fn state(&self) -> zbus::Result<i32>;
 }
 
-/// Subscribes to ModemManager property and object lifecycle changes. A new
-/// status is emitted immediately and every time signal strength, radio access
-/// technology, or the set of available modems changes.
+/// Subscribes to ModemManager lifecycle changes and refreshes all modem
+/// properties at a short fixed interval. Polling avoids subscribing only to
+/// the first modem when more than one is present, while still keeping signal
+/// and radio-technology updates close to real time.
 pub fn events_task() -> cosmic::Task<crate::app::Message> {
     cosmic::Task::stream(async_fn_stream::fn_stream(|emitter| async move {
         let connection = match Connection::system().await {
@@ -179,42 +180,8 @@ pub fn events_task() -> cosmic::Task<crate::app::Message> {
                 }
             }
 
-            let Some(path) = paths.first() else {
-                tokio::select! {
-                    _ = interfaces_added.next() => {},
-                    _ = interfaces_removed.next() => {},
-                }
-                continue;
-            };
-
-            let proxy = match ModemProxy::builder(&connection).path(path.as_str()) {
-                Ok(builder) => match builder.build().await {
-                    Ok(proxy) => proxy,
-                    Err(error) => {
-                        let _ = emitter
-                            .emit(Err(format!("watch modem properties: {error}")))
-                            .await;
-                        return;
-                    }
-                },
-                Err(error) => {
-                    let _ = emitter
-                        .emit(Err(format!("build modem proxy: {error}")))
-                        .await;
-                    return;
-                }
-            };
-
-            let (mut technologies, mut signal_quality, mut state) = (
-                proxy.receive_access_technologies_changed().await.skip(1),
-                proxy.receive_signal_quality_changed().await.skip(1),
-                proxy.receive_state_changed().await.skip(1),
-            );
-
             tokio::select! {
-                _ = technologies.next() => {},
-                _ = signal_quality.next() => {},
-                _ = state.next() => {},
+                _ = tokio::time::sleep(Duration::from_secs(2)) => {},
                 _ = interfaces_added.next() => {},
                 _ = interfaces_removed.next() => {},
             }
@@ -243,30 +210,43 @@ async fn modem_paths(manager: &ObjectManagerProxy<'_>) -> Result<Vec<String>, St
 
 async fn read_statuses(connection: &Connection, paths: &[String]) -> Result<Vec<Status>, String> {
     let mut statuses = Vec::with_capacity(paths.len());
+    let mut last_error = None;
     for path in paths {
-        let proxy = ModemProxy::builder(connection)
-            .path(path.as_str())
-            .map_err(|error| format!("build modem proxy: {error}"))?
-            .build()
-            .await
-            .map_err(|error| format!("read modem properties: {error}"))?;
-        let (interface, access_technologies, signal_quality) = futures::join!(
-            proxy.primary_port(),
-            proxy.access_technologies(),
-            proxy.signal_quality(),
-        );
-        let (signal_quality, recent) = signal_quality
-            .map_err(|error| format!("read modem signal quality: {error}"))?;
-        statuses.push(Status {
-            interface: interface.map_err(|error| format!("read modem interface: {error}"))?,
-            technology: Technology::from_access_technologies(
-                access_technologies
-                    .map_err(|error| format!("read modem access technology: {error}"))?,
-            ),
-            signal_quality: recent.then_some(signal_quality.min(100) as u8),
-        });
+        match read_status(connection, path).await {
+            Ok(status) => statuses.push(status),
+            Err(error) => last_error = Some(error),
+        }
     }
+
+    if statuses.is_empty() {
+        return last_error.map_or_else(|| Ok(statuses), Err);
+    }
+
     Ok(statuses)
+}
+
+async fn read_status(connection: &Connection, path: &str) -> Result<Status, String> {
+    let proxy = ModemProxy::builder(connection)
+        .path(path)
+        .map_err(|error| format!("build modem proxy: {error}"))?
+        .build()
+        .await
+        .map_err(|error| format!("read modem properties: {error}"))?;
+    let (interface, access_technologies, signal_quality) = futures::join!(
+        proxy.primary_port(),
+        proxy.access_technologies(),
+        proxy.signal_quality(),
+    );
+    let (signal_quality, recent) = signal_quality
+        .map_err(|error| format!("read modem signal quality: {error}"))?;
+
+    Ok(Status {
+        interface: interface.map_err(|error| format!("read modem interface: {error}"))?,
+        technology: Technology::from_access_technologies(
+            access_technologies.map_err(|error| format!("read modem access technology: {error}"))?,
+        ),
+        signal_quality: recent.then_some(signal_quality.min(100) as u8),
+    })
 }
 
 #[cfg(test)]
@@ -282,6 +262,26 @@ mod tests {
     }
 
     #[test]
+    fn classifies_each_supported_radio_generation() {
+        assert_eq!(
+            Technology::from_access_technologies(ACCESS_TECHNOLOGY_GPRS),
+            Technology::TwoG
+        );
+        assert_eq!(
+            Technology::from_access_technologies(ACCESS_TECHNOLOGY_HSPA_PLUS),
+            Technology::ThreeG
+        );
+        assert_eq!(
+            Technology::from_access_technologies(ACCESS_TECHNOLOGY_LTE),
+            Technology::FourG
+        );
+        assert_eq!(
+            Technology::from_access_technologies(ACCESS_TECHNOLOGY_5GNR_MMWAVE),
+            Technology::FiveG
+        );
+    }
+
+    #[test]
     fn maps_signal_quality_to_standard_icon_levels() {
         let status = |signal_quality| Status {
             signal_quality,
@@ -290,5 +290,6 @@ mod tests {
         assert_eq!(status(Some(24)).signal_icon(), "network-cellular-signal-weak-symbolic");
         assert_eq!(status(Some(25)).signal_icon(), "network-cellular-signal-ok-symbolic");
         assert_eq!(status(Some(75)).signal_icon(), "network-cellular-signal-excellent-symbolic");
+        assert_eq!(status(None).signal_icon(), "network-cellular-signal-none-symbolic");
     }
 }

--- a/cosmic-applet-network/src/modem.rs
+++ b/cosmic-applet-network/src/modem.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! ModemManager integration for mobile broadband state shown by the network applet.
+//! `ModemManager` integration for mobile broadband state shown by the network applet.
 
 use std::time::Duration;
 
@@ -70,10 +70,10 @@ impl Technology {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Status {
-    /// Network interface exposed by ModemManager, e.g. `wwan0mbim0`.
+    /// Network interface exposed by `ModemManager`, e.g. `wwan0mbim0`.
     pub interface: String,
     pub technology: Technology,
-    /// Percentage reported by ModemManager. `None` means no recent measurement.
+    /// Percentage reported by `ModemManager`. `None` means no recent measurement.
     pub signal_quality: Option<u8>,
 }
 
@@ -103,10 +103,9 @@ trait Modem {
 
     #[zbus(property, name = "SignalQuality")]
     fn signal_quality(&self) -> zbus::Result<(u32, bool)>;
-
 }
 
-/// Subscribes to ModemManager lifecycle changes and refreshes all modem
+/// Subscribes to `ModemManager` lifecycle changes and refreshes all modem
 /// properties at a short fixed interval. Polling avoids subscribing only to
 /// the first modem when more than one is present, while still keeping signal
 /// and radio-technology updates close to real time.
@@ -115,7 +114,7 @@ pub fn events_task() -> cosmic::Task<crate::app::Message> {
         let connection = match Connection::system().await {
             Ok(connection) => connection,
             Err(error) => {
-                let _ = emitter
+                let () = emitter
                     .emit(Err(format!("connect to ModemManager: {error}")))
                     .await;
                 return;
@@ -129,14 +128,14 @@ pub fn events_task() -> cosmic::Task<crate::app::Message> {
             Ok(builder) => match builder.build().await {
                 Ok(manager) => manager,
                 Err(error) => {
-                    let _ = emitter
+                    let () = emitter
                         .emit(Err(format!("connect to ModemManager: {error}")))
                         .await;
                     return;
                 }
             },
             Err(error) => {
-                let _ = emitter
+                let () = emitter
                     .emit(Err(format!("build ModemManager proxy: {error}")))
                     .await;
                 return;
@@ -146,7 +145,7 @@ pub fn events_task() -> cosmic::Task<crate::app::Message> {
         let mut interfaces_added = match manager.receive_interfaces_added().await {
             Ok(stream) => stream,
             Err(error) => {
-                let _ = emitter
+                let () = emitter
                     .emit(Err(format!("watch ModemManager devices: {error}")))
                     .await;
                 return;
@@ -155,7 +154,7 @@ pub fn events_task() -> cosmic::Task<crate::app::Message> {
         let mut interfaces_removed = match manager.receive_interfaces_removed().await {
             Ok(stream) => stream,
             Err(error) => {
-                let _ = emitter
+                let () = emitter
                     .emit(Err(format!("watch ModemManager devices: {error}")))
                     .await;
                 return;
@@ -166,7 +165,7 @@ pub fn events_task() -> cosmic::Task<crate::app::Message> {
             let paths = match modem_paths(&manager).await {
                 Ok(paths) => paths,
                 Err(error) => {
-                    let _ = emitter.emit(Err(error)).await;
+                    let () = emitter.emit(Err(error)).await;
                     return;
                 }
             };
@@ -181,7 +180,7 @@ pub fn events_task() -> cosmic::Task<crate::app::Message> {
             }
 
             tokio::select! {
-                _ = tokio::time::sleep(Duration::from_secs(2)) => {},
+                () = tokio::time::sleep(Duration::from_secs(2)) => {},
                 _ = interfaces_added.next() => {},
                 _ = interfaces_removed.next() => {},
             }
@@ -237,13 +236,14 @@ async fn read_status(connection: &Connection, path: &str) -> Result<Status, Stri
         proxy.access_technologies(),
         proxy.signal_quality(),
     );
-    let (signal_quality, recent) = signal_quality
-        .map_err(|error| format!("read modem signal quality: {error}"))?;
+    let (signal_quality, recent) =
+        signal_quality.map_err(|error| format!("read modem signal quality: {error}"))?;
 
     Ok(Status {
         interface: interface.map_err(|error| format!("read modem interface: {error}"))?,
         technology: Technology::from_access_technologies(
-            access_technologies.map_err(|error| format!("read modem access technology: {error}"))?,
+            access_technologies
+                .map_err(|error| format!("read modem access technology: {error}"))?,
         ),
         signal_quality: recent.then_some(signal_quality.min(100) as u8),
     })
@@ -287,9 +287,21 @@ mod tests {
             signal_quality,
             ..Status::default()
         };
-        assert_eq!(status(Some(24)).signal_icon(), "network-cellular-signal-weak-symbolic");
-        assert_eq!(status(Some(25)).signal_icon(), "network-cellular-signal-ok-symbolic");
-        assert_eq!(status(Some(75)).signal_icon(), "network-cellular-signal-excellent-symbolic");
-        assert_eq!(status(None).signal_icon(), "network-cellular-signal-none-symbolic");
+        assert_eq!(
+            status(Some(24)).signal_icon(),
+            "network-cellular-signal-weak-symbolic"
+        );
+        assert_eq!(
+            status(Some(25)).signal_icon(),
+            "network-cellular-signal-ok-symbolic"
+        );
+        assert_eq!(
+            status(Some(75)).signal_icon(),
+            "network-cellular-signal-excellent-symbolic"
+        );
+        assert_eq!(
+            status(None).signal_icon(),
+            "network-cellular-signal-none-symbolic"
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR adds mobile broadband status to the COSMIC network applet, so cellular connectivity is visible from the top-right panel without opening Settings.

It adds:

- a cellular connection entry in the network applet;
- a connection-type indicator for the active cellular data session, including 4G/LTE and 5G/NR;
- live signal-strength updates;
- handling for disconnects and refreshes across all detected mobile modems, rather than keeping stale state from only the first modem.

This is complementary to [pop-os/cosmic-settings#2135](https://github.com/pop-os/cosmic-settings/pull/2135), which provides the dedicated Mobile Broadband settings page, preferred radio modes, cellular diagnostics, and preferred-band selection.

## Validation performed

- compiled and manually tested with a Foxconn/Qualcomm Snapdragon X55 MBIM modem;
- verified the cellular status path while LTE and 5G NR are available;
- formatted the modified applet source.

## Community testing requested

Hardware and carrier coverage would be especially helpful for:

1. LTE-only, 5G NSA, and 5G SA sessions, including transitions between them;
2. modems using QMI, MBIM, and serial/AT ModemManager backends;
3. no modem, modem hot-plug/removal, airplane mode, and cellular disconnect/reconnect;
4. systems with multiple modems, multiple SIMs, or an inactive cellular profile;
5. whether the displayed technology and signal level match the modem and NetworkManager state on different devices.

## Notes

- AI assistance was used while developing this change. The resulting code was reviewed, compiled, and tested locally; maintainer feedback on the preferred contribution workflow is welcome.
- Feedback on using ModemManager directly from the applet, including any preferred COSMIC architecture for this status data, is welcome.