### PR TITLE
Add hibernation to power control options

### DIFF
--- a/cosmic-applet-power/src/lib.rs
+++ b/cosmic-applet-power/src/lib.rs
@@ -21,7 +21,7 @@ use cosmic::{
 use std::sync::LazyLock;
 
 use logind_zbus::{
-    manager::ManagerProxy,
+    manager::{IsSupported, ManagerProxy},
     session::{SessionClass, SessionProxy, SessionType},
     user::UserProxy,
 };
@@ -44,12 +44,26 @@ pub fn run() -> cosmic::iced::Result {
     cosmic::applet::run::<Power>(())
 }
 
+async fn can_hibernate() -> bool {
+    let Ok(connection) = Connection::system().await else {
+        return false;
+    };
+    let Ok(manager_proxy) = ManagerProxy::new(&connection).await else {
+        return false;
+    };
+    matches!(
+        manager_proxy.can_hibernate().await,
+        Ok(IsSupported::Yes | IsSupported::Challenge)
+    )
+}
+
 struct Power {
     core: cosmic::app::Core,
     icon_name: String,
     popup: Option<window::Id>,
     token_tx: Option<calloop::channel::Sender<TokenRequest>>,
     subsurface_id: window::Id,
+    can_hibernate: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -57,6 +71,7 @@ enum PowerAction {
     Lock,
     LogOut,
     Suspend,
+    Hibernate,
     Restart,
     Shutdown,
 }
@@ -68,6 +83,7 @@ impl PowerAction {
             PowerAction::Lock => iced::Task::perform(lock(), msg),
             PowerAction::LogOut => iced::Task::perform(log_out(), msg),
             PowerAction::Suspend => iced::Task::perform(suspend(), msg),
+            PowerAction::Hibernate => iced::Task::perform(hibernate(), msg),
             PowerAction::Restart => iced::Task::perform(restart(), msg),
             PowerAction::Shutdown => iced::Task::perform(shutdown(), msg),
         }
@@ -83,6 +99,7 @@ enum Message {
     Closed(window::Id),
     Token(TokenUpdate),
     Surface(surface::Action),
+    CanHibernate(bool)
 }
 
 impl cosmic::Application for Power {
@@ -107,8 +124,9 @@ impl cosmic::Application for Power {
                 subsurface_id: window::Id::unique(),
                 token_tx: None,
                 popup: Option::default(),
+                can_hibernate: false
             },
-            Task::none(),
+            Task::perform(can_hibernate(), |can_hibernate: bool| cosmic::action::app(Message::CanHibernate(can_hibernate))),
         )
     }
 
@@ -167,6 +185,12 @@ impl cosmic::Application for Power {
                         return PowerAction::Restart.perform();
                     }
                 }
+                PowerAction::Hibernate => {
+                    if let Err(err) = process::Command::new("cosmic-osd").arg("hibernate").spawn() {
+                        tracing::error!("Failed to spawn cosmic-osd. {err:?}");
+                        return PowerAction::Hibernate.perform();
+                    }
+                }
                 PowerAction::Shutdown => {
                     if let Err(err) = process::Command::new("cosmic-osd").arg("shutdown").spawn() {
                         tracing::error!("Failed to spawn cosmic-osd. {err:?}");
@@ -205,6 +229,9 @@ impl cosmic::Application for Power {
                 return cosmic::task::message(cosmic::Action::Cosmic(
                     cosmic::app::Action::Surface(a),
                 ));
+            }
+            Message::CanHibernate(can_hibernate) => {
+                self.can_hibernate = can_hibernate
             }
         }
         Task::none()
@@ -262,6 +289,10 @@ impl cosmic::Application for Power {
                 power_buttons(
                     "system-reboot-symbolic",
                     Message::Action(PowerAction::Restart)
+                ),
+                power_buttons(
+                    "system-hibernate-symbolic",
+                    Message::Action(PowerAction::Hibernate)
                 ),
                 power_buttons(
                     "system-shutdown-symbolic",
@@ -331,6 +362,12 @@ async fn suspend() -> zbus::Result<()> {
     let connection = Connection::system().await?;
     let manager_proxy = ManagerProxy::new(&connection).await?;
     manager_proxy.suspend(true).await
+}
+
+async fn hibernate() -> zbus::Result<()> {
+    let connection = Connection::system().await?;
+    let manager_proxy = ManagerProxy::new(&connection).await?;
+    manager_proxy.hibernate(true).await
 }
 
 async fn lock() -> zbus::Result<()> {

--- a/cosmic-applet-power/src/session_manager.rs
+++ b/cosmic-applet-power/src/session_manager.rs
@@ -31,6 +31,9 @@ pub trait SessionManager {
     /// CanShutdown method
     fn can_shutdown(&self) -> zbus::Result<bool>;
 
+    /// CanHibernate method
+    fn can_hibernate(&self) -> zbus::Result<bool>;
+
     /// GetClients method
     fn get_clients(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedObjectPath>>;
 
@@ -39,6 +42,9 @@ pub trait SessionManager {
 
     /// GetLocale method
     fn get_locale(&self, category: i32) -> zbus::Result<String>;
+
+    /// Hibernate method
+    fn hibernate(&self) -> zbus::Result<()>;
 
     /// Inhibit method
     fn inhibit(


### PR DESCRIPTION
Determine if system hibernation (suspend to disk) is available via systemd-logind. If the system supports hibernation, add a hibernate option to the power control applet alongside standard sleep, reboot, poweroff.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

