### PR TITLE
fix(network) fix vpn dropdown reflow

### DIFF
--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -1631,49 +1631,9 @@ impl cosmic::Application for CosmicNetworkApplet {
         let mut known_wifi = Vec::new();
         for conn in &self.nm_state.nm_state.active_conns {
             match conn {
-                ActiveConnectionInfo::Vpn {
-                    name,
-                    ip4_address,
-                    ip6_address,
-                } => {
-                    if self.active_device.as_ref().is_some_and(|d| {
-                        d.active_connection.as_ref().is_none_or(|a| a.0.id != *name)
-                    }) {
-                        continue;
-                    }
-                    let mut info_col = Vec::with_capacity(3);
-                    info_col.push(text::body(name).into());
-                    for elem in ip_address_elements(ip4_address, ip6_address) {
-                        info_col.push(elem);
-                    }
-                    vpn_ethernet_col = vpn_ethernet_col.push(
-                        column::with_capacity::<Message, cosmic::Theme, _>(2)
-                            .push(
-                                row::with_children([
-                                    Element::from(
-                                        icon::icon(
-                                            icon::from_name("network-vpn-symbolic")
-                                                .symbolic(true)
-                                                .into(),
-                                        )
-                                        .size(40),
-                                    ),
-                                    column::with_children(info_col).into(),
-                                    text::body(fl!("connected"))
-                                        .width(Length::Fill)
-                                        .align_x(Alignment::End)
-                                        .into(),
-                                ])
-                                .align_y(Alignment::Center)
-                                .spacing(8)
-                                .padding(menu_control_padding()),
-                            )
-                            .push(
-                                padded_control(divider::horizontal::default())
-                                    .padding([space_xxs, space_s]),
-                            ),
-                    );
-                }
+                // Active VPNs are rendered inline in `vpn_section`, not as a
+                // large panel at the top of the popup.
+                ActiveConnectionInfo::Vpn { .. } => continue,
                 ActiveConnectionInfo::Wired {
                     name,
                     hw_address: _,

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -431,22 +431,35 @@ fn vpn_section<'a>(
                         id.as_str()
                     }
                 };
-                // Check if this VPN is currently active
-                let is_active = nm_state.nm_state.active_conns.iter().any(
-                    |conn| matches!(conn, ActiveConnectionInfo::Vpn { name, .. } if name == id),
-                );
+                // Check if this VPN is currently active, and if so grab its IP addresses
+                let active_vpn = nm_state.nm_state.active_conns.iter().find_map(|conn| {
+                    if let ActiveConnectionInfo::Vpn { name, ip4_address, ip6_address } = conn {
+                        (name == id).then_some((ip4_address, ip6_address))
+                    } else {
+                        None
+                    }
+                });
+                let is_active = active_vpn.is_some();
                 let pending_action = nm_state
                     .pending_vpn
                     .as_ref()
                     .filter(|pending| pending.uuid.as_ref() == uuid.as_ref())
                     .map(|pending| pending.action);
 
+                let ip_elements = active_vpn
+                    .map(|(ip4, ip6)| ip_address_elements(ip4, ip6))
+                    .unwrap_or_default();
                 let mut btn_content = vec![
                     icon::from_name("network-vpn-symbolic")
                         .size(24)
                         .symbolic(true)
                         .into(),
-                    text::body(id).width(Length::Fill).into(),
+                    column::with_children([
+                        text::body(id).into(),
+                        column::with_children(ip_elements).into(),
+                    ])
+                    .width(Length::Fill)
+                    .into(),
                 ];
 
                 if is_active {
@@ -612,8 +625,12 @@ fn network_events_task() -> Task<Message> {
 
 fn snapshot_to_applet(snapshot: NetworkSnapshot) -> AppletSnapshot {
     let summary = snapshot.applet_summary();
+    // Sort so the VPN list has a stable order across snapshots; iterating
+    // the map directly would reorder the list on every connect/disconnect.
+    let mut saved_vpns: Vec<_> = summary.saved_vpns.values().collect();
+    saved_vpns.sort_by_cached_key(|vpn| (vpn.id.to_lowercase(), vpn.uuid.clone()));
     let mut known_vpns = IndexMap::new();
-    for vpn in summary.saved_vpns.values() {
+    for vpn in saved_vpns {
         let uuid: Uuid = Arc::from(vpn.uuid.as_str());
         let entry = match vpn.kind {
             Some(nmrs::VpnKind::WireGuard) => ConnectionSettings::Wireguard { id: vpn.id.clone() },


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

### Changes
Active VPNs are no longer rendered at the top of the dropdown, this avoids the entire menu to reflow on new connections. The sorting of VPNs is also now stable. Claude code was used for this PR. Closes #1486 

### Current main behavior

https://github.com/user-attachments/assets/2c87202a-4248-40f8-a785-9867a9c96be7

- Random resort flickering
- Reflows on connect/ disconnect
- Loading spinners are inconsistent. E.g. disconnecting spins for a fraction of a second then shows `Connected` then just disappears. Instead of spinning until disconnect happened. Not addressed here.

### This branch


https://github.com/user-attachments/assets/950761e2-4242-4024-b01a-1d56e40674eb


- Removed top level VPN display to avoid reflow
- added IPv4 inline, this causes only minimal reflow, consistent with WiFi section
- fixed ordering issues of VPNs

### New spinner duration/ IP layout.

https://github.com/user-attachments/assets/0f6315c5-475b-49d3-a53c-eeff0dca274d

- As a discussion point: I prototyped how to fix the spinner animation, but it's a bit involved. If there is interest I would get into a reviewable shape.


