### PR TITLE
feat: improve window identity and presentation

### DIFF
--- a/cosmic-app-list/src/app.rs
+++ b/cosmic-app-list/src/app.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     fl,
+    wayland_handler::should_replace_icon_handle,
     wayland_subscription::{
         OutputUpdate, ToplevelRequest, ToplevelUpdate, WaylandImage, WaylandRequest, WaylandUpdate,
         wayland_subscription,
@@ -10,7 +11,7 @@ use crate::{
 };
 use cctk::{
     sctk::{output::OutputInfo, reexports::calloop::channel::Sender},
-    toplevel_info::ToplevelInfo,
+    toplevel_info::{ToplevelIcon, ToplevelInfo},
     wayland_client::protocol::{
         wl_data_device_manager::DndAction, wl_output::WlOutput, wl_seat::WlSeat,
     },
@@ -165,20 +166,191 @@ impl From<usize> for DockItemId {
     }
 }
 
+#[derive(Debug, PartialEq)]
+enum DockIconSource<'a, T> {
+    DesktopEntry(&'a str),
+    Propagated(&'a T),
+    GenericExecutable,
+}
+
+fn select_icon_source<'a, T>(
+    desktop_entry_icon: Option<&'a str>,
+    propagated_icon: Option<&'a T>,
+) -> DockIconSource<'a, T> {
+    if let Some(icon) = desktop_entry_icon.filter(|icon| !icon.trim().is_empty()) {
+        DockIconSource::DesktopEntry(icon)
+    } else if let Some(icon) = propagated_icon {
+        DockIconSource::Propagated(icon)
+    } else {
+        DockIconSource::GenericExecutable
+    }
+}
+
+fn first_filtered_icon<'a, T>(
+    icons: impl IntoIterator<Item = (bool, Option<&'a T>)>,
+) -> Option<&'a T> {
+    icons
+        .into_iter()
+        .find_map(|(is_visible, icon)| is_visible.then_some(icon).flatten())
+}
+
+fn propagated_icon_handle(icon: &ToplevelIcon) -> Option<cosmic::widget::icon::Handle> {
+    icon.name
+        .as_ref()
+        .map(|name| fde::IconSource::from_unknown(name.as_ref()).as_cosmic_icon())
+}
+
+fn toplevel_data(
+    info: ToplevelInfo,
+) -> (
+    ToplevelInfo,
+    Option<WaylandImage>,
+    Option<cosmic::widget::icon::Handle>,
+) {
+    let icon = info.icon.as_ref().and_then(propagated_icon_handle);
+    (info, None, icon)
+}
+
+fn fallback_desktop_entry(app_id: &str) -> DesktopEntry {
+    fde::DesktopEntry::from_appid(app_id.to_owned())
+}
+
+fn normalized_app_id(incoming: &str, current: Option<&str>, unknown_id: u32) -> String {
+    if !incoming.is_empty() {
+        incoming.to_owned()
+    } else if let Some(current) = current.filter(|current| !current.is_empty()) {
+        current.to_owned()
+    } else {
+        format!("Unknown Application {unknown_id}")
+    }
+}
+
+fn find_desktop_entry_by_strong_identity<'a>(
+    desktop_entries: &'a [DesktopEntry],
+    app_id: Ascii<&str>,
+) -> Option<&'a DesktopEntry> {
+    let entries = || desktop_entries.iter().filter(|entry| !entry.hidden());
+
+    entries()
+        .find(|entry| entry.matches_wm_class(app_id))
+        .or_else(|| entries().find(|entry| entry.matches_id(app_id)))
+        .or_else(|| entries().find(|entry| entry.exec().is_some_and(|exec| exec == app_id)))
+        .or_else(|| {
+            entries().find(|entry| {
+                entry.exec().is_some_and(|exec| {
+                    exec.split_ascii_whitespace()
+                        .next()
+                        .is_some_and(|exec| exec == app_id)
+                })
+            })
+        })
+        .or_else(|| entries().find(|entry| entry.matches_snap_appname(app_id)))
+}
+
+fn find_desktop_entry_by_identity<'a>(
+    desktop_entries: &'a [DesktopEntry],
+    app_id: Ascii<&str>,
+) -> Option<&'a DesktopEntry> {
+    find_desktop_entry_by_strong_identity(desktop_entries, app_id).or_else(|| {
+        desktop_entries
+            .iter()
+            .find(|entry| !entry.hidden() && !entry.no_display() && entry.matches_name(app_id))
+    })
+}
+
+fn presentation_name<'a, L, I>(
+    desktop_info: &'a DesktopEntry,
+    is_unmatched: bool,
+    titles: I,
+    locales: &[L],
+) -> Cow<'a, str>
+where
+    L: AsRef<str>,
+    I: IntoIterator<Item = &'a str>,
+{
+    if is_unmatched
+        && let Some(title) = titles
+            .into_iter()
+            .next()
+            .filter(|title| !title.trim().is_empty())
+    {
+        return Cow::Borrowed(title);
+    }
+
+    desktop_info
+        .full_name(locales)
+        .unwrap_or_else(|| Cow::Borrowed(desktop_info.id()))
+}
+
+fn reconcile_desktop_entry(
+    current: &mut DesktopEntry,
+    current_is_unmatched: &mut bool,
+    candidate: &DesktopEntry,
+    candidate_is_unmatched: bool,
+) {
+    if *current_is_unmatched && !candidate_is_unmatched {
+        current.clone_from(candidate);
+        *current_is_unmatched = false;
+    }
+}
+
 #[derive(Debug, Clone)]
 struct DockItem {
     // ID used internally in the applet. Each dock item
     // have an unique id
     id: u32,
-    toplevels: Vec<(ToplevelInfo, Option<WaylandImage>)>,
+    toplevels: Vec<(
+        ToplevelInfo,
+        Option<WaylandImage>,
+        Option<cosmic::widget::icon::Handle>,
+    )>,
     // Information found in the .desktop file
     desktop_info: DesktopEntry,
+    is_unmatched: bool,
     // We must use this because the id in `DesktopEntry` is an estimation.
     // Thus, if we unpin an item, we want to be sure to use the real id
     original_app_id: String,
 }
 
 impl DockItem {
+    fn display_name<'a, L: AsRef<str>>(
+        &'a self,
+        locales: &[L],
+        filter: Option<&dyn Fn(&ToplevelInfo) -> bool>,
+    ) -> Cow<'a, str> {
+        presentation_name(
+            &self.desktop_info,
+            self.is_unmatched,
+            self.toplevels
+                .iter()
+                .filter(|(info, _, _)| filter.is_none_or(|filter_fn| filter_fn(info)))
+                .map(|(info, _, _)| info.title.as_str()),
+            locales,
+        )
+    }
+
+    fn icon_handle(
+        &self,
+        filter: Option<&dyn Fn(&ToplevelInfo) -> bool>,
+    ) -> cosmic::widget::icon::Handle {
+        let propagated_icon = first_filtered_icon(self.toplevels.iter().map(|(info, _, icon)| {
+            (
+                filter.is_none_or(|filter_fn| filter_fn(info)),
+                icon.as_ref(),
+            )
+        }));
+
+        match select_icon_source(self.desktop_info.icon(), propagated_icon) {
+            DockIconSource::DesktopEntry(icon) => {
+                fde::IconSource::from_unknown(icon).as_cosmic_icon()
+            }
+            DockIconSource::Propagated(icon) => icon.clone(),
+            DockIconSource::GenericExecutable => {
+                fde::IconSource::from_unknown("application-x-executable").as_cosmic_icon()
+            }
+        }
+    }
+
     fn as_icon(
         &self,
         applet: &Context,
@@ -201,7 +373,7 @@ impl DockItem {
         let filtered_toplevels: Vec<_> = if let Some(filter_fn) = filter {
             toplevels
                 .iter()
-                .filter(|(info, _)| filter_fn(info))
+                .filter(|(info, _, _)| filter_fn(info))
                 .collect()
         } else {
             toplevels.iter().collect()
@@ -210,13 +382,11 @@ impl DockItem {
 
         let app_icon = AppletIconData::new(applet);
 
-        let cosmic_icon = cosmic::widget::icon(
-            fde::IconSource::from_unknown(desktop_info.icon().unwrap_or_default()).as_cosmic_icon(),
-        )
-        // sets the preferred icon size variant
-        .size(128)
-        .width(app_icon.icon_size.into())
-        .height(app_icon.icon_size.into());
+        let cosmic_icon = cosmic::widget::icon(self.icon_handle(filter))
+            // sets the preferred icon size variant
+            .size(128)
+            .width(app_icon.icon_size.into())
+            .height(app_icon.icon_size.into());
 
         let indicator = {
             let container = if toplevel_count <= 1 {
@@ -632,12 +802,12 @@ pub fn menu_control_padding() -> Padding {
 fn find_desktop_entries<'a>(
     desktop_entries: &'a [fde::DesktopEntry],
     app_ids: &'a [String],
-) -> impl Iterator<Item = fde::DesktopEntry> + 'a {
+) -> impl Iterator<Item = (fde::DesktopEntry, bool)> + 'a {
     app_ids.iter().map(|fav| {
         let unicase_fav = fde::unicase::Ascii::new(fav.as_str());
         fde::find_app_by_id(desktop_entries, unicase_fav).map_or_else(
-            || fde::DesktopEntry::from_appid(fav.clone()),
-            ToOwned::to_owned,
+            || (fde::DesktopEntry::from_appid(fav.clone()), true),
+            |entry| (entry.to_owned(), false),
         )
     })
 }
@@ -685,10 +855,11 @@ impl CosmicAppList {
         self.pinned_list = find_desktop_entries(&self.desktop_entries, &self.config.favorites)
             .zip(&self.config.favorites)
             .enumerate()
-            .map(|(pinned_ctr, (e, original_id))| DockItem {
+            .map(|(pinned_ctr, ((e, is_unmatched), original_id))| DockItem {
                 id: pinned_ctr as u32,
                 toplevels: Vec::new(),
                 desktop_info: e,
+                is_unmatched,
                 original_app_id: original_id.clone(),
             })
             .collect();
@@ -774,7 +945,7 @@ impl CosmicAppList {
         let mut focused_toplevels: Vec<ExtForeignToplevelHandleV1> = Vec::new();
         let active_workspaces = &self.active_workspaces;
         for toplevel_list in self.active_list.iter().chain(self.pinned_list.iter()) {
-            for (t_info, _) in &toplevel_list.toplevels {
+            for (t_info, _, _) in &toplevel_list.toplevels {
                 if t_info.state.contains(&State::Activated)
                     && active_workspaces
                         .iter()
@@ -796,42 +967,19 @@ impl CosmicAppList {
         &mut self,
         info: &ToplevelInfo,
         unicase_appid: Ascii<&str>,
-    ) -> DesktopEntry {
-        if let Some(appid) = fde::find_app_by_id(&self.desktop_entries, unicase_appid) {
-            appid.clone()
+    ) -> (DesktopEntry, bool) {
+        if let Some(appid) = find_desktop_entry_by_identity(&self.desktop_entries, unicase_appid) {
+            (appid.clone(), false)
         } else {
             // Update desktop entries in case it was not found.
             self.update_desktop_entries();
-            if let Some(appid) = fde::find_app_by_id(&self.desktop_entries, unicase_appid) {
-                appid.clone()
+            if let Some(appid) =
+                find_desktop_entry_by_identity(&self.desktop_entries, unicase_appid)
+            {
+                (appid.clone(), false)
             } else {
                 tracing::error!(id = info.app_id, "could not find desktop entry for app");
-                let mut fallback_entry = fde::DesktopEntry::from_appid(info.app_id.clone());
-                // proton opens games as steam_app_X, where X is either
-                // the steam appid or "default". games with a steam appid
-                // can have a desktop entry generated elsewhere; this
-                // specifically handles non-steam games opened
-                // under proton
-                // in addition, try to match WINE entries who have its
-                // appid = the full name of the executable (incl. .exe)
-                let is_proton_game = info.app_id == "steam_app_default";
-                if is_proton_game || info.app_id.ends_with(".exe") {
-                    for entry in &self.desktop_entries {
-                        let localised_name = entry.name(&self.locales).unwrap_or_default();
-                        if localised_name == info.title {
-                            // if this is a proton game, we only want
-                            // to look for game entries
-                            if is_proton_game
-                                && !entry.categories().unwrap_or_default().contains(&"Game")
-                            {
-                                continue;
-                            }
-                            fallback_entry = entry.clone();
-                            break;
-                        }
-                    }
-                }
-                fallback_entry
+                (fallback_desktop_entry(&info.app_id), true)
             }
         }
     }
@@ -980,7 +1128,7 @@ impl cosmic::Application for CosmicAppList {
                     .chain(self.pinned_list.iter())
                     .find(|t| t.id == id)
                 {
-                    for (info, _) in &toplevel_group.toplevels {
+                    for (info, _, _) in &toplevel_group.toplevels {
                         if let Some(tx) = self.wayland_sender.as_ref() {
                             let _ =
                                 tx.send(WaylandRequest::Screencopy(info.foreign_toplevel.clone()));
@@ -1121,7 +1269,7 @@ impl cosmic::Application for CosmicAppList {
                     .chain(self.pinned_list.iter())
                     .find(|t| t.desktop_info.id() == id)
                 {
-                    for (info, _) in &toplevel_group.toplevels {
+                    for (info, _, _) in &toplevel_group.toplevels {
                         if let Some(tx) = self.wayland_sender.as_ref() {
                             let _ = tx.send(WaylandRequest::Toplevel(ToplevelRequest::Quit(
                                 info.foreign_toplevel.clone(),
@@ -1256,6 +1404,7 @@ impl cosmic::Application for CosmicAppList {
                             toplevels: Vec::new(),
                             original_app_id: de.id().to_string(),
                             desktop_info: de,
+                            is_unmatched: false,
                         });
                     }
                 }
@@ -1320,13 +1469,34 @@ impl cosmic::Application for CosmicAppList {
                             .iter_mut()
                             .chain(self.pinned_list.iter_mut())
                         {
-                            if let Some((_, handle_img)) = x
+                            if let Some((_, handle_img, _)) = x
                                 .toplevels
                                 .iter_mut()
-                                .find(|(info, _)| info.foreign_toplevel == handle)
+                                .find(|(info, _, _)| info.foreign_toplevel == handle)
                             {
                                 *handle_img = Some(img);
                                 break 'img_update;
+                            }
+                        }
+                    }
+                    WaylandUpdate::Icon(handle, generation, img) => {
+                        'icon_update: for x in self
+                            .active_list
+                            .iter_mut()
+                            .chain(self.pinned_list.iter_mut())
+                        {
+                            if let Some((_, _, icon)) =
+                                x.toplevels.iter_mut().find(|(info, _, _)| {
+                                    info.foreign_toplevel == handle
+                                        && info.icon_generation == generation
+                                })
+                            {
+                                *icon = Some(cosmic::widget::icon::from_raster_pixels(
+                                    img.width,
+                                    img.height,
+                                    img.img.to_vec(),
+                                ));
+                                break 'icon_update;
                             }
                         }
                     }
@@ -1354,8 +1524,9 @@ impl cosmic::Application for CosmicAppList {
                     }
                     WaylandUpdate::Toplevel(event) => match event {
                         ToplevelUpdate::Add(mut info) => {
+                            info.app_id = normalized_app_id(&info.app_id, None, self.item_ctr);
                             let unicase_appid = fde::unicase::Ascii::new(&*info.app_id);
-                            let new_desktop_info =
+                            let (new_desktop_info, is_unmatched) =
                                 self.find_desktop_entry_for_toplevel(&info, unicase_appid);
 
                             if let Some(t) = self
@@ -1366,18 +1537,22 @@ impl cosmic::Application for CosmicAppList {
                                     desktop_info.id() == new_desktop_info.id()
                                 })
                             {
-                                t.toplevels.push((info, None));
+                                reconcile_desktop_entry(
+                                    &mut t.desktop_info,
+                                    &mut t.is_unmatched,
+                                    &new_desktop_info,
+                                    is_unmatched,
+                                );
+                                t.toplevels.push(toplevel_data(info));
                             } else {
-                                if info.app_id.is_empty() {
-                                    info.app_id = format!("Unknown Application {}", self.item_ctr);
-                                }
                                 self.item_ctr += 1;
 
                                 self.active_list.push(DockItem {
                                     id: self.item_ctr,
                                     original_app_id: info.app_id.clone(),
-                                    toplevels: vec![(info, None)],
+                                    toplevels: vec![toplevel_data(info)],
                                     desktop_info: new_desktop_info,
+                                    is_unmatched,
                                 });
                             }
                         }
@@ -1388,7 +1563,7 @@ impl cosmic::Application for CosmicAppList {
                                 .chain(self.pinned_list.iter_mut())
                             {
                                 t.toplevels
-                                    .retain(|(info, _)| info.foreign_toplevel != handle);
+                                    .retain(|(info, _, _)| info.foreign_toplevel != handle);
                             }
                             self.active_list.retain(|t| !t.toplevels.is_empty());
 
@@ -1398,7 +1573,7 @@ impl cosmic::Application for CosmicAppList {
                                 popup
                                     .dock_item
                                     .toplevels
-                                    .retain(|(info, _)| info.foreign_toplevel != handle);
+                                    .retain(|(info, _, _)| info.foreign_toplevel != handle);
 
                                 if popup.dock_item.toplevels.is_empty() {
                                     let id = popup.id;
@@ -1407,11 +1582,21 @@ impl cosmic::Application for CosmicAppList {
                                 }
                             }
                         }
-                        ToplevelUpdate::Update(info) => {
-                            // TODO probably want to make sure it is removed
-                            if info.app_id.is_empty() {
-                                return Task::none();
-                            }
+                        ToplevelUpdate::Update(mut info) => {
+                            let current_app_id = self
+                                .active_list
+                                .iter()
+                                .chain(self.pinned_list.iter())
+                                .flat_map(|item| &item.toplevels)
+                                .find(|(current, _, _)| {
+                                    current.foreign_toplevel == info.foreign_toplevel
+                                })
+                                .map(|(current, _, _)| current.app_id.clone());
+                            info.app_id = normalized_app_id(
+                                &info.app_id,
+                                current_app_id.as_deref(),
+                                self.item_ctr,
+                            );
                             let mut updated_appid = false;
 
                             'toplevel_loop: for toplevel_list in self
@@ -1419,12 +1604,20 @@ impl cosmic::Application for CosmicAppList {
                                 .iter_mut()
                                 .chain(self.pinned_list.iter_mut())
                             {
-                                for (t_info, _) in &mut toplevel_list.toplevels {
+                                for (t_info, _, icon) in &mut toplevel_list.toplevels {
                                     if info.foreign_toplevel == t_info.foreign_toplevel {
                                         if info.app_id != t_info.app_id {
                                             updated_appid = true;
                                         }
 
+                                        if should_replace_icon_handle(
+                                            t_info.icon_generation,
+                                            info.icon_generation,
+                                            info.icon.is_some(),
+                                        ) {
+                                            *icon =
+                                                info.icon.as_ref().and_then(propagated_icon_handle);
+                                        }
                                         *t_info = info.clone();
                                         break 'toplevel_loop;
                                     }
@@ -1432,22 +1625,33 @@ impl cosmic::Application for CosmicAppList {
                             }
 
                             if updated_appid {
-                                // remove the current toplevel from its dock item
-                                for t in self
+                                // Move the existing toplevel data, including captured images and
+                                // unnamed icon handles, to its new dock item.
+                                let mut moved_toplevel = None;
+                                'remove_toplevel: for item in self
                                     .active_list
                                     .iter_mut()
                                     .chain(self.pinned_list.iter_mut())
                                 {
-                                    t.toplevels
-                                        .retain(|(t_info, _)| t_info.app_id != info.app_id);
+                                    if let Some(index) =
+                                        item.toplevels.iter().position(|(t_info, _, _)| {
+                                            t_info.foreign_toplevel == info.foreign_toplevel
+                                        })
+                                    {
+                                        moved_toplevel = Some(item.toplevels.remove(index));
+                                        break 'remove_toplevel;
+                                    }
                                 }
                                 self.active_list.retain(|t| !t.toplevels.is_empty());
+                                let moved_toplevel =
+                                    moved_toplevel.unwrap_or_else(|| toplevel_data(info.clone()));
 
                                 // find a new one for it
-                                let new_desktop_entry = self.find_desktop_entry_for_toplevel(
-                                    &info,
-                                    Ascii::new(&info.app_id),
-                                );
+                                let (new_desktop_entry, is_unmatched) = self
+                                    .find_desktop_entry_for_toplevel(
+                                        &info,
+                                        Ascii::new(&info.app_id),
+                                    );
 
                                 if let Some(t) = self
                                     .active_list
@@ -1457,15 +1661,22 @@ impl cosmic::Application for CosmicAppList {
                                         desktop_info.id() == new_desktop_entry.id()
                                     })
                                 {
-                                    t.toplevels.push((info, None));
+                                    reconcile_desktop_entry(
+                                        &mut t.desktop_info,
+                                        &mut t.is_unmatched,
+                                        &new_desktop_entry,
+                                        is_unmatched,
+                                    );
+                                    t.toplevels.push(moved_toplevel);
                                 } else {
                                     self.item_ctr += 1;
 
                                     self.active_list.push(DockItem {
                                         id: self.item_ctr,
                                         original_app_id: info.app_id.clone(),
-                                        toplevels: vec![(info, None)],
+                                        toplevels: vec![moved_toplevel],
                                         desktop_info: new_desktop_entry,
+                                        is_unmatched,
                                     });
                                 }
                             }
@@ -1566,7 +1777,7 @@ impl cosmic::Application for CosmicAppList {
                 self.pinned_list =
                     find_desktop_entries(&self.desktop_entries, &self.config.favorites)
                         .zip(&self.config.favorites)
-                        .map(|(de, original_id)| {
+                        .map(|((de, is_unmatched), original_id)| {
                             if let Some(p) = self
                                 .active_list
                                 .iter()
@@ -1576,6 +1787,12 @@ impl cosmic::Application for CosmicAppList {
                                 let mut d = self.active_list.remove(p);
                                 // but use the id from the config
                                 d.original_app_id.clone_from(original_id);
+                                reconcile_desktop_entry(
+                                    &mut d.desktop_info,
+                                    &mut d.is_unmatched,
+                                    &de,
+                                    is_unmatched,
+                                );
                                 d
                             } else {
                                 self.item_ctr += 1;
@@ -1583,6 +1800,7 @@ impl cosmic::Application for CosmicAppList {
                                     id: self.item_ctr,
                                     toplevels: Vec::new(),
                                     desktop_info: de.clone(),
+                                    is_unmatched,
                                     original_app_id: original_id.clone(),
                                 }
                             }
@@ -1803,7 +2021,7 @@ impl cosmic::Application for CosmicAppList {
                 let filtered_is_focused = dock_item
                     .toplevels
                     .iter()
-                    .filter(|(info, _)| self.is_on_current_monitor_and_workspace(info))
+                    .filter(|(info, _, _)| self.is_on_current_monitor_and_workspace(info))
                     .any(|y| focused_item.contains(&y.0.foreign_toplevel));
 
                 self.core
@@ -1821,9 +2039,10 @@ impl cosmic::Application for CosmicAppList {
                             Some(&|info| self.is_on_current_monitor_and_workspace(info)),
                         ),
                         dock_item
-                            .desktop_info
-                            .full_name(&self.locales)
-                            .unwrap_or_default()
+                            .display_name(
+                                &self.locales,
+                                Some(&|info| self.is_on_current_monitor_and_workspace(info)),
+                            )
                             .into_owned(),
                         self.popup.is_some(),
                         Message::Surface,
@@ -1864,7 +2083,7 @@ impl cosmic::Application for CosmicAppList {
             let filtered_is_focused = item
                 .toplevels
                 .iter()
-                .filter(|(info, _)| self.is_on_current_monitor_and_workspace(info))
+                .filter(|(info, _, _)| self.is_on_current_monitor_and_workspace(info))
                 .any(|y| focused_item.contains(&y.0.foreign_toplevel));
 
             favorites.insert(
@@ -1897,7 +2116,7 @@ impl cosmic::Application for CosmicAppList {
             .active_list
             .iter()
             .filter(|dock_item| {
-                dock_item.toplevels.iter().any(|(toplevel_info, _)| {
+                dock_item.toplevels.iter().any(|(toplevel_info, _, _)| {
                     self.is_on_current_monitor_and_workspace(toplevel_info)
                 })
             })
@@ -1916,7 +2135,7 @@ impl cosmic::Application for CosmicAppList {
                     let filtered_is_focused = dock_item
                         .toplevels
                         .iter()
-                        .filter(|(info, _)| self.is_on_current_monitor_and_workspace(info))
+                        .filter(|(info, _, _)| self.is_on_current_monitor_and_workspace(info))
                         .any(|y| focused_item.contains(&y.0.foreign_toplevel));
 
                     self.core
@@ -1934,9 +2153,10 @@ impl cosmic::Application for CosmicAppList {
                                 Some(&|info| self.is_on_current_monitor_and_workspace(info)),
                             ),
                             dock_item
-                                .desktop_info
-                                .full_name(&self.locales)
-                                .unwrap_or_default()
+                                .display_name(
+                                    &self.locales,
+                                    Some(&|info| self.is_on_current_monitor_and_workspace(info)),
+                                )
                                 .into_owned(),
                             self.popup.is_some(),
                             Message::Surface,
@@ -2086,8 +2306,7 @@ impl cosmic::Application for CosmicAppList {
 
         if let Some((_, item, _, _)) = self.dnd_source.as_ref().filter(|s| s.0 == id) {
             cosmic::widget::icon(
-                fde::IconSource::from_unknown(item.desktop_info.icon().unwrap_or_default())
-                    .as_cosmic_icon(),
+                item.icon_handle(Some(&|info| self.is_on_current_monitor_and_workspace(info))),
             )
             .size(self.core.applet.suggested_size(false).0)
             .into()
@@ -2109,7 +2328,7 @@ impl cosmic::Application for CosmicAppList {
             let filtered_toplevels: Vec<_> = dock_item
                 .toplevels
                 .iter()
-                .filter(|(toplevel_info, _)| {
+                .filter(|(toplevel_info, _, _)| {
                     self.is_on_current_monitor_and_workspace(toplevel_info)
                 })
                 .collect();
@@ -2185,7 +2404,7 @@ impl cosmic::Application for CosmicAppList {
 
                     if !toplevels.is_empty() {
                         let mut list_col = column![];
-                        for (info, _) in toplevels {
+                        for (info, _, _) in toplevels {
                             list_col = list_col.push(
                                 menu_button(
                                     text::body(&info.title)
@@ -2257,7 +2476,7 @@ impl cosmic::Application for CosmicAppList {
                     PanelAnchor::Left | PanelAnchor::Right => {
                         let mut content =
                             column![].padding(8).align_x(Alignment::Center).spacing(8);
-                        for (info, img) in toplevels {
+                        for (info, img, _) in toplevels {
                             content = content.push(toplevel_button(
                                 img.clone(),
                                 info.title.clone(),
@@ -2274,7 +2493,7 @@ impl cosmic::Application for CosmicAppList {
                     }
                     PanelAnchor::Bottom | PanelAnchor::Top => {
                         let mut content = row![].padding(8).align_y(Alignment::Center).spacing(8);
-                        for (info, img) in toplevels {
+                        for (info, img, _) in toplevels {
                             content = content.push(toplevel_button(
                                 img.clone(),
                                 info.title.clone(),
@@ -2305,7 +2524,7 @@ impl cosmic::Application for CosmicAppList {
                 .active_list
                 .iter()
                 .filter(|dock_item| {
-                    dock_item.toplevels.iter().any(|(toplevel_info, _)| {
+                    dock_item.toplevels.iter().any(|(toplevel_info, _, _)| {
                         self.is_on_current_monitor_and_workspace(toplevel_info)
                     })
                 })
@@ -2325,7 +2544,7 @@ impl cosmic::Application for CosmicAppList {
                     let filtered_is_focused = dock_item
                         .toplevels
                         .iter()
-                        .filter(|(info, _)| self.is_on_current_monitor_and_workspace(info))
+                        .filter(|(info, _, _)| self.is_on_current_monitor_and_workspace(info))
                         .any(|y| focused_item.contains(&y.0.foreign_toplevel));
 
                     self.core
@@ -2343,9 +2562,10 @@ impl cosmic::Application for CosmicAppList {
                                 Some(&|info| self.is_on_current_monitor_and_workspace(info)),
                             ),
                             dock_item
-                                .desktop_info
-                                .full_name(&self.locales)
-                                .unwrap_or_default()
+                                .display_name(
+                                    &self.locales,
+                                    Some(&|info| self.is_on_current_monitor_and_workspace(info)),
+                                )
                                 .into_owned(),
                             self.popup.is_some(),
                             Message::Surface,
@@ -2433,7 +2653,7 @@ impl cosmic::Application for CosmicAppList {
                     let filtered_is_focused = dock_item
                         .toplevels
                         .iter()
-                        .filter(|(info, _)| self.is_on_current_monitor_and_workspace(info))
+                        .filter(|(info, _, _)| self.is_on_current_monitor_and_workspace(info))
                         .any(|y| focused_item.contains(&y.0.foreign_toplevel));
 
                     self.core
@@ -2451,10 +2671,11 @@ impl cosmic::Application for CosmicAppList {
                                 Some(&|info| self.is_on_current_monitor_and_workspace(info)),
                             ),
                             dock_item
-                                .desktop_info
-                                .full_name(&self.locales)
-                                .unwrap_or_default()
-                                .to_string(),
+                                .display_name(
+                                    &self.locales,
+                                    Some(&|info| self.is_on_current_monitor_and_workspace(info)),
+                                )
+                                .into_owned(),
                             self.popup.is_some(),
                             Message::Surface,
                             Some(id),

--- a/cosmic-app-list/src/wayland_handler.rs
+++ b/cosmic-app-list/src/wayland_handler.rs
@@ -5,11 +5,14 @@ use crate::wayland_subscription::{
     OutputUpdate, ToplevelRequest, ToplevelUpdate, WaylandImage, WaylandRequest, WaylandUpdate,
 };
 use std::{
+    collections::{HashMap, VecDeque},
+    hash::Hash,
     os::{
         fd::{AsFd, FromRawFd, RawFd},
         unix::net::UnixStream,
     },
-    sync::{Arc, Condvar, Mutex, MutexGuard},
+    sync::{Arc, Condvar, Mutex, MutexGuard, Weak},
+    time::Duration,
 };
 
 use cctk::{
@@ -68,6 +71,16 @@ struct AppData {
     seat_state: SeatState,
     shm_state: Shm,
     activation_state: Option<ActivationState>,
+    icon_captures: HashMap<ExtForeignToplevelHandleV1, u64>,
+    capture_sessions: Arc<SessionRegistry>,
+    icon_capture_scheduler: Arc<IconCaptureScheduler>,
+}
+
+impl Drop for AppData {
+    fn drop(&mut self) {
+        self.icon_capture_scheduler.stop();
+        self.capture_sessions.cancel_all();
+    }
 }
 
 // Workspace and toplevel handling
@@ -235,10 +248,11 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
-        if let Some(info) = self.toplevel_info_state.info(toplevel) {
+        if let Some(info) = self.toplevel_info_state.info(toplevel).cloned() {
             let _ = self
                 .tx
                 .unbounded_send(WaylandUpdate::Toplevel(ToplevelUpdate::Add(info.clone())));
+            self.send_icon(&info);
         }
     }
 
@@ -248,12 +262,13 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
-        if let Some(info) = self.toplevel_info_state.info(toplevel) {
+        if let Some(info) = self.toplevel_info_state.info(toplevel).cloned() {
             let _ = self
                 .tx
                 .unbounded_send(WaylandUpdate::Toplevel(ToplevelUpdate::Update(
                     info.clone(),
                 )));
+            self.send_icon(&info);
         }
     }
 
@@ -263,6 +278,8 @@ impl ToplevelInfoHandler for AppData {
         _qh: &QueueHandle<Self>,
         toplevel: &ExtForeignToplevelHandleV1,
     ) {
+        self.icon_captures.remove(toplevel);
+        self.icon_capture_scheduler.remove(toplevel);
         let _ = self
             .tx
             .unbounded_send(WaylandUpdate::Toplevel(ToplevelUpdate::Remove(
@@ -277,6 +294,7 @@ impl ToplevelInfoHandler for AppData {
 struct SessionInner {
     formats: Option<Formats>,
     res: Option<Result<(), WEnum<FailureReason>>>,
+    stopped: bool,
 }
 
 // TODO: dmabuf? need to handle modifier negotation
@@ -284,6 +302,59 @@ struct SessionInner {
 struct Session {
     condvar: Condvar,
     inner: Mutex<SessionInner>,
+}
+
+#[derive(Default)]
+struct SessionRegistry {
+    inner: Mutex<SessionRegistryInner>,
+}
+
+#[derive(Default)]
+struct SessionRegistryInner {
+    stopped: bool,
+    sessions: Vec<Weak<Session>>,
+}
+
+impl SessionRegistry {
+    fn register(&self, session: &Arc<Session>) -> bool {
+        let stopped = {
+            let mut registry = self.inner.lock().unwrap();
+            if registry.stopped {
+                true
+            } else {
+                registry
+                    .sessions
+                    .retain(|session| session.strong_count() > 0);
+                registry.sessions.push(Arc::downgrade(session));
+                false
+            }
+        };
+        if stopped {
+            session.update(|data| data.stopped = true);
+            false
+        } else {
+            true
+        }
+    }
+
+    fn cancel_all(&self) {
+        let sessions = {
+            let mut registry = self.inner.lock().unwrap();
+            registry.stopped = true;
+            registry
+                .sessions
+                .drain(..)
+                .filter_map(|session| session.upgrade())
+                .collect::<Vec<_>>()
+        };
+        for session in sessions {
+            session.update(|data| data.stopped = true);
+        }
+    }
+}
+
+fn cancel_capture_sessions(registry: &SessionRegistry) {
+    registry.cancel_all();
 }
 
 #[derive(Default)]
@@ -314,6 +385,131 @@ impl Session {
         self.condvar
             .wait_while(self.inner.lock().unwrap(), |data| f(data))
             .unwrap()
+    }
+
+    fn wait_for_formats(&self) -> Option<Formats> {
+        let mut data = self.wait_while(|data| data.formats.is_none() && !data.stopped);
+        data.formats.take()
+    }
+
+    fn wait_for_formats_timeout(&self, timeout: Duration) -> Option<Formats> {
+        let (mut data, _) = self
+            .condvar
+            .wait_timeout_while(self.inner.lock().unwrap(), timeout, |data| {
+                data.formats.is_none() && !data.stopped
+            })
+            .unwrap();
+        data.formats.take()
+    }
+
+    fn wait_for_result(&self) -> Option<Result<(), WEnum<FailureReason>>> {
+        let mut data = self.wait_while(|data| data.res.is_none() && !data.stopped);
+        data.res.take()
+    }
+
+    fn wait_for_result_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Option<Result<(), WEnum<FailureReason>>> {
+        let (mut data, _) = self
+            .condvar
+            .wait_timeout_while(self.inner.lock().unwrap(), timeout, |data| {
+                data.res.is_none() && !data.stopped
+            })
+            .unwrap();
+        data.res.take()
+    }
+
+    fn stop(&self) {
+        self.update(|data| data.stopped = true);
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.inner.lock().unwrap().stopped
+    }
+}
+
+struct CoalescingCaptureQueue<K, V> {
+    max_entries: usize,
+    stopped: bool,
+    pending_order: VecDeque<K>,
+    pending: HashMap<K, V>,
+    active: HashMap<K, Arc<Session>>,
+}
+
+impl<K: Clone + Eq + Hash, V> CoalescingCaptureQueue<K, V> {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries,
+            stopped: false,
+            pending_order: VecDeque::new(),
+            pending: HashMap::new(),
+            active: HashMap::new(),
+        }
+    }
+
+    fn enqueue(&mut self, key: K, value: V) -> bool {
+        if self.stopped {
+            return false;
+        }
+        let known = self.pending.contains_key(&key) || self.active.contains_key(&key);
+        if !known && self.len() >= self.max_entries {
+            return false;
+        }
+        if let Some(session) = self.active.get(&key) {
+            session.stop();
+        }
+        if self.pending.insert(key.clone(), value).is_none() {
+            self.pending_order.push_back(key);
+        }
+        true
+    }
+
+    fn next(&mut self) -> Option<(K, V, Arc<Session>)> {
+        while let Some(key) = self.pending_order.pop_front() {
+            let Some(value) = self.pending.remove(&key) else {
+                continue;
+            };
+            let session = Arc::new(Session::default());
+            self.active.insert(key.clone(), session.clone());
+            return Some((key, value, session));
+        }
+        None
+    }
+
+    fn finish(&mut self, key: &K, session: &Arc<Session>) {
+        if self
+            .active
+            .get(key)
+            .is_some_and(|active| Arc::ptr_eq(active, session))
+        {
+            self.active.remove(key);
+        }
+    }
+
+    fn remove(&mut self, key: &K) {
+        self.pending.remove(key);
+        self.pending_order.retain(|pending| pending != key);
+        if let Some(session) = self.active.remove(key) {
+            session.stop();
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.pending
+            .keys()
+            .filter(|key| !self.active.contains_key(*key))
+            .count()
+            + self.active.len()
+    }
+
+    fn stop(&mut self) {
+        self.stopped = true;
+        self.pending.clear();
+        self.pending_order.clear();
+        for (_, session) in self.active.drain() {
+            session.stop();
+        }
     }
 }
 
@@ -358,15 +554,123 @@ struct CaptureData {
     conn: Connection,
     wl_shm: WlShm,
     capturer: Capturer,
+    sessions: Arc<SessionRegistry>,
+}
+
+const ICON_CAPTURE_WORKERS: usize = 4;
+const MAX_ICON_CAPTURE_JOBS: usize = 64;
+const ICON_CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
+
+struct IconCaptureJob {
+    capture_data: CaptureData,
+    source: CaptureSource,
+    handle: ExtForeignToplevelHandleV1,
+    generation: u64,
+    tx: UnboundedSender<WaylandUpdate>,
+}
+
+struct IconCaptureScheduler {
+    queue: Mutex<CoalescingCaptureQueue<ExtForeignToplevelHandleV1, IconCaptureJob>>,
+    ready: Condvar,
+}
+
+impl IconCaptureScheduler {
+    fn start() -> Arc<Self> {
+        let scheduler = Arc::new(Self {
+            queue: Mutex::new(CoalescingCaptureQueue::new(MAX_ICON_CAPTURE_JOBS)),
+            ready: Condvar::new(),
+        });
+        for index in 0..ICON_CAPTURE_WORKERS {
+            let scheduler = scheduler.clone();
+            std::thread::Builder::new()
+                .name(format!("app-list-icon-{index}"))
+                .spawn(move || scheduler.run())
+                .expect("failed to start icon capture worker");
+        }
+        scheduler
+    }
+
+    fn enqueue(&self, job: IconCaptureJob) -> bool {
+        let handle = job.handle.clone();
+        let queued = self.queue.lock().unwrap().enqueue(handle, job);
+        if queued {
+            self.ready.notify_one();
+        }
+        queued
+    }
+
+    fn remove(&self, handle: &ExtForeignToplevelHandleV1) {
+        self.queue.lock().unwrap().remove(handle);
+    }
+
+    fn stop(&self) {
+        self.queue.lock().unwrap().stop();
+        self.ready.notify_all();
+    }
+
+    fn run(&self) {
+        loop {
+            let next = {
+                let mut queue = self.queue.lock().unwrap();
+                loop {
+                    if let Some(next) = queue.next() {
+                        break Some(next);
+                    }
+                    if queue.stopped {
+                        break None;
+                    }
+                    queue = self.ready.wait(queue).unwrap();
+                }
+            };
+            let Some((handle, job, session)) = next else {
+                return;
+            };
+
+            if job.capture_data.sessions.register(&session) && !session.is_stopped() {
+                capture_icon_job(job, session.clone());
+            }
+            self.queue.lock().unwrap().finish(&handle, &session);
+        }
+    }
+}
+
+fn shm_buffer_layout(width: u32, height: u32) -> Option<(i32, i32, i32, u32)> {
+    const MAX_CAPTURE_PIXELS: u32 = 16 * 1024 * 1024;
+    let pixels = width.checked_mul(height)?;
+    if pixels == 0 || pixels > MAX_CAPTURE_PIXELS {
+        return None;
+    }
+    let width_i32 = i32::try_from(width).ok()?;
+    let height_i32 = i32::try_from(height).ok()?;
+    let stride = width_i32.checked_mul(4)?;
+    let len = pixels.checked_mul(4)?;
+    i32::try_from(len).ok()?;
+    Some((width_i32, height_i32, stride, len))
 }
 
 impl CaptureData {
     pub fn capture_source_shm_fd<Fd: AsFd>(
         &self,
         overlay_cursor: bool,
-        source: &ExtForeignToplevelHandleV1,
+        source: &CaptureSource,
         fd: Fd,
         len: Option<u32>,
+    ) -> Option<ShmImage<Fd>> {
+        let session = Arc::new(Session::default());
+        if !self.sessions.register(&session) {
+            return None;
+        }
+        self.capture_source_shm_fd_with_session(overlay_cursor, source, fd, len, session, None)
+    }
+
+    fn capture_source_shm_fd_with_session<Fd: AsFd>(
+        &self,
+        overlay_cursor: bool,
+        source: &CaptureSource,
+        fd: Fd,
+        len: Option<u32>,
+        session: Arc<Session>,
+        timeout: Option<Duration>,
     ) -> Option<ShmImage<Fd>> {
         // XXX error type?
         // TODO: way to get cursor metadata?
@@ -374,61 +678,59 @@ impl CaptureData {
         #[allow(unused_variables)] // TODO
         let overlay_cursor = if overlay_cursor { 1 } else { 0 };
 
-        let session = Arc::new(Session::default());
-        // Unwrap assumes compositor supports this capture type
-        let capture_session = self
-            .capturer
-            .create_session(
-                &CaptureSource::Toplevel(source.clone()),
-                CaptureOptions::empty(),
-                &self.qh,
-                SessionData {
-                    session: session.clone(),
-                    session_data: ScreencopySessionData::default(),
-                },
-            )
-            .unwrap();
-        self.conn.flush().unwrap();
-
-        let formats = session
-            .wait_while(|data| data.formats.is_none())
-            .formats
-            .take()
-            .unwrap();
-        let (width, height) = formats.buffer_size;
-
-        if width == 0 || height == 0 {
+        if session.is_stopped() {
             return None;
         }
+        let capture_session = match self.capturer.create_session(
+            source,
+            CaptureOptions::empty(),
+            &self.qh,
+            SessionData {
+                session: session.clone(),
+                session_data: ScreencopySessionData::default(),
+            },
+        ) {
+            Ok(session) => session,
+            Err(err) => {
+                tracing::debug!(?err, "Image-copy capture is unavailable");
+                return None;
+            }
+        };
+        self.conn.flush().unwrap();
+
+        let formats = if let Some(timeout) = timeout {
+            session.wait_for_formats_timeout(timeout)?
+        } else {
+            session.wait_for_formats()?
+        };
+        let (width, height) = formats.buffer_size;
+        let (width_i32, height_i32, stride_i32, buf_len) = shm_buffer_layout(width, height)?;
 
         // XXX
-        if !formats.shm_formats.contains(&wl_shm::Format::Abgr8888) {
+        let format = if formats.shm_formats.contains(&wl_shm::Format::Abgr8888) {
+            wl_shm::Format::Abgr8888
+        } else if formats.shm_formats.contains(&wl_shm::Format::Argb8888) {
+            wl_shm::Format::Argb8888
+        } else {
             tracing::error!("No suitable buffer format found");
             tracing::warn!("Available formats: {:#?}", formats);
             return None;
-        }
+        };
 
-        let buf_len = width * height * 4;
         if let Some(len) = len {
             if len != buf_len {
                 return None;
             }
-        } else if let Err(_err) = rustix::fs::ftruncate(&fd, buf_len.into()) {
+        } else if let Err(err) = rustix::fs::ftruncate(&fd, u64::from(buf_len)) {
+            tracing::error!(?err, "Failed to size screencopy buffer");
+            return None;
         }
         let pool = self
             .wl_shm
-            .create_pool(fd.as_fd(), buf_len as i32, &self.qh, ());
-        let buffer = pool.create_buffer(
-            0,
-            width as i32,
-            height as i32,
-            width as i32 * 4,
-            wl_shm::Format::Abgr8888,
-            &self.qh,
-            (),
-        );
+            .create_pool(fd.as_fd(), i32::try_from(buf_len).ok()?, &self.qh, ());
+        let buffer = pool.create_buffer(0, width_i32, height_i32, stride_i32, format, &self.qh, ());
 
-        capture_session.capture(
+        let frame = capture_session.capture(
             &buffer,
             &[],
             &self.qh,
@@ -440,18 +742,28 @@ impl CaptureData {
         self.conn.flush().unwrap();
 
         // TODO: wait for server to release buffer?
-        let res = session
-            .wait_while(|data| data.res.is_none())
-            .res
-            .take()
-            .unwrap();
+        let res = if let Some(timeout) = timeout {
+            session.wait_for_result_timeout(timeout)
+        } else {
+            session.wait_for_result()
+        };
+        frame.destroy();
         pool.destroy();
         buffer.destroy();
+        if let Err(err) = self.conn.flush() {
+            tracing::debug!(?err, "Failed to flush capture cleanup");
+        }
+        let res = res?;
 
         //std::thread::sleep(std::time::Duration::from_millis(16));
 
         if res.is_ok() {
-            Some(ShmImage { fd, width, height })
+            Some(ShmImage {
+                fd,
+                width,
+                height,
+                format,
+            })
         } else {
             None
         }
@@ -462,14 +774,100 @@ pub struct ShmImage<T: AsFd> {
     fd: T,
     pub width: u32,
     pub height: u32,
+    format: wl_shm::Format,
+}
+
+fn normalize_shm_pixels(format: wl_shm::Format, pixels: &mut [u8]) -> Option<()> {
+    if !matches!(format, wl_shm::Format::Abgr8888 | wl_shm::Format::Argb8888) {
+        return None;
+    }
+    for pixel in pixels.chunks_exact_mut(4) {
+        let packed = u32::from_ne_bytes(pixel.try_into().ok()?);
+        let alpha = (packed >> 24) as u8;
+        let (red, green, blue) = if format == wl_shm::Format::Argb8888 {
+            ((packed >> 16) as u8, (packed >> 8) as u8, packed as u8)
+        } else {
+            (packed as u8, (packed >> 8) as u8, (packed >> 16) as u8)
+        };
+        let unpremultiply = |channel: u8| {
+            if alpha == 0 {
+                0
+            } else {
+                (((u32::from(channel) * 255 + u32::from(alpha) / 2) / u32::from(alpha)).min(255))
+                    as u8
+            }
+        };
+        pixel.copy_from_slice(&[
+            unpremultiply(red),
+            unpremultiply(green),
+            unpremultiply(blue),
+            alpha,
+        ]);
+    }
+    Some(())
 }
 
 impl<T: AsFd> ShmImage<T> {
     pub fn image(&self) -> anyhow::Result<image::RgbaImage> {
         let mmap = unsafe { memmap2::Mmap::map(&self.fd.as_fd())? };
-        image::RgbaImage::from_raw(self.width, self.height, mmap.to_vec())
+        let mut pixels = mmap.to_vec();
+        normalize_shm_pixels(self.format, &mut pixels)
+            .ok_or_else(|| anyhow::anyhow!("ShmImage had an unsupported format"))?;
+        image::RgbaImage::from_raw(self.width, self.height, pixels)
             .ok_or_else(|| anyhow::anyhow!("ShmImage had incorrect size"))
     }
+}
+
+fn capture_icon_job(job: IconCaptureJob, session: Arc<Session>) {
+    let Ok(fd) = rustix::fs::memfd_create(c"app-list-icon", rustix::fs::MemfdFlags::CLOEXEC) else {
+        tracing::error!("Failed to get fd for icon capture");
+        return;
+    };
+    let Some(img) = job.capture_data.capture_source_shm_fd_with_session(
+        false,
+        &job.source,
+        fd,
+        None,
+        session,
+        Some(ICON_CAPTURE_TIMEOUT),
+    ) else {
+        tracing::debug!("Toplevel icon capture was canceled or failed");
+        return;
+    };
+    let Ok(img) = img.image() else {
+        tracing::error!("Failed to decode captured toplevel icon");
+        return;
+    };
+    if let Err(err) = job.tx.unbounded_send(WaylandUpdate::Icon(
+        job.handle,
+        job.generation,
+        WaylandImage::new(img),
+    )) {
+        tracing::error!("Failed to send icon event to subscription {err:?}");
+    }
+}
+
+fn mark_icon_capture_requested<K: Eq + Hash>(
+    requested: &mut HashMap<K, u64>,
+    key: K,
+    generation: u64,
+) -> bool {
+    if requested.get(&key) == Some(&generation) {
+        false
+    } else {
+        requested.insert(key, generation);
+        true
+    }
+}
+
+// Keep the current handle across same-generation metadata updates: it may be a
+// successfully captured raster fallback rather than the locally resolved name.
+pub(crate) fn should_replace_icon_handle(
+    old_generation: u64,
+    new_generation: u64,
+    new_icon_is_present: bool,
+) -> bool {
+    !new_icon_is_present || old_generation != new_generation
 }
 
 impl AppData {
@@ -490,6 +888,7 @@ impl AppData {
             conn: self.conn.clone(),
             wl_shm: self.shm_state.wl_shm().clone(),
             capturer: self.screencopy_state.capturer().clone(),
+            sessions: self.capture_sessions.clone(),
         };
         std::thread::spawn(move || {
             let name = c"app-list-screencopy";
@@ -499,7 +898,12 @@ impl AppData {
             };
 
             // XXX is this going to use to much memory?
-            let img = capture_data.capture_source_shm_fd(false, &handle, fd, None);
+            let img = capture_data.capture_source_shm_fd(
+                false,
+                &CaptureSource::Toplevel(handle.clone()),
+                fd,
+                None,
+            );
             if let Some(img) = img {
                 let Ok(img) = img.image() else {
                     tracing::error!("Failed to get RgbaImage");
@@ -533,6 +937,42 @@ impl AppData {
                 tracing::error!("Failed to capture image");
             }
         });
+    }
+
+    fn send_icon(&mut self, info: &cctk::toplevel_info::ToplevelInfo) {
+        let Some(icon) = info.icon.as_ref() else {
+            self.icon_captures.remove(&info.foreign_toplevel);
+            self.icon_capture_scheduler.remove(&info.foreign_toplevel);
+            return;
+        };
+        if !mark_icon_capture_requested(
+            &mut self.icon_captures,
+            info.foreign_toplevel.clone(),
+            info.icon_generation,
+        ) {
+            return;
+        }
+        let Ok(source) = icon.capture_source(256, 256) else {
+            self.icon_captures.remove(&info.foreign_toplevel);
+            return;
+        };
+        let capture_data = CaptureData {
+            qh: self.queue_handle.clone(),
+            conn: self.conn.clone(),
+            wl_shm: self.shm_state.wl_shm().clone(),
+            capturer: self.screencopy_state.capturer().clone(),
+            sessions: self.capture_sessions.clone(),
+        };
+        if !self.icon_capture_scheduler.enqueue(IconCaptureJob {
+            capture_data,
+            source,
+            handle: info.foreign_toplevel.clone(),
+            generation: info.icon_generation,
+            tx: self.tx.clone(),
+        }) {
+            self.icon_captures.remove(&info.foreign_toplevel);
+            tracing::warn!("Toplevel icon capture queue is full or stopped");
+        }
     }
 }
 
@@ -586,7 +1026,11 @@ impl ScreencopyHandler for AppData {
         });
     }
 
-    fn stopped(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _session: &CaptureSession) {}
+    fn stopped(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, session: &CaptureSession) {
+        if let Some(session) = Session::for_session(session) {
+            session.update(|data| data.stopped = true);
+        }
+    }
 }
 
 pub(crate) fn wayland_handler(
@@ -702,6 +1146,9 @@ pub(crate) fn wayland_handler(
         seat_state: SeatState::new(&globals, &qh),
         shm_state: Shm::bind(&globals, &qh).unwrap(),
         activation_state: ActivationState::bind::<AppData>(&globals, &qh).ok(),
+        icon_captures: HashMap::new(),
+        capture_sessions: Arc::new(SessionRegistry::default()),
+        icon_capture_scheduler: IconCaptureScheduler::start(),
         queue_handle: qh,
     };
 
@@ -709,8 +1156,12 @@ pub(crate) fn wayland_handler(
         if app_data.exit {
             break;
         }
-        event_loop.dispatch(None, &mut app_data).unwrap();
+        if let Err(err) = event_loop.dispatch(None, &mut app_data) {
+            tracing::error!(?err, "Wayland event dispatch failed");
+            break;
+        }
     }
+    cancel_capture_sessions(&app_data.capture_sessions);
 }
 
 sctk::delegate_seat!(AppData);

--- a/cosmic-app-list/src/wayland_subscription.rs
+++ b/cosmic-app-list/src/wayland_subscription.rs
@@ -120,6 +120,7 @@ pub enum WaylandUpdate {
         terminal: bool,
     },
     Image(ExtForeignToplevelHandleV1, WaylandImage),
+    Icon(ExtForeignToplevelHandleV1, u64, WaylandImage),
 }
 
 #[derive(Clone, Debug)]

--- a/cosmic-applet-minimize/src/wayland_handler.rs
+++ b/cosmic-applet-minimize/src/wayland_handler.rs
@@ -146,18 +146,21 @@ impl CaptureData {
         let overlay_cursor = if overlay_cursor { 1 } else { 0 };
 
         let session = Arc::new(Session::default());
-        let capture_session = self
-            .capturer
-            .create_session(
-                &CaptureSource::Toplevel(source),
-                CaptureOptions::empty(),
-                &self.qh,
-                SessionData {
-                    session: session.clone(),
-                    session_data: ScreencopySessionData::default(),
-                },
-            )
-            .unwrap();
+        let capture_session = match self.capturer.create_session(
+            &CaptureSource::Toplevel(source),
+            CaptureOptions::empty(),
+            &self.qh,
+            SessionData {
+                session: session.clone(),
+                session_data: ScreencopySessionData::default(),
+            },
+        ) {
+            Ok(session) => session,
+            Err(err) => {
+                tracing::debug!(?err, "Image-copy capture is unavailable");
+                return None;
+            }
+        };
         self.conn.flush().unwrap();
 
         let formats = session


### PR DESCRIPTION
I noticed that icons and application names are not properly shown for video games launched through Steam in COSMIC dock. This pr fixes that by using the propagated window icons when no matched desktop-entry icon is available. Also improve desktop-entry identity matching and reject hidden or weak `NoDisplay` collisions.


depends on https://github.com/pop-os/cosmic-comp/pull/2833
depends on https://github.com/pop-os/cosmic-protocols/pull/87
depends on https://github.com/Smithay/smithay/pull/2160



before:
<img width="899" height="141" alt="Screenshot_2026-09-07_12-54-50" src="https://github.com/user-attachments/assets/c6b0f9be-a75f-4617-889c-8c3cbe403978" />



after:
<img width="866" height="117" alt="Screenshot_2026-09-07_14-51-24" src="https://github.com/user-attachments/assets/44087fe1-ca7a-47bf-a282-39f9f62d599c" />





- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

