### PR TITLE
fix(network): bump nmrs to 3.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "nmrs"
-version = "3.4.0"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c427203beda58ac05815b356d64a34eeb2fba180b3077d543ebb1472fc1269"
+checksum = "aa84a0ad51eda83c8817099a0b613847599c712d049e89d892cca53ed6c4a337"
 dependencies = [
  "async-trait",
  "base64",

--- a/cosmic-applet-network/Cargo.toml
+++ b/cosmic-applet-network/Cargo.toml
@@ -26,4 +26,4 @@ tracing.workspace = true
 indexmap = "2.13.0"
 secure-string = "0.3.0"
 uuid = { version = "1.21.0", features = ["v4"] }
-nmrs = "3.4.0"
+nmrs = "3.5.2"

--- a/cosmic-applet-network/src/app.rs
+++ b/cosmic-applet-network/src/app.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use nmrs::{
-    ActiveConnection, ActiveConnectionState, ConnectType, ConnectivityState, EapOptions,
-    NetworkEvent, NetworkManager as NmrsManager, NetworkSnapshot, WifiSecurity,
+    ActiveConnection, ActiveConnectionState, ConnectByUuidConfig, ConnectType, ConnectivityState,
+    EapOptions, NetworkEvent, NetworkManager as NmrsManager, NetworkSnapshot, WifiSecurity,
     agent::{SecretAgent, SecretAgentCapabilities, SecretRequest, SecretResponder, SecretSetting},
 };
 use rustc_hash::FxHashSet;
@@ -916,7 +916,7 @@ impl CosmicNetworkApplet {
         cosmic::task::future(async move {
             let error = match NmrsManager::new().await {
                 Ok(nm) => nm
-                    .connect_vpn_by_uuid(&uuid)
+                    .connect_by_uuid(&uuid, ConnectByUuidConfig::default())
                     .await
                     .err()
                     .map(|e| format!("activate VPN {uuid}: {e}")),
@@ -1318,7 +1318,7 @@ impl cosmic::Application for CosmicNetworkApplet {
                 let disconnect_task = cosmic::task::future(async move {
                     let error = match NmrsManager::new().await {
                         Ok(nm) => nm
-                            .disconnect_vpn_by_uuid(&uuid)
+                            .disconnect_by_uuid(&uuid)
                             .await
                             .err()
                             .map(|e| format!("disconnect VPN {uuid}: {e}")),


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
----

Bump `nmrs` from 3.4.0 to 3.5.2 and migrate to non-deprecated connect/disconnect APIs.

This fixes the following issues:

- `active_connection_kind()` now checks connection type before device type
- `connect`/`connect_to_bssid` auto-upgrade `WpaPsk` to `Sae` when the AP advertises SAE without PSK

Fixes #1507
Fixes #1509
Fixes #1544