### PR TITLE
feat(bluetooth): show bluetooth alias name

### DIFF
--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -287,10 +287,11 @@ impl BluerDevice {
                 .icon()
                 .map(|res| device_type_to_icon(&res.ok().flatten().unwrap_or_default()))
         );
+        let address_string = device.address().to_string();
         let name = alias
-            .filter(|name| !name.is_empty())
+            .filter(|name| !name.is_empty() && *name != address_string.replace(':', "-"))
             .or(name.filter(|name| !name.is_empty()))
-            .unwrap_or_else(|| device.address().to_string());
+            .unwrap_or(address_string);
 
         let status = if is_connected {
             BluerDeviceStatus::Connected

--- a/cosmic-applet-bluetooth/src/bluetooth.rs
+++ b/cosmic-applet-bluetooth/src/bluetooth.rs
@@ -276,10 +276,9 @@ const DEFAULT_DEVICE_ICON: &str = "bluetooth-symbolic";
 impl BluerDevice {
     #[inline(never)]
     pub async fn from_device(device: &bluer::Device) -> Self {
-        let (mut name, is_paired, is_trusted, is_connected, battery_percent, icon) = futures::join!(
-            device
-                .name()
-                .map(|res| res.ok().flatten().unwrap_or(device.address().to_string())),
+        let (alias, name, is_paired, is_trusted, is_connected, battery_percent, icon) = futures::join!(
+            device.alias().map(|res| res.ok()),
+            device.name().map(|res| res.ok().flatten()),
             device.is_paired().map(Result::unwrap_or_default),
             device.is_trusted().map(Result::unwrap_or_default),
             device.is_connected().map(Result::unwrap_or_default),
@@ -288,10 +287,10 @@ impl BluerDevice {
                 .icon()
                 .map(|res| device_type_to_icon(&res.ok().flatten().unwrap_or_default()))
         );
-
-        if name.is_empty() {
-            name = device.address().to_string();
-        }
+        let name = alias
+            .filter(|name| !name.is_empty())
+            .or(name.filter(|name| !name.is_empty()))
+            .unwrap_or_else(|| device.address().to_string());
 
         let status = if is_connected {
             BluerDeviceStatus::Connected


### PR DESCRIPTION
This PR change the main display string of the bluetooth applet to show the alias name first (if exists), falling back to the existing logic(name/address) when empty.
This is complementary of [Cosmic Settings Feat](https://github.com/pop-os/cosmic-settings/pull/2160)


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

